### PR TITLE
Fix / a11y card optimized for screen readers

### DIFF
--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -5,7 +5,7 @@
 
 .card {
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   justify-content: flex-start;
   color: inherit;
   text-decoration: none;

--- a/packages/ui-react/src/components/Card/Card.test.tsx
+++ b/packages/ui-react/src/components/Card/Card.test.tsx
@@ -22,18 +22,19 @@ describe('<Card>', () => {
 
   it('renders the image with the image prop when valid', () => {
     const { getByAltText } = renderWithRouter(<Card item={itemWithImage} url="https://test.dummy.jwplayer.com" />);
-    expect(getByAltText('This is a movie')).toHaveAttribute('src', 'http://movie.jpg?width=320');
+    expect(getByAltText('')).toHaveAttribute('src', 'http://movie.jpg?width=320');
   });
 
   it('makes the image visible after load', () => {
     const { getByAltText } = renderWithRouter(<Card item={itemWithImage} url="https://test.dummy.jwplayer.com" />);
+    const image = getByAltText(''); // Image alt is intentionally empty for a11y
 
-    expect(getByAltText('This is a movie')).toHaveAttribute('src', 'http://movie.jpg?width=320');
-    expect(getByAltText('This is a movie')).toHaveStyle({ opacity: 0 });
+    expect(image).toHaveAttribute('src', 'http://movie.jpg?width=320');
+    expect(image).toHaveStyle({ opacity: 0 });
 
-    fireEvent.load(getByAltText('This is a movie'));
+    fireEvent.load(image);
 
-    expect(getByAltText('This is a movie')).toHaveStyle({ opacity: 1 });
+    expect(image).toHaveStyle({ opacity: 1 });
   });
 
   it('should render anchor tag', () => {

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -6,6 +6,7 @@ import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import { formatDurationTag, formatLocalizedDateTime, formatSeriesMetaString } from '@jwp/ott-common/src/utils/formatting';
 import { isLiveChannel, isSeries } from '@jwp/ott-common/src/utils/media';
 import { MediaStatus } from '@jwp/ott-common/src/utils/liveEvent';
+import { testId } from '@jwp/ott-common/src/utils/common';
 
 import Lock from '../../icons/Lock';
 import Today from '../../icons/Today';
@@ -92,6 +93,7 @@ function Card({
       onClick={disabled ? (e) => e.preventDefault() : undefined}
       onMouseEnter={onHover}
       tabIndex={disabled ? -1 : 0}
+      data-testid={testId(title)}
     >
       {!featured && !disabled && (
         <div className={styles.titleContainer}>

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -86,22 +86,29 @@ function Card({
 
   return (
     <Link
+      role="button"
       to={url}
       className={cardClassName}
       onClick={disabled ? (e) => e.preventDefault() : undefined}
       onMouseEnter={onHover}
       tabIndex={disabled ? -1 : 0}
-      aria-label={title}
     >
+      {!featured && !disabled && (
+        <div className={styles.titleContainer}>
+          <h3 className={classNames(styles.title, { [styles.loading]: loading })}>{title}</h3>
+          {!!scheduledStart && (
+            <div className={classNames(styles.scheduledStart, { [styles.loading]: loading })}>{formatLocalizedDateTime(scheduledStart, language)}</div>
+          )}
+        </div>
+      )}
       <div className={posterClassNames}>
-        <Image className={posterImageClassNames} image={image} width={featured ? 640 : 320} onLoad={() => setImageLoaded(true)} alt={title} />
-        {isCurrent && <div className={styles.currentLabel}>{currentLabel}</div>}
+        <Image className={posterImageClassNames} image={image} width={featured ? 640 : 320} onLoad={() => setImageLoaded(true)} alt="" />
         {!loading && (
           <div className={styles.meta}>
-            {featured && !disabled && <div className={classNames(styles.title, { [styles.loading]: loading })}>{title}</div>}
+            {featured && !disabled && <h3 className={classNames(styles.title, { [styles.loading]: loading })}>{title}</h3>}
             <div className={styles.tags}>
               {isLocked && (
-                <div className={classNames(styles.tag, styles.lock)} aria-label={t('card_lock')} role="status">
+                <div className={classNames(styles.tag, styles.lock)} aria-label={t('card_lock')}>
                   <Lock />
                 </div>
               )}
@@ -109,20 +116,13 @@ function Card({
             </div>
           </div>
         )}
+        {isCurrent && <div className={styles.currentLabel}>{currentLabel}</div>}
         {progress ? (
           <div className={styles.progressContainer}>
             <div className={styles.progressBar} style={{ width: `${Math.round(progress * 100)}%` }} />
           </div>
         ) : null}
       </div>
-      {!featured && !disabled && (
-        <div className={styles.titleContainer}>
-          {!!scheduledStart && (
-            <div className={classNames(styles.scheduledStart, { [styles.loading]: loading })}>{formatLocalizedDateTime(scheduledStart, language)}</div>
-          )}
-          <div className={classNames(styles.title, { [styles.loading]: loading })}>{title}</div>
-        </div>
-      )}
     </Link>
   );
 }

--- a/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -3,16 +3,25 @@
 exports[`<Card> > should render anchor tag 1`] = `
 <div>
   <a
-    aria-label="This is a movie"
     class="_card_d75732"
     href="https://test.dummy.jwplayer.com"
+    role="button"
     tabindex="0"
   >
+    <div
+      class="_titleContainer_d75732"
+    >
+      <h3
+        class="_title_d75732"
+      >
+        This is a movie
+      </h3>
+    </div>
     <div
       class="_poster_d75732 _aspect169_d75732"
     >
       <img
-        alt="This is a movie"
+        alt=""
         class="_posterImage_d75732 _image_4c41c3"
         src="http://movie.jpg?width=320"
       />
@@ -25,7 +34,6 @@ exports[`<Card> > should render anchor tag 1`] = `
           <div
             aria-label="card_lock"
             class="_tag_d75732 _lock_d75732"
-            role="status"
           >
             <svg
               aria-hidden="true"
@@ -46,15 +54,6 @@ exports[`<Card> > should render anchor tag 1`] = `
             2 min
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      class="_titleContainer_d75732"
-    >
-      <div
-        class="_title_d75732"
-      >
-        This is a movie
       </div>
     </div>
   </a>

--- a/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<Card> > should render anchor tag 1`] = `
 <div>
   <a
     class="_card_d75732"
+    data-testid="This is a movie"
     href="https://test.dummy.jwplayer.com"
     role="button"
     tabindex="0"

--- a/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
+++ b/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
@@ -15,11 +15,20 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
           role="cell"
         >
           <a
-            aria-label="Agent 327"
             class="_card_d75732"
             href="/m/uB8aRnu6"
+            role="button"
             tabindex="0"
           >
+            <div
+              class="_titleContainer_d75732"
+            >
+              <h3
+                class="_title_d75732"
+              >
+                Agent 327
+              </h3>
+            </div>
             <div
               class="_poster_d75732 _aspect169_d75732"
             >
@@ -37,15 +46,6 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              class="_titleContainer_d75732"
-            >
-              <div
-                class="_title_d75732"
-              >
-                Agent 327
-              </div>
-            </div>
           </a>
         </div>
       </div>
@@ -57,11 +57,20 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
           role="cell"
         >
           <a
-            aria-label="Big Buck Bunny"
             class="_card_d75732"
             href="/m/awWEFyPu"
+            role="button"
             tabindex="0"
           >
+            <div
+              class="_titleContainer_d75732"
+            >
+              <h3
+                class="_title_d75732"
+              >
+                Big Buck Bunny
+              </h3>
+            </div>
             <div
               class="_poster_d75732 _aspect169_d75732"
             >
@@ -79,15 +88,6 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              class="_titleContainer_d75732"
-            >
-              <div
-                class="_title_d75732"
-              >
-                Big Buck Bunny
-              </div>
-            </div>
           </a>
         </div>
       </div>
@@ -99,11 +99,20 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
           role="cell"
         >
           <a
-            aria-label="Elephants Dream"
             class="_card_d75732"
             href="/m/eFPH2tVG"
+            role="button"
             tabindex="0"
           >
+            <div
+              class="_titleContainer_d75732"
+            >
+              <h3
+                class="_title_d75732"
+              >
+                Elephants Dream
+              </h3>
+            </div>
             <div
               class="_poster_d75732 _aspect169_d75732"
             >
@@ -119,15 +128,6 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                     11 min
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="_titleContainer_d75732"
-            >
-              <div
-                class="_title_d75732"
-              >
-                Elephants Dream
               </div>
             </div>
           </a>

--- a/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
+++ b/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
         >
           <a
             class="_card_d75732"
+            data-testid="Agent 327"
             href="/m/uB8aRnu6"
             role="button"
             tabindex="0"
@@ -58,6 +59,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
         >
           <a
             class="_card_d75732"
+            data-testid="Big Buck Bunny"
             href="/m/awWEFyPu"
             role="button"
             tabindex="0"
@@ -100,6 +102,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
         >
           <a
             class="_card_d75732"
+            data-testid="Elephants Dream"
             href="/m/eFPH2tVG"
             role="button"
             tabindex="0"

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           >
             <a
               class="_card_d75732 _featured_d75732 _disabled_d75732"
+              data-testid="Third movie"
               href="/m/12332123/third-movie"
               role="button"
               tabindex="-1"
@@ -65,6 +66,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           >
             <a
               class="_card_d75732 _featured_d75732 _disabled_d75732"
+              data-testid="Last playlist item"
               href="/m/ddeeddee/last-playlist-item"
               role="button"
               tabindex="-1"
@@ -88,6 +90,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           >
             <a
               class="_card_d75732 _featured_d75732"
+              data-testid="Movie 1"
               href="/m/1234abcd/movie-1"
               role="button"
               tabindex="0"
@@ -122,6 +125,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           >
             <a
               class="_card_d75732 _featured_d75732 _disabled_d75732"
+              data-testid="Movie 2"
               href="/m/aaaaaaaa/movie-2"
               role="button"
               tabindex="-1"
@@ -145,6 +149,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           >
             <a
               class="_card_d75732 _featured_d75732 _disabled_d75732"
+              data-testid="Third movie"
               href="/m/12332123/third-movie"
               role="button"
               tabindex="-1"
@@ -232,6 +237,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           >
             <a
               class="_card_d75732"
+              data-testid="Movie 1"
               href="/m/1234abcd/movie-1"
               role="button"
               tabindex="0"
@@ -270,6 +276,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           >
             <a
               class="_card_d75732"
+              data-testid="Movie 2"
               href="/m/aaaaaaaa/movie-2"
               role="button"
               tabindex="0"
@@ -308,6 +315,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           >
             <a
               class="_card_d75732"
+              data-testid="Third movie"
               href="/m/12332123/third-movie"
               role="button"
               tabindex="0"
@@ -346,6 +354,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           >
             <a
               class="_card_d75732"
+              data-testid="Last playlist item"
               href="/m/ddeeddee/last-playlist-item"
               role="button"
               tabindex="0"

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -41,9 +41,9 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
             style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
           >
             <a
-              aria-label="Third movie"
               class="_card_d75732 _featured_d75732 _disabled_d75732"
               href="/m/12332123/third-movie"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -64,9 +64,9 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
             style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
           >
             <a
-              aria-label="Last playlist item"
               class="_card_d75732 _featured_d75732 _disabled_d75732"
               href="/m/ddeeddee/last-playlist-item"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -87,9 +87,9 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
             style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
           >
             <a
-              aria-label="Movie 1"
               class="_card_d75732 _featured_d75732"
               href="/m/1234abcd/movie-1"
+              role="button"
               tabindex="0"
             >
               <div
@@ -98,11 +98,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
                 <div
                   class="_meta_d75732"
                 >
-                  <div
+                  <h3
                     class="_title_d75732"
                   >
                     Movie 1
-                  </div>
+                  </h3>
                   <div
                     class="_tags_d75732"
                   >
@@ -121,9 +121,9 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
             style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
           >
             <a
-              aria-label="Movie 2"
               class="_card_d75732 _featured_d75732 _disabled_d75732"
               href="/m/aaaaaaaa/movie-2"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -144,9 +144,9 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
             style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
           >
             <a
-              aria-label="Third movie"
               class="_card_d75732 _featured_d75732 _disabled_d75732"
               href="/m/12332123/third-movie"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -231,49 +231,20 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
             style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
           >
             <a
-              aria-label="Movie 1"
               class="_card_d75732"
               href="/m/1234abcd/movie-1"
+              role="button"
               tabindex="0"
             >
               <div
-                class="_poster_d75732 _aspect169_d75732"
-              >
-                <div
-                  class="_meta_d75732"
-                >
-                  <div
-                    class="_tags_d75732"
-                  >
-                    <div
-                      class="_tag_d75732"
-                    >
-                      1 min
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
                 class="_titleContainer_d75732"
               >
-                <div
+                <h3
                   class="_title_d75732"
                 >
                   Movie 1
-                </div>
+                </h3>
               </div>
-            </a>
-          </li>
-          <li
-            class=""
-            style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          >
-            <a
-              aria-label="Movie 2"
-              class="_card_d75732"
-              href="/m/aaaaaaaa/movie-2"
-              tabindex="0"
-            >
               <div
                 class="_poster_d75732 _aspect169_d75732"
               >
@@ -291,27 +262,27 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                   </div>
                 </div>
               </div>
+            </a>
+          </li>
+          <li
+            class=""
+            style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          >
+            <a
+              class="_card_d75732"
+              href="/m/aaaaaaaa/movie-2"
+              role="button"
+              tabindex="0"
+            >
               <div
                 class="_titleContainer_d75732"
               >
-                <div
+                <h3
                   class="_title_d75732"
                 >
                   Movie 2
-                </div>
+                </h3>
               </div>
-            </a>
-          </li>
-          <li
-            class=""
-            style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          >
-            <a
-              aria-label="Third movie"
-              class="_card_d75732"
-              href="/m/12332123/third-movie"
-              tabindex="0"
-            >
               <div
                 class="_poster_d75732 _aspect169_d75732"
               >
@@ -329,13 +300,42 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                   </div>
                 </div>
               </div>
+            </a>
+          </li>
+          <li
+            class=""
+            style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          >
+            <a
+              class="_card_d75732"
+              href="/m/12332123/third-movie"
+              role="button"
+              tabindex="0"
+            >
               <div
                 class="_titleContainer_d75732"
               >
-                <div
+                <h3
                   class="_title_d75732"
                 >
                   Third movie
+                </h3>
+              </div>
+              <div
+                class="_poster_d75732 _aspect169_d75732"
+              >
+                <div
+                  class="_meta_d75732"
+                >
+                  <div
+                    class="_tags_d75732"
+                  >
+                    <div
+                      class="_tag_d75732"
+                    >
+                      1 min
+                    </div>
+                  </div>
                 </div>
               </div>
             </a>
@@ -345,11 +345,20 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
             style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
           >
             <a
-              aria-label="Last playlist item"
               class="_card_d75732"
               href="/m/ddeeddee/last-playlist-item"
+              role="button"
               tabindex="0"
             >
+              <div
+                class="_titleContainer_d75732"
+              >
+                <h3
+                  class="_title_d75732"
+                >
+                  Last playlist item
+                </h3>
+              </div>
               <div
                 class="_poster_d75732 _aspect169_d75732"
               >
@@ -365,15 +374,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                       21 min
                     </div>
                   </div>
-                </div>
-              </div>
-              <div
-                class="_titleContainer_d75732"
-              >
-                <div
-                  class="_title_d75732"
-                >
-                  Last playlist item
                 </div>
               </div>
             </a>

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -40,11 +40,20 @@ exports[`Home Component tests > Home test 1`] = `
                     style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
                   >
                     <a
-                      aria-label="My video"
                       class="_card_d75732"
                       href="/m/abcddabc/my-video"
+                      role="button"
                       tabindex="0"
                     >
+                      <div
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          My video
+                        </h3>
+                      </div>
                       <div
                         class="_poster_d75732 _aspect169_d75732"
                       >
@@ -57,7 +66,6 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               aria-label="card_lock"
                               class="_tag_d75732 _lock_d75732"
-                              role="status"
                             >
                               <svg
                                 aria-hidden="true"
@@ -78,15 +86,6 @@ exports[`Home Component tests > Home test 1`] = `
                               6 min
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="_titleContainer_d75732"
-                      >
-                        <div
-                          class="_title_d75732"
-                        >
-                          My video
                         </div>
                       </div>
                     </a>
@@ -96,11 +95,20 @@ exports[`Home Component tests > Home test 1`] = `
                     style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
                   >
                     <a
-                      aria-label="Other Vids"
                       class="_card_d75732"
                       href="/m/zzzaaazz/other-vids"
+                      role="button"
                       tabindex="0"
                     >
+                      <div
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          Other Vids
+                        </h3>
+                      </div>
                       <div
                         class="_poster_d75732 _aspect169_d75732"
                       >
@@ -113,7 +121,6 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               aria-label="card_lock"
                               class="_tag_d75732 _lock_d75732"
-                              role="status"
                             >
                               <svg
                                 aria-hidden="true"
@@ -134,15 +141,6 @@ exports[`Home Component tests > Home test 1`] = `
                               6 min
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="_titleContainer_d75732"
-                      >
-                        <div
-                          class="_title_d75732"
-                        >
-                          Other Vids
                         </div>
                       </div>
                     </a>
@@ -181,11 +179,20 @@ exports[`Home Component tests > Home test 1`] = `
                     style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
                   >
                     <a
-                      aria-label="My video"
                       class="_card_d75732"
                       href="/m/abcddabc/my-video"
+                      role="button"
                       tabindex="0"
                     >
+                      <div
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          My video
+                        </h3>
+                      </div>
                       <div
                         class="_poster_d75732 _aspect169_d75732"
                       >
@@ -198,7 +205,6 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               aria-label="card_lock"
                               class="_tag_d75732 _lock_d75732"
-                              role="status"
                             >
                               <svg
                                 aria-hidden="true"
@@ -219,15 +225,6 @@ exports[`Home Component tests > Home test 1`] = `
                               6 min
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="_titleContainer_d75732"
-                      >
-                        <div
-                          class="_title_d75732"
-                        >
-                          My video
                         </div>
                       </div>
                     </a>
@@ -237,11 +234,20 @@ exports[`Home Component tests > Home test 1`] = `
                     style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
                   >
                     <a
-                      aria-label="Other Vids"
                       class="_card_d75732"
                       href="/m/zzzaaazz/other-vids"
+                      role="button"
                       tabindex="0"
                     >
+                      <div
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          Other Vids
+                        </h3>
+                      </div>
                       <div
                         class="_poster_d75732 _aspect169_d75732"
                       >
@@ -254,7 +260,6 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               aria-label="card_lock"
                               class="_tag_d75732 _lock_d75732"
-                              role="status"
                             >
                               <svg
                                 aria-hidden="true"
@@ -275,15 +280,6 @@ exports[`Home Component tests > Home test 1`] = `
                               6 min
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="_titleContainer_d75732"
-                      >
-                        <div
-                          class="_title_d75732"
-                        >
-                          Other Vids
                         </div>
                       </div>
                     </a>

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`Home Component tests > Home test 1`] = `
                   >
                     <a
                       class="_card_d75732"
+                      data-testid="My video"
                       href="/m/abcddabc/my-video"
                       role="button"
                       tabindex="0"
@@ -96,6 +97,7 @@ exports[`Home Component tests > Home test 1`] = `
                   >
                     <a
                       class="_card_d75732"
+                      data-testid="Other Vids"
                       href="/m/zzzaaazz/other-vids"
                       role="button"
                       tabindex="0"
@@ -180,6 +182,7 @@ exports[`Home Component tests > Home test 1`] = `
                   >
                     <a
                       class="_card_d75732"
+                      data-testid="My video"
                       href="/m/abcddabc/my-video"
                       role="button"
                       tabindex="0"
@@ -235,6 +238,7 @@ exports[`Home Component tests > Home test 1`] = `
                   >
                     <a
                       class="_card_d75732"
+                      data-testid="Other Vids"
                       href="/m/zzzaaazz/other-vids"
                       role="button"
                       tabindex="0"

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -398,11 +398,20 @@ exports[`User Component tests > Favorites Page 1`] = `
                 role="cell"
               >
                 <a
-                  aria-label="Fav 1"
                   class="_card_d75732"
                   href="/m/aaabbbcc/fav-1?r=abcdffff"
+                  role="button"
                   tabindex="0"
                 >
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      Fav 1
+                    </h3>
+                  </div>
                   <div
                     class="_poster_d75732 _aspect169_d75732"
                   >
@@ -420,15 +429,6 @@ exports[`User Component tests > Favorites Page 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="_titleContainer_d75732"
-                  >
-                    <div
-                      class="_title_d75732"
-                    >
-                      Fav 1
-                    </div>
-                  </div>
                 </a>
               </div>
             </div>
@@ -440,11 +440,20 @@ exports[`User Component tests > Favorites Page 1`] = `
                 role="cell"
               >
                 <a
-                  aria-label="Big Buck Bunny"
                   class="_card_d75732"
                   href="/m/aaabbbcd/big-buck-bunny?r=bbbdddff"
+                  role="button"
                   tabindex="0"
                 >
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      Big Buck Bunny
+                    </h3>
+                  </div>
                   <div
                     class="_poster_d75732 _aspect169_d75732"
                   >
@@ -462,15 +471,6 @@ exports[`User Component tests > Favorites Page 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="_titleContainer_d75732"
-                  >
-                    <div
-                      class="_title_d75732"
-                    >
-                      Big Buck Bunny
-                    </div>
-                  </div>
                 </a>
               </div>
             </div>
@@ -482,11 +482,20 @@ exports[`User Component tests > Favorites Page 1`] = `
                 role="cell"
               >
                 <a
-                  aria-label="My last favorite"
                   class="_card_d75732"
                   href="/m/ggaaccvv/my-last-favorite?r=bbbbbbbb"
+                  role="button"
                   tabindex="0"
                 >
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      My last favorite
+                    </h3>
+                  </div>
                   <div
                     class="_poster_d75732 _aspect169_d75732"
                   >
@@ -502,15 +511,6 @@ exports[`User Component tests > Favorites Page 1`] = `
                           11 min
                         </div>
                       </div>
-                    </div>
-                  </div>
-                  <div
-                    class="_titleContainer_d75732"
-                  >
-                    <div
-                      class="_title_d75732"
-                    >
-                      My last favorite
                     </div>
                   </div>
                 </a>

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -399,6 +399,7 @@ exports[`User Component tests > Favorites Page 1`] = `
               >
                 <a
                   class="_card_d75732"
+                  data-testid="Fav 1"
                   href="/m/aaabbbcc/fav-1?r=abcdffff"
                   role="button"
                   tabindex="0"
@@ -441,6 +442,7 @@ exports[`User Component tests > Favorites Page 1`] = `
               >
                 <a
                   class="_card_d75732"
+                  data-testid="Big Buck Bunny"
                   href="/m/aaabbbcd/big-buck-bunny?r=bbbdddff"
                   role="button"
                   tabindex="0"
@@ -483,6 +485,7 @@ exports[`User Component tests > Favorites Page 1`] = `
               >
                 <a
                   class="_card_d75732"
+                  data-testid="My last favorite"
                   href="/m/ggaaccvv/my-last-favorite?r=bbbbbbbb"
                   role="button"
                   tabindex="0"

--- a/platforms/web/test-e2e/tests/playlist_test.ts
+++ b/platforms/web/test-e2e/tests/playlist_test.ts
@@ -61,7 +61,7 @@ Scenario('I can filter and click on a card and navigate to the video screen', as
 });
 
 function canNavigateToBigBuckBunny(I: CodeceptJS.I) {
-  I.click({ css: 'a[aria-label="Big Buck Bunny"]' });
+  I.click({ css: 'a[data-testid="Big Buck Bunny"]' });
 
   I.see(constants.bigBuckBunnyDescription);
   I.see(constants.startWatchingButton);

--- a/platforms/web/test-e2e/tests/seo_test.ts
+++ b/platforms/web/test-e2e/tests/seo_test.ts
@@ -73,7 +73,7 @@ Scenario('It renders the correct meta tags for the episode screen', async ({ I }
   await I.openVideoCard(constants.primitiveAnimalsTitle);
   I.see('Primitive Animals');
 
-  I.click('a[aria-label="Blocking"]');
+  I.click('a[data-testid="Blocking"]');
 
   await checkMetaTags(I, 'Blocking', constants.primitiveAnimalsDescription, 'episode');
 });
@@ -102,7 +102,7 @@ Scenario('It renders the correct structured metadata for the episode screen', as
   await I.openVideoCard(constants.primitiveAnimalsTitle);
   I.see('Primitive Animals');
 
-  I.click('a[aria-label="Blocking"]');
+  I.click('a[data-testid="Blocking"]');
 
   const rawURL = await I.grabCurrentUrl();
   const url = removeQueryParams(rawURL, ['r', 'app-config']);

--- a/platforms/web/test-e2e/tests/series_test.ts
+++ b/platforms/web/test-e2e/tests/series_test.ts
@@ -25,19 +25,19 @@ Scenario('I can see series without seasons', async ({ I }) => {
   I.see('Share');
   I.seeTextEquals('Episodes', 'h2');
 
-  I.click('a[aria-label="Blocking"]');
+  I.click('a[data-testid="Blocking"]');
   I.scrollTo('text="Episodes"');
 
   I.see('E1 - Blocking');
-  I.see('Current episode', { css: 'a[aria-label="Blocking"]' });
+  I.see('Current episode', { css: 'a[data-testid="Blocking"]' });
   I.see('Concept Art');
-  I.see('E2', { css: 'a[aria-label="Concept Art"]' });
-  I.see('E3', { css: 'a[aria-label="Modeling Part 1"]' });
-  I.see('E4', { css: 'a[aria-label="Modeling Part 2"]' });
+  I.see('E2', { css: 'a[data-testid="Concept Art"]' });
+  I.see('E3', { css: 'a[data-testid="Modeling Part 1"]' });
+  I.see('E4', { css: 'a[data-testid="Modeling Part 2"]' });
 
-  I.scrollTo('a[aria-label="Modeling Part 2"]');
+  I.scrollTo('a[data-testid="Modeling Part 2"]');
 
-  I.see('E5', { css: 'a[aria-label="Texturing and Lighting"]' });
+  I.see('E5', { css: 'a[data-testid="Texturing and Lighting"]' });
 });
 
 Scenario('I can see series with seasons', async ({ I }) => {
@@ -53,19 +53,19 @@ Scenario('I can see series with seasons', async ({ I }) => {
   I.see('Share');
   I.seeTextEquals('Episodes', 'h2');
 
-  I.click('a[aria-label="Welcome"]');
+  I.click('a[data-testid="Welcome"]');
   I.scrollTo('text="Episodes"');
 
   I.see('S1:E1 - Welcome');
-  I.see('Current episode', { css: 'a[aria-label="Welcome"]' });
-  I.see('S1:E2', { css: 'a[aria-label="Basics Of Blender"]' });
-  I.see('S1:E3', { css: 'a[aria-label="Using Mineways"]' });
-  I.see('S1:E4', { css: 'a[aria-label="Texturing your Minecraft World (Blender Render)"]' });
+  I.see('Current episode', { css: 'a[data-testid="Welcome"]' });
+  I.see('S1:E2', { css: 'a[data-testid="Basics Of Blender"]' });
+  I.see('S1:E3', { css: 'a[data-testid="Using Mineways"]' });
+  I.see('S1:E4', { css: 'a[data-testid="Texturing your Minecraft World (Blender Render)"]' });
 
-  I.scrollTo('a[aria-label="Texturing your Minecraft World (Blender Render)"]');
+  I.scrollTo('a[data-testid="Texturing your Minecraft World (Blender Render)"]');
 
-  I.see('S1:E5', { css: 'a[aria-label="Texturing your Minecraft World (Cycles)"]' });
-  I.see('S1:E6', { css: 'a[aria-label="Rig Overview (Boxscape Studios)"]' });
+  I.see('S1:E5', { css: 'a[data-testid="Texturing your Minecraft World (Cycles)"]' });
+  I.see('S1:E6', { css: 'a[data-testid="Rig Overview (Boxscape Studios)"]' });
 });
 
 Scenario('I can other episodes from the series', async ({ I }) => {
@@ -73,7 +73,7 @@ Scenario('I can other episodes from the series', async ({ I }) => {
   I.see('Fantasy Vehicle Creation');
 
   I.scrollTo('text="Modeling Part 1"');
-  I.click('a[aria-label="Modeling Part 1"]');
+  I.click('a[data-testid="Modeling Part 1"]');
 
   // Scroll to the top when a new episode is selected (takes a short time)
   I.wait(2);
@@ -84,7 +84,7 @@ Scenario('I can other episodes from the series', async ({ I }) => {
   );
 
   I.scrollTo('text="Texturing and Lighting"');
-  I.click('a[aria-label="Texturing and Lighting"]');
+  I.click('a[data-testid="Texturing and Lighting"]');
 
   // Check that scrolled to the top
   I.wait(2);

--- a/platforms/web/test-e2e/tests/video_detail_test.ts
+++ b/platforms/web/test-e2e/tests/video_detail_test.ts
@@ -32,7 +32,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     I.see('Favorite');
     I.see('Share');
     I.see('Elephants Dream');
-    I.see('11 min', { css: 'a[aria-label="Elephants Dream"]' });
+    I.see('11 min', { css: 'a[data-testid="Elephants Dream"]' });
   });
 
   Scenario(`I can expand the description (@mobile-only) - ${providerName}`, async ({ I }) => {

--- a/platforms/web/test-e2e/tests/watch_history/local_test.ts
+++ b/platforms/web/test-e2e/tests/watch_history/local_test.ts
@@ -45,7 +45,7 @@ Scenario('I can see my watch history on the Home screen', async ({ I }) => {
     I.see('10 min');
   });
 
-  const selector = `${makeShelfXpath(ShelfId.continueWatching)}//a[@aria-label="${videoTitle}"]`;
+  const selector = `${makeShelfXpath(ShelfId.continueWatching)}//a[@data-testid="${videoTitle}"]`;
   await checkProgress(I, selector, (200 / videoLength) * 100);
 
   I.click(selector);

--- a/platforms/web/test-e2e/tests/watch_history/logged_in_test.ts
+++ b/platforms/web/test-e2e/tests/watch_history/logged_in_test.ts
@@ -72,7 +72,7 @@ function runTestSuite(config: typeof testConfigs.svod, configNoWatchlist: typeof
       I.see('10 min');
     });
 
-    const selector = `${makeShelfXpath(ShelfId.continueWatching)}//a[@aria-label="${videoTitle}"]`;
+    const selector = `${makeShelfXpath(ShelfId.continueWatching)}//a[@data-testid="${videoTitle}"]`;
     await checkProgress(I, selector, (80 / videoLength) * 100);
 
     I.click(selector);

--- a/platforms/web/test-e2e/utils/steps_file.ts
+++ b/platforms/web/test-e2e/utils/steps_file.ts
@@ -466,7 +466,7 @@ const stepsObj = {
     scrollToTheRight: boolean = true,
     preOpenCallback?: (locator: string) => void,
   ) {
-    const cardLocator = `//a[@aria-label="${name}"]`;
+    const cardLocator = `//a[@data-testid="${name}"]`;
     const shelfLocator = shelf ? makeShelfXpath(shelf) : undefined;
 
     this.scrollPageToTop();


### PR DESCRIPTION
This change optimize the cards (tiles) for accessibility. The cards are is also used as 'slides' in the carrousel on top of the homepage. I originally thought this was a different component ;)

### Screen reader reading order
With this change the cards are read by the screen reader in the following order:
1. Title
2. "Item locked" (when the media item is locked)
3. Duration or "Live" or "Scheduled" or "Series" or "S10:E5". The latest one could be improved for screen readers (something for [later](https://videodock.atlassian.net/browse/OTT-535))
4. A possible "Current episode" overlay over the tile (within the `CardGrid` component)

It will be read as one sentence.

### Summary of changes
- Use a `<h3>` for the title (since a `<h2>` is used for the shelf title) - It makes the heading structure of the page logical (for users who using heading hierarchy to navigate through the page) [OTT-399](https://videodock.atlassian.net/browse/OTT-399)
- Reorder HTML so the screen reader wil read everything in the correct order while maintaining the same visual order (using flexbox `column-reverse`) [OTT-399](https://videodock.atlassian.net/browse/OTT-399)
- Convert link to a button by applying `role="button"` [OTT-399](https://videodock.atlassian.net/browse/OTT-399)
- Keep `alt=""` intentionally empty so the title will not be read twice [OTT-367](https://videodock.atlassian.net/browse/OTT-367) & [OTT-368](https://videodock.atlassian.net/browse/OTT-368)

### Card button
The primary reason I have chosen to convert the link to a button within the Card-component is that the whole contents of the card will be read out in one sentence and navigating (swiping left/right) will move the focus to the other card immediately instead of navigating through the inner elements of the Card. TLDR; it makes navigation more easy.

Using `<Button as="a">` instead of `<Link role="button">` will require a lot of structural changes to the Button-component regarding the properties (making label optional, adding new props, overriding of existing props on the NavLink-component). With this current change I kept it simple by only applying `role="button"` (also to keep my solution my estimated time).

### Todo
- [x] CardGrid component grid (cell vs. row) still needs optimisation. this has been discussed with the team. Something for next sprint. Ticket created.
- [x]  Tested on iOS and Android with screenreader
- [ ] After I get your 2 approvals I will rewrite all e2e tests with using `//a//h3[text()="${name}"]` instead of the `a[aria-label]` selector. This requires a lot of changes. So before I do this I have to know if you are satisfied with my approach.


[OTT-399]: https://videodock.atlassian.net/browse/OTT-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-399]: https://videodock.atlassian.net/browse/OTT-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ