### PR TITLE
Fix / a11y role=“alertdialog” for alert component

### DIFF
--- a/packages/ui-react/src/components/Alert/Alert.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.tsx
@@ -21,7 +21,7 @@ const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess, actionsOver
   const headingId = useOpaqueId('alert-heading');
 
   return (
-    <Dialog open={open} onClose={onClose} role="alertdialog" aria-labelledby={headingId}>
+    <Dialog open={open} onClose={onClose} role="alertdialog" aria-modal="true" aria-labelledby={headingId}>
       <h2 id={headingId} className={styles.title}>
         {titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}
       </h2>

--- a/packages/ui-react/src/components/Alert/Alert.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.tsx
@@ -21,7 +21,7 @@ const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess, actionsOver
   const headingId = useOpaqueId('alert-heading');
 
   return (
-    <Dialog open={open} onClose={onClose} role="alert" aria-labelledby="alert-heading">
+    <Dialog open={open} onClose={onClose} role="alertdialog" aria-labelledby={headingId}>
       <h2 id={headingId} className={styles.title}>
         {titleOverride ?? (isSuccess ? t('alert.success') : t('alert.title'))}
       </h2>


### PR DESCRIPTION
Change `role="alert"` to `role="alertdialog"` because the alert has an interactive element. That could be a close button or custom defined button(s).

Read docs:
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role

Also `aria-modal="true"` was missing so i added it too.