### PR TITLE
Feat / Link underlines, role attribute and page titles

### DIFF
--- a/packages/ui-react/src/components/Alert/Alert.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.tsx
@@ -19,7 +19,7 @@ const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess, actionsOver
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} role="alert" aria-live="polite">
       <h2 className={styles.title}>{titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}</h2>
       <p className={styles.body}>{message}</p>
       {actionsOverride ?? <Button label={t('alert.close')} variant="outlined" onClick={onClose} fullWidth />}

--- a/packages/ui-react/src/components/Alert/Alert.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import useOpaqueId from '@jwp/ott-hooks-react/src/useOpaqueId';
 
 import Dialog from '../Dialog/Dialog';
 import Button from '../Button/Button';
@@ -17,10 +18,11 @@ type Props = {
 
 const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess, actionsOverride, titleOverride }: Props) => {
   const { t } = useTranslation('common');
+  const headingId = useOpaqueId('alert-heading');
 
   return (
     <Dialog open={open} onClose={onClose} role="alert" aria-labelledby="alert-heading">
-      <h2 id="alert-heading" className={styles.title}>
+      <h2 id={headingId} className={styles.title}>
         {titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}
       </h2>
       <p className={styles.body}>{message}</p>

--- a/packages/ui-react/src/components/Alert/Alert.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.tsx
@@ -19,8 +19,10 @@ const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess, actionsOver
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose} role="alert" aria-live="polite">
-      <h2 className={styles.title}>{titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}</h2>
+    <Dialog open={open} onClose={onClose} role="alert" aria-labelledby="alert-heading">
+      <h2 id="alert-heading" className={styles.title}>
+        {titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}
+      </h2>
       <p className={styles.body}>{message}</p>
       {actionsOverride ?? <Button label={t('alert.close')} variant="outlined" onClick={onClose} fullWidth />}
     </Dialog>

--- a/packages/ui-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/ui-react/src/components/Checkbox/Checkbox.module.scss
@@ -12,11 +12,7 @@
     a {
       color: variables.$white;
       font-weight: var(--body-font-weight-bold);
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
+      text-decoration: underline;
     }
   }
 

--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -19,8 +19,10 @@ const ConfirmationDialog: React.FC<Props> = ({ open, title, body, onConfirm, onC
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose}>
-      <h2 className={styles.title}>{title}</h2>
+    <Dialog open={open} onClose={onClose} role="dialog" aria-labbeledby="confirmation-heading">
+      <h2 className={styles.title} id="confirmation-heading">
+        {title}
+      </h2>
       <p className={styles.body}>{body}</p>
       <Button
         className={styles.confirmButton}

--- a/packages/ui-react/src/components/ConfirmationForm/ConfirmationForm.module.scss
+++ b/packages/ui-react/src/components/ConfirmationForm/ConfirmationForm.module.scss
@@ -24,8 +24,6 @@
   margin-left: 6px;
   color: var(--primary-color);
   font-weight: var(--body-font-weight-bold);
+  text-decoration: underline;
   cursor: pointer;
-  &:hover {
-    text-decoration: underline;
-  }
 }

--- a/packages/ui-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.test.tsx
@@ -8,7 +8,7 @@ describe('<Dialog>', () => {
     const { baseElement } = render(
       <>
         <span>Some content</span>
-        <Dialog onClose={vi.fn()} open={true} role="">
+        <Dialog onClose={vi.fn()} open={true} role="dialog">
           Dialog contents
         </Dialog>
         <span>Some other content</span>

--- a/packages/ui-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.test.tsx
@@ -8,7 +8,7 @@ describe('<Dialog>', () => {
     const { baseElement } = render(
       <>
         <span>Some content</span>
-        <Dialog onClose={vi.fn()} open={true}>
+        <Dialog onClose={vi.fn()} open={true} role="">
           Dialog contents
         </Dialog>
         <span>Some other content</span>

--- a/packages/ui-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { AriaAttributes } from 'react';
 import classNames from 'classnames';
 
 import Modal from '../Modal/Modal';
@@ -7,17 +7,18 @@ import ModalCloseButton from '../ModalCloseButton/ModalCloseButton';
 
 import styles from './Dialog.module.scss';
 
-type Props = {
+type Props = Pick<AriaAttributes, 'aria-labelledby' | 'aria-label'> & {
   open: boolean;
   onClose: () => void;
   size?: 'small' | 'large';
   children: React.ReactNode;
-  role?: string;
+  role: React.AriaRole;
+  'aria-labelledby'?: string; // non-optional
 };
 
-const Dialog: React.FC<Props> = ({ open, onClose, size = 'small', children, role }: Props) => {
+const Dialog: React.FC<Props> = ({ open, onClose, size = 'small', children, role, ...rest }: Props) => {
   return (
-    <Modal open={open} onClose={onClose} AnimationComponent={Slide} role={role}>
+    <Modal open={open} onClose={onClose} AnimationComponent={Slide} role={role} {...rest}>
       <div className={classNames(styles.dialog, styles[size])}>
         <ModalCloseButton onClick={onClose} />
         {children}

--- a/packages/ui-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.tsx
@@ -12,11 +12,12 @@ type Props = {
   onClose: () => void;
   size?: 'small' | 'large';
   children: React.ReactNode;
+  role?: string;
 };
 
-const Dialog: React.FC<Props> = ({ open, onClose, size = 'small', children }: Props) => {
+const Dialog: React.FC<Props> = ({ open, onClose, size = 'small', children, role }: Props) => {
   return (
-    <Modal open={open} onClose={onClose} AnimationComponent={Slide}>
+    <Modal open={open} onClose={onClose} AnimationComponent={Slide} role={role}>
       <div className={classNames(styles.dialog, styles[size])}>
         <ModalCloseButton onClick={onClose} />
         {children}

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
   >
     <div
       class="_modal_6c6c55"
+      role=""
     >
       <div
         class="_backdrop_6c6c55"

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
   >
     <div
       class="_modal_6c6c55"
-      role=""
+      role="dialog"
     >
       <div
         class="_backdrop_6c6c55"

--- a/packages/ui-react/src/components/Link/Link.module.scss
+++ b/packages/ui-react/src/components/Link/Link.module.scss
@@ -5,13 +5,8 @@
   display: inline-block;
   color: var(--primary-color);
   font-weight: var(--body-font-weight-bold);
-  text-decoration: none;
+  text-decoration: underline;
   cursor: pointer;
-
-  &:hover,
-  &:focus {
-    text-decoration: underline;
-  }
 
   &:disabled {
     cursor: default;

--- a/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.module.scss
+++ b/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.module.scss
@@ -61,11 +61,7 @@
   a,
   a:visited {
     color: theme.$link-color;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
+    text-decoration: underline;
   }
 
   ul,

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -13,9 +13,10 @@ type Props = {
   AnimationComponent?: React.JSXElementConstructor<{ open?: boolean; duration?: number; delay?: number; children: React.ReactNode }>;
   open: boolean;
   onClose?: () => void;
+  role?: string;
 };
 
-const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow }: Props) => {
+const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, role }: Props) => {
   const [visible, setVisible] = useState(open);
   const lastFocus = useRef<HTMLElement>() as React.MutableRefObject<HTMLElement>;
   const modalRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
@@ -76,7 +77,7 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
 
   return ReactDOM.createPortal(
     <Fade open={open} duration={300} onCloseAnimationEnd={() => setVisible(false)}>
-      <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
+      <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef} role={role}>
         <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
         <div className={styles.container}>
           <AnimationComponent open={open} duration={200}>

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.module.scss
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.module.scss
@@ -23,12 +23,8 @@
 .login {
   margin-left: 6px;
   font-weight: var(--body-font-weight-bold);
+  text-decoration: underline;
   cursor: pointer;
-
-  &:hover,
-  &:focus {
-    text-decoration: underline;
-  }
 }
 
 .customFields {

--- a/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
+++ b/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
@@ -134,7 +134,7 @@ const AccountModal = () => {
   const dialogSize = ['delete-account-confirmation'].includes(view ?? '') ? 'large' : 'small';
 
   return (
-    <Dialog size={dialogSize} open={!!viewParam} onClose={closeHandler}>
+    <Dialog size={dialogSize} open={!!viewParam} onClose={closeHandler} role="dialog">
       {shouldShowBanner && banner && <div className={styles.banner}>{<img src={banner} alt="" />}</div>}
       {renderForm()}
     </Dialog>

--- a/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
@@ -49,11 +49,11 @@ const DeleteProfile = () => {
   if (view !== 'delete-profile') return null;
   return (
     <div>
-      <Dialog open={!!viewParam} onClose={closeHandler}>
+      <Dialog open={!!viewParam} onClose={closeHandler} role="dialog" aria-labbeledby="delete-profile-heading">
         {isDeleting && <LoadingOverlay />}
         <div className={styles.deleteModal}>
           <div>
-            <h2>{t('profile.delete')}</h2>
+            <h2 id="delete-profile-heading">{t('profile.delete')}</h2>
             <p>{t('profile.delete_confirmation')}</p>
           </div>
           <div className={styles.deleteButtons}>

--- a/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
@@ -49,7 +49,7 @@ const DeleteProfile = () => {
   if (view !== 'delete-profile') return null;
   return (
     <div>
-      <Dialog open={!!viewParam} onClose={closeHandler} role="dialog" aria-labbeledby="delete-profile-heading">
+      <Dialog open={!!viewParam} onClose={closeHandler} role="dialog" aria-labelledby="delete-profile-heading">
         {isDeleting && <LoadingOverlay />}
         <div className={styles.deleteModal}>
           <div>

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -27,7 +27,7 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
   if (!item) return null;
 
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal open={open} onClose={onClose} role="dialog">
       <div className={styles.container}>
         <Player
           item={item}

--- a/packages/ui-react/src/styles/accessibility.scss
+++ b/packages/ui-react/src/styles/accessibility.scss
@@ -36,8 +36,11 @@ $focus-box-shadow: 0 0 1px 5px var(--highlight-color, variables.$white),
     clip: auto;
   }
 }
+<<<<<<< HEAD:packages/ui-react/src/styles/accessibility.scss
 
 .linkUnderline {
   text-decoration: underline;
 }
 
+=======
+>>>>>>> 4ee91a83 (feat(a11y): add an underline to links at all times):src/styles/accessibility.scss

--- a/packages/ui-react/src/styles/accessibility.scss
+++ b/packages/ui-react/src/styles/accessibility.scss
@@ -36,11 +36,3 @@ $focus-box-shadow: 0 0 1px 5px var(--highlight-color, variables.$white),
     clip: auto;
   }
 }
-<<<<<<< HEAD:packages/ui-react/src/styles/accessibility.scss
-
-.linkUnderline {
-  text-decoration: underline;
-}
-
-=======
->>>>>>> 4ee91a83 (feat(a11y): add an underline to links at all times):src/styles/accessibility.scss


### PR DESCRIPTION
## This PR:

- Adds an underline to links at all times
- Adjust the Page title of the Home page 
  - All other pages already had a page title with a similar format: `media item - siteName`
- Adds `role` attribute to the Modal and Dialog components
  