### PR TITLE
Feat / Geo blocking for media items

### DIFF
--- a/packages/hooks-react/src/useProtectedMedia.ts
+++ b/packages/hooks-react/src/useProtectedMedia.ts
@@ -9,19 +9,19 @@ export default function useProtectedMedia(item: PlaylistItem) {
   const apiService = getModule(ApiService);
 
   const [isGeoBlocked, setIsGeoBlocked] = useState(false);
-  const queryResult = useContentProtection('media', item.mediaid, (token, drmPolicyId) => apiService.getMediaById(item.mediaid, token, drmPolicyId));
+  const contentProtectionQuery = useContentProtection('media', item.mediaid, (token, drmPolicyId) => apiService.getMediaById(item.mediaid, token, drmPolicyId));
 
   useEffect(() => {
-    const m3u8 = queryResult.data?.sources.find((source) => source.file.indexOf('.m3u8') !== -1);
+    const m3u8 = contentProtectionQuery.data?.sources.find((source) => source.file.indexOf('.m3u8') !== -1);
     if (m3u8) {
       fetch(m3u8.file, { method: 'HEAD' }).then((response) => {
         response.status === 403 && setIsGeoBlocked(true);
       });
     }
-  }, [queryResult.data]);
+  }, [contentProtectionQuery.data]);
 
   return {
-    ...queryResult,
+    ...contentProtectionQuery,
     isGeoBlocked,
   };
 }

--- a/packages/hooks-react/src/useProtectedMedia.ts
+++ b/packages/hooks-react/src/useProtectedMedia.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import ApiService from '@jwp/ott-common/src/services/ApiService';
 import { getModule } from '@jwp/ott-common/src/modules/container';
@@ -7,5 +8,20 @@ import useContentProtection from './useContentProtection';
 export default function useProtectedMedia(item: PlaylistItem) {
   const apiService = getModule(ApiService);
 
-  return useContentProtection('media', item.mediaid, (token, drmPolicyId) => apiService.getMediaById(item.mediaid, token, drmPolicyId));
+  const [isGeoBlocked, setIsGeoBlocked] = useState(false);
+  const queryResult = useContentProtection('media', item.mediaid, (token, drmPolicyId) => apiService.getMediaById(item.mediaid, token, drmPolicyId));
+
+  useEffect(() => {
+    const m3u8 = queryResult.data?.sources.find((source) => source.file.indexOf('.m3u8') !== -1);
+    if (m3u8) {
+      fetch(m3u8.file, { method: 'HEAD' }).then((response) => {
+        response.status === 403 && setIsGeoBlocked(true);
+      });
+    }
+  }, [queryResult.data]);
+
+  return {
+    ...queryResult,
+    isGeoBlocked,
+  };
 }

--- a/packages/ui-react/src/components/PlayerError/PlayerError.module.scss
+++ b/packages/ui-react/src/components/PlayerError/PlayerError.module.scss
@@ -1,0 +1,23 @@
+@use '@jwp/ott-ui-react/src/styles/variables';
+@use '@jwp/ott-ui-react/src/styles/theme';
+@use '@jwp/ott-ui-react/src/styles/mixins/responsive';
+
+.error {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: variables.$base-spacing;
+}
+
+.title {
+  color: variables.$white;
+  font-weight: var(--body-font-weight-bold);
+  font-size: 34px;
+
+  @include responsive.mobile-only() {
+    font-size: 24px;
+  }
+}

--- a/packages/ui-react/src/components/PlayerError/PlayerError.test.tsx
+++ b/packages/ui-react/src/components/PlayerError/PlayerError.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import PlayerError, { PlayerErrorState } from './PlayerError';
+
+describe('<ErrorPage>', () => {
+  test('renders and matches snapshot', () => {
+    const { container } = render(<PlayerError error={PlayerErrorState.GEO_BLOCKED} />);
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/ui-react/src/components/PlayerError/PlayerError.tsx
+++ b/packages/ui-react/src/components/PlayerError/PlayerError.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './PlayerError.module.scss';
+
+export enum PlayerErrorState {
+  GEO_BLOCKED = 'GEO_BLOCKED',
+}
+
+type Props = {
+  error: keyof typeof PlayerErrorState;
+};
+
+const PlayerError: React.FC<Props> = () => {
+  const { t } = useTranslation('video');
+  return (
+    <div className={styles.error}>
+      <h2 className={styles.title}>{t('player_error.geo_blocked_title')}</h2>
+      <p>{t('player_error.geo_blocked_description')}</p>
+    </div>
+  );
+};
+
+export default PlayerError;

--- a/packages/ui-react/src/components/PlayerError/__snapshots__/PlayerError.test.tsx.snap
+++ b/packages/ui-react/src/components/PlayerError/__snapshots__/PlayerError.test.tsx.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<ErrorPage> > renders and matches snapshot 1`] = `
+<div>
+  <div
+    class="_error_41dece"
+  >
+    <h2
+      class="_title_41dece"
+    >
+      player_error.geo_blocked_title
+    </h2>
+    <p>
+      player_error.geo_blocked_description
+    </p>
+  </div>
+</div>
+`;

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -109,7 +109,7 @@ const Cinema: React.FC<Props> = ({
                 <ArrowLeft />
               </IconButton>
               <div>
-                <h2 className={styles.title}>{title}</h2>
+                <h1 className={styles.title}>{title}</h1>
                 <div className={styles.metaContainer}>
                   {secondaryMetadata && <div className={styles.secondaryMetadata}>{secondaryMetadata}</div>}
                   <div className={styles.primaryMetadata}>{primaryMetadata}</div>

--- a/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
+++ b/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
@@ -51,11 +51,11 @@ exports[`<Cinema> > renders and matches snapshot 1`] = `
               </svg>
             </div>
             <div>
-              <h2
+              <h1
                 class="_title_555f3c"
               >
                 Test item title
-              </h2>
+              </h1>
               <div
                 class="_metaContainer_555f3c"
               >

--- a/packages/ui-react/src/containers/InlinePlayer/InlinePlayer.module.scss
+++ b/packages/ui-react/src/containers/InlinePlayer/InlinePlayer.module.scss
@@ -8,6 +8,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  background-color: theme.$panel-bg;
 }
 
 .paywall {

--- a/packages/ui-react/src/containers/PlayerContainer/PlayerContainer.tsx
+++ b/packages/ui-react/src/containers/PlayerContainer/PlayerContainer.tsx
@@ -8,6 +8,7 @@ import useProtectedMedia from '@jwp/ott-hooks-react/src/useProtectedMedia';
 
 import Player from '../../components/Player/Player';
 import LoadingOverlay from '../../components/LoadingOverlay/LoadingOverlay';
+import PlayerError, { PlayerErrorState } from '../../components/PlayerError/PlayerError';
 
 type Props = {
   item: PlaylistItem;
@@ -43,7 +44,7 @@ const PlayerContainer: React.FC<Props> = ({
 }: Props) => {
   // data
   const { data: adsData, isLoading: isAdsLoading } = useAds({ mediaId: item?.mediaid });
-  const { data: playableItem, isLoading } = useProtectedMedia(item);
+  const { data: playableItem, isLoading, isGeoBlocked } = useProtectedMedia(item);
   // state
   const [playerInstance, setPlayerInstance] = useState<JWPlayer>();
 
@@ -68,6 +69,10 @@ const PlayerContainer: React.FC<Props> = ({
 
   if (!playableItem || isLoading || isAdsLoading) {
     return <LoadingOverlay inline />;
+  }
+
+  if (isGeoBlocked) {
+    return <PlayerError error={PlayerErrorState.GEO_BLOCKED} />;
   }
 
   return (

--- a/platforms/web/public/locales/en/video.json
+++ b/platforms/web/public/locales/en/video.json
@@ -12,6 +12,10 @@
   "favorite": "Favorite",
   "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{maxCount}} favorite videos. Please delete one and repeat the operation.",
   "live": "Live",
+  "player_error": {
+    "geo_blocked_description": "We apologize, but this content is currently unavailable in your region.",
+    "geo_blocked_title": "Content unavailable"
+  },
   "remove_from_favorites": "Remove from favorites",
   "season": "season",
   "season_number_filter_template": "Season {{seasonNumber}}",

--- a/platforms/web/public/locales/es/video.json
+++ b/platforms/web/public/locales/es/video.json
@@ -12,6 +12,10 @@
   "favorite": "Favorito",
   "favorites_warning": "Se ha alcanzado el máximo de videos favoritos. Solo puedes agregar hasta {{maxCount}} videos favoritos. Por favor, elimina uno y repite la operación.",
   "live": "EN VIVO",
+  "player_error": {
+    "geo_blocked_description": "Pedimos disculpas, pero este contenido no está disponible actualmente en tu región.",
+    "geo_blocked_title": "Contenido no disponible"
+  },
   "remove_from_favorites": "Eliminar de favoritos",
   "season": "temporada",
   "season_number_filter_template": "Temporada {{seasonNumber}}",


### PR DESCRIPTION
This change will show a nice message to the user when a media item is geographically blocked. Previously you would see a generic JW Player error message on top of the player.

**EDIT: Updated screenshots on 11 january**

### Cinema example
![Screenshot 2024-01-11 at 14 21 37](https://github.com/Videodock/ott-web-app/assets/1019129/4937682c-b2af-433c-82ab-bde57ecc389b)

### Inline player example
![Screenshot 2024-01-11 at 14 22 00](https://github.com/Videodock/ott-web-app/assets/1019129/7da5ab0c-28dc-4735-875b-c2fd475d5f46)

It will determine the availability of the media item based on the HTTP statuscode of the m3u8 (playlist) file based on a `HEAD`-request. The media API itself will always return a 200 statuscode. 

I created a new `<PlayerError />` component which handles the display of the geo blocked message. In the future this could be extended to also show other (nice) error messages instead of the (default) JWPlayer error box.

I noticed that for a split second it can occur that you will see a JWPlayer error box which will get replaced by this nice friendly message. If this is something we do not want to occur, I will need to invest some extra time in it. ❗ 

I also changed the cinema title to a `<h1>` to keep the heading hierarchy logical.

I have also tested this on a iOS device. Responsiveness is also guaranteed.

Tickets: 
- https://videodock.atlassian.net/browse/OTT-363 - Generic logic
- https://videodock.atlassian.net/browse/OTT-364 - Implementation
- https://videodock.atlassian.net/browse/OTT-365 - UI & translation
- https://videodock.atlassian.net/browse/OTT-366 - Testing


