### PR TITLE
Fix/a11y apply section to account pages

### DIFF
--- a/packages/hooks-react/src/useOpaqueId.ts
+++ b/packages/hooks-react/src/useOpaqueId.ts
@@ -5,7 +5,11 @@ const generateId = (prefix?: string, suffix?: string) => {
   // Ideally it would be mocked in the test setup but there seems to be a bug with vitest if you mock Math.random
   const randomId = import.meta.env.MODE === 'test' ? 1235 : Math.random() * 10000;
 
-  return [prefix, Math.round(randomId), suffix].filter(Boolean).join('_');
+  return [prefix, Math.round(randomId), suffix]
+    .filter(Boolean)
+    .join('_')
+    .replace(/[\s.]+/g, '_')
+    .toLowerCase();
 };
 
 const useOpaqueId = (prefix?: string, suffix?: string, override?: string): string => {

--- a/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
+++ b/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`<Account> > renders and matches snapshot 1`] = `
 <div>
   <section
-    aria-labelledby="account.about_you_1235"
+    aria-labelledby="account_about_you_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
       <h2
-        id="account.about_you_1235"
+        id="account_about_you_1235"
       >
         account.about_you
       </h2>
@@ -29,7 +29,7 @@ exports[`<Account> > renders and matches snapshot 1`] = `
       >
         <label
           class="_label_e16c1b"
-          for="text-field_1235_firstName"
+          for="text-field_1235_firstname"
         >
           account.firstname
         </label>
@@ -42,7 +42,7 @@ exports[`<Account> > renders and matches snapshot 1`] = `
       >
         <label
           class="_label_e16c1b"
-          for="text-field_1235_lastName"
+          for="text-field_1235_lastname"
         >
           account.lastname
         </label>
@@ -65,14 +65,14 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     </div>
   </section>
   <section
-    aria-labelledby="account.email_1235"
+    aria-labelledby="account_email_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
       <h2
-        id="account.email_1235"
+        id="account_email_1235"
       >
         account.email
       </h2>
@@ -109,14 +109,14 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     </div>
   </section>
   <section
-    aria-labelledby="account.security_1235"
+    aria-labelledby="account_security_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
       <h2
-        id="account.security_1235"
+        id="account_security_1235"
       >
         account.security
       </h2>
@@ -139,14 +139,14 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     </div>
   </section>
   <section
-    aria-labelledby="account.terms_and_tracking_1235"
+    aria-labelledby="account_terms_and_tracking_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
       <h2
-        id="account.terms_and_tracking_1235"
+        id="account_terms_and_tracking_1235"
       >
         account.terms_and_tracking
       </h2>
@@ -160,14 +160,14 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     />
   </section>
   <section
-    aria-labelledby="account.other_registration_details_1235"
+    aria-labelledby="account_other_registration_details_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
       <h2
-        id="account.other_registration_details_1235"
+        id="account_other_registration_details_1235"
       >
         account.other_registration_details
       </h2>
@@ -188,13 +188,13 @@ exports[`<Account> > renders and matches snapshot 1`] = `
             class="_row_531f07"
           >
             <input
-              id="check-box_1235_consentsValues.marketing"
+              id="check-box_1235_consentsvalues_marketing"
               name="consentsValues.marketing"
               type="checkbox"
               value=""
             />
             <label
-              for="check-box_1235_consentsValues.marketing"
+              for="check-box_1235_consentsvalues_marketing"
             >
               Receive Marketing Emails
             </label>

--- a/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
+++ b/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
@@ -2,13 +2,16 @@
 
 exports[`<Account> > renders and matches snapshot 1`] = `
 <div>
-  <div
+  <section
+    aria-labelledby="account.about_you_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
-      <h2>
+      <h2
+        id="account.about_you_1235"
+      >
         account.about_you
       </h2>
     </div>
@@ -60,14 +63,17 @@ exports[`<Account> > renders and matches snapshot 1`] = `
         </span>
       </button>
     </div>
-  </div>
-  <div
+  </section>
+  <section
+    aria-labelledby="account.email_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
-      <h2>
+      <h2
+        id="account.email_1235"
+      >
         account.email
       </h2>
     </div>
@@ -101,14 +107,17 @@ exports[`<Account> > renders and matches snapshot 1`] = `
         </span>
       </button>
     </div>
-  </div>
-  <div
+  </section>
+  <section
+    aria-labelledby="account.security_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
-      <h2>
+      <h2
+        id="account.security_1235"
+      >
         account.security
       </h2>
     </div>
@@ -128,14 +137,17 @@ exports[`<Account> > renders and matches snapshot 1`] = `
         </span>
       </button>
     </div>
-  </div>
-  <div
+  </section>
+  <section
+    aria-labelledby="account.terms_and_tracking_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
-      <h2>
+      <h2
+        id="account.terms_and_tracking_1235"
+      >
         account.terms_and_tracking
       </h2>
     </div>
@@ -146,14 +158,17 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     <div
       class="_controls_1c1c63"
     />
-  </div>
-  <div
+  </section>
+  <section
+    aria-labelledby="account.other_registration_details_1235"
     class="panel-class"
   >
     <div
       class="header-class"
     >
-      <h2>
+      <h2
+        id="account.other_registration_details_1235"
+      >
         account.other_registration_details
       </h2>
     </div>
@@ -190,6 +205,6 @@ exports[`<Account> > renders and matches snapshot 1`] = `
     <div
       class="_controls_1c1c63"
     />
-  </div>
+  </section>
 </div>
 `;

--- a/packages/ui-react/src/components/CreditCardCVCField/__snapshots__/CreditCardCVCField.test.tsx.snap
+++ b/packages/ui-react/src/components/CreditCardCVCField/__snapshots__/CreditCardCVCField.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<CreditCardCVCField> > renders and matches snapshot 1`] = `
   >
     <label
       class="_label_e16c1b"
-      for="text-field_1235_cardCVC"
+      for="text-field_1235_cardcvc"
     >
       payment.security_code
     </label>
@@ -17,7 +17,7 @@ exports[`<CreditCardCVCField> > renders and matches snapshot 1`] = `
       <input
         aria-label="payment.security_code"
         class="_input_e16c1b"
-        id="text-field_1235_cardCVC"
+        id="text-field_1235_cardcvc"
         name="cardCVC"
         pattern="\\\\d*"
         placeholder="###"

--- a/packages/ui-react/src/components/CreditCardExpiryField/__snapshots__/CreditCardExpiryField.test.tsx.snap
+++ b/packages/ui-react/src/components/CreditCardExpiryField/__snapshots__/CreditCardExpiryField.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<CreditCardExpiryField> > renders and matches snapshot 1`] = `
   >
     <label
       class="_label_e16c1b"
-      for="text-field_1235_cardExpiry"
+      for="text-field_1235_cardexpiry"
     >
       Expiry date
     </label>
@@ -16,7 +16,7 @@ exports[`<CreditCardExpiryField> > renders and matches snapshot 1`] = `
     >
       <input
         class="_input_e16c1b"
-        id="text-field_1235_cardExpiry"
+        id="text-field_1235_cardexpiry"
         name="cardExpiry"
         pattern="\\\\d*"
         placeholder="MM/YY"

--- a/packages/ui-react/src/components/CreditCardNumberField/__snapshots__/CreditCardNumberField.test.tsx.snap
+++ b/packages/ui-react/src/components/CreditCardNumberField/__snapshots__/CreditCardNumberField.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<CreditCardNumberField> > renders and matches snapshot 1`] = `
   >
     <label
       class="_label_e16c1b"
-      for="text-field_1235_cardNumber"
+      for="text-field_1235_cardnumber"
     >
       Card number
     </label>
@@ -16,7 +16,7 @@ exports[`<CreditCardNumberField> > renders and matches snapshot 1`] = `
     >
       <input
         class="_input_e16c1b"
-        id="text-field_1235_cardNumber"
+        id="text-field_1235_cardnumber"
         name="cardNumber"
         pattern="\\\\d*"
         placeholder="1234 5678 9012 3456"

--- a/packages/ui-react/src/components/EditPasswordForm/__snapshots__/EditPasswordForm.test.tsx.snap
+++ b/packages/ui-react/src/components/EditPasswordForm/__snapshots__/EditPasswordForm.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`<EditPasswordForm> > renders and matches snapshot 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_passwordConfirmation"
+        for="text-field_1235_passwordconfirmation"
       >
         reset.repeat_new_password
       </label>
@@ -76,7 +76,7 @@ exports[`<EditPasswordForm> > renders and matches snapshot 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_passwordConfirmation"
+          id="text-field_1235_passwordconfirmation"
           name="passwordConfirmation"
           placeholder="reset.repeat_new_password"
           required=""

--- a/packages/ui-react/src/components/Form/FormSection.tsx
+++ b/packages/ui-react/src/components/Form/FormSection.tsx
@@ -147,9 +147,9 @@ export function FormSection<TData extends GenericFormValues>({
   );
 
   return (
-    <div className={className}>
+    <section aria-labelledby={sectionId} className={className}>
       <div className={panelHeaderClassName}>
-        <h2>{label}</h2>
+        <h2 id={sectionId}>{label}</h2>
       </div>
       {isBusy && isEditing && <LoadingOverlay transparentBackground />}
       {content && (
@@ -183,6 +183,6 @@ export function FormSection<TData extends GenericFormValues>({
           )}
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/packages/ui-react/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/ui-react/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -2,9 +2,13 @@
 
 exports[`<Form> > renders Form 1`] = `
 <div>
-  <div>
+  <section
+    aria-labelledby="Edit This_1235"
+  >
     <div>
-      <h2>
+      <h2
+        id="Edit This_1235"
+      >
         Edit This
       </h2>
     </div>
@@ -29,6 +33,6 @@ exports[`<Form> > renders Form 1`] = `
         </span>
       </button>
     </div>
-  </div>
+  </section>
 </div>
 `;

--- a/packages/ui-react/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/ui-react/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`<Form> > renders Form 1`] = `
 <div>
   <section
-    aria-labelledby="Edit This_1235"
+    aria-labelledby="edit_this_1235"
   >
     <div>
       <h2
-        id="Edit This_1235"
+        id="edit_this_1235"
       >
         Edit This
       </h2>

--- a/packages/ui-react/src/components/Payment/Payment.tsx
+++ b/packages/ui-react/src/components/Payment/Payment.tsx
@@ -9,6 +9,7 @@ import { formatLocalizedDate, formatPrice } from '@jwp/ott-common/src/utils/form
 import { addQueryParam } from '@jwp/ott-common/src/utils/location';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useBreakpoint, { Breakpoint } from '@jwp/ott-hooks-react/src/useBreakpoint';
+import useOpaqueId from '@jwp/ott-hooks-react/src/useOpaqueId';
 
 import ExternalLink from '../../icons/ExternalLink';
 import PayPal from '../../icons/PayPal';
@@ -83,6 +84,9 @@ const Payment = ({
   isUpgradeOffer,
   setIsUpgradeOffer,
 }: Props): JSX.Element => {
+  const subscriptionDetailsId = useOpaqueId('subscription-details');
+  const paymentMethodId = useOpaqueId('payment-method');
+  const billingHistoryId = useOpaqueId('billing-history');
   const { t, i18n } = useTranslation(['user', 'account']);
   const hiddenTransactionsCount = transactions ? transactions?.length - VISIBLE_TRANSACTIONS : 0;
   const hasMoreTransactions = hiddenTransactionsCount > 0;
@@ -168,9 +172,9 @@ const Payment = ({
       />
       <h1 className="hideUntilFocus">{t('nav.payments')}</h1>
       {accessModel === ACCESS_MODEL.SVOD && (
-        <div className={panelClassName}>
+        <section aria-labelledby={subscriptionDetailsId} className={panelClassName}>
           <div className={panelHeaderClassName}>
-            <h2>{isChangingOffer ? t('user:payment.change_plan') : t('user:payment.subscription_details')}</h2>
+            <h2 id={subscriptionDetailsId}>{isChangingOffer ? t('user:payment.change_plan') : t('user:payment.subscription_details')}</h2>
           </div>
           {activeSubscription ? (
             <React.Fragment>
@@ -268,11 +272,11 @@ const Payment = ({
               </div>
             </div>
           )}
-        </div>
+        </section>
       )}
-      <div className={panelClassName}>
+      <section aria-labelledby={paymentMethodId} className={panelClassName}>
         <div className={panelHeaderClassName}>
-          <h2>{t('user:payment.payment_method')}</h2>
+          <h2 id={paymentMethodId}>{t('user:payment.payment_method')}</h2>
         </div>
         {activePaymentDetail ? (
           activePaymentDetail.paymentMethod === 'paypal' ? (
@@ -305,10 +309,10 @@ const Payment = ({
         {canUpdatePaymentMethod && (
           <Button label={t('user:payment.update_payment_details')} type="button" onClick={() => navigate(addQueryParam(location, 'u', 'payment-method'))} />
         )}
-      </div>
-      <div className={panelClassName}>
+      </section>
+      <section aria-labelledby={billingHistoryId} className={panelClassName}>
         <div className={panelHeaderClassName}>
-          <h2>{t('user:payment.billing_history')}</h2>
+          <h2 id={billingHistoryId}>{t('user:payment.billing_history')}</h2>
         </div>
         {transactions?.length ? (
           <React.Fragment>
@@ -352,7 +356,7 @@ const Payment = ({
             <p>{!isLoading && t('user:payment.no_transactions')}</p>
           </div>
         )}
-      </div>
+      </section>
       {isLoading && <LoadingOverlay inline />}
     </>
   );

--- a/packages/ui-react/src/components/Payment/__snapshots__/Payment.test.tsx.snap
+++ b/packages/ui-react/src/components/Payment/__snapshots__/Payment.test.tsx.snap
@@ -7,9 +7,13 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
   >
     nav.payments
   </h1>
-  <div>
+  <section
+    aria-labelledby="payment-method_1235"
+  >
     <div>
-      <h2>
+      <h2
+        id="payment-method_1235"
+      >
         user:payment.payment_method
       </h2>
     </div>
@@ -65,10 +69,14 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         </span>
       </button>
     </div>
-  </div>
-  <div>
+  </section>
+  <section
+    aria-labelledby="billing-history_1235"
+  >
     <div>
-      <h2>
+      <h2
+        id="billing-history_1235"
+      >
         user:payment.billing_history
       </h2>
     </div>
@@ -150,6 +158,6 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </section>
 </div>
 `;

--- a/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
+++ b/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_firstName"
+        for="text-field_1235_firstname"
       >
         personal_details.fist_name
       </label>
@@ -30,7 +30,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_firstName"
+          id="text-field_1235_firstname"
           name="firstName"
           placeholder="personal_details.fist_name"
           required=""
@@ -49,7 +49,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_lastName"
+        for="text-field_1235_lastname"
       >
         personal_details.last_name
       </label>
@@ -58,7 +58,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_lastName"
+          id="text-field_1235_lastname"
           name="lastName"
           placeholder="personal_details.last_name"
           required=""
@@ -77,7 +77,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_companyName"
+        for="text-field_1235_companyname"
       >
         personal_details.company_name
         <span>
@@ -89,7 +89,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_companyName"
+          id="text-field_1235_companyname"
           name="companyName"
           placeholder="personal_details.company_name"
           type="text"
@@ -221,7 +221,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_postCode"
+        for="text-field_1235_postcode"
       >
         personal_details.post_code
       </label>
@@ -230,7 +230,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_postCode"
+          id="text-field_1235_postcode"
           name="postCode"
           placeholder="personal_details.post_code"
           required=""
@@ -249,7 +249,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_phoneNumber"
+        for="text-field_1235_phonenumber"
       >
         personal_details.phone_number
       </label>
@@ -258,7 +258,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_phoneNumber"
+          id="text-field_1235_phonenumber"
           name="phoneNumber"
           placeholder="personal_details.phone_number"
           required=""
@@ -274,11 +274,11 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
     </div>
     <div
       class="_dateField_eb6974 _error_eb6974"
-      id="text-field_1235_birthDate"
+      id="text-field_1235_birthdate"
     >
       <label
         class="_label_eb6974"
-        for="text-field_1235_birthDate"
+        for="text-field_1235_birthdate"
       >
         personal_details.birth_date
       </label>
@@ -287,12 +287,12 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       >
         <input
           class="_hiddenInput_eb6974"
-          id="text-field_1235_birthDate-hidden"
+          id="text-field_1235_birthdate-hidden"
           name="birthDate"
         />
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-date"
+          id="text-field_1235_birthdate-date"
           maxlength="2"
           name="date"
           placeholder="dd"
@@ -302,7 +302,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
          / 
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-month"
+          id="text-field_1235_birthdate-month"
           maxlength="2"
           name="month"
           placeholder="mm"
@@ -312,7 +312,7 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
          / 
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-year"
+          id="text-field_1235_birthdate-year"
           maxlength="4"
           name="year"
           placeholder="yyyy"
@@ -485,7 +485,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_firstName"
+        for="text-field_1235_firstname"
       >
         personal_details.fist_name
       </label>
@@ -494,7 +494,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_firstName"
+          id="text-field_1235_firstname"
           name="firstName"
           placeholder="personal_details.fist_name"
           required=""
@@ -508,7 +508,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_lastName"
+        for="text-field_1235_lastname"
       >
         personal_details.last_name
       </label>
@@ -517,7 +517,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_lastName"
+          id="text-field_1235_lastname"
           name="lastName"
           placeholder="personal_details.last_name"
           required=""
@@ -531,7 +531,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_companyName"
+        for="text-field_1235_companyname"
       >
         personal_details.company_name
         <span>
@@ -543,7 +543,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_companyName"
+          id="text-field_1235_companyname"
           name="companyName"
           placeholder="personal_details.company_name"
           type="text"
@@ -650,7 +650,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_postCode"
+        for="text-field_1235_postcode"
       >
         personal_details.post_code
       </label>
@@ -659,7 +659,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_postCode"
+          id="text-field_1235_postcode"
           name="postCode"
           placeholder="personal_details.post_code"
           required=""
@@ -673,7 +673,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     >
       <label
         class="_label_e16c1b"
-        for="text-field_1235_phoneNumber"
+        for="text-field_1235_phonenumber"
       >
         personal_details.phone_number
       </label>
@@ -682,7 +682,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_input_e16c1b"
-          id="text-field_1235_phoneNumber"
+          id="text-field_1235_phonenumber"
           name="phoneNumber"
           placeholder="personal_details.phone_number"
           required=""
@@ -693,11 +693,11 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     </div>
     <div
       class="_dateField_eb6974"
-      id="text-field_1235_birthDate"
+      id="text-field_1235_birthdate"
     >
       <label
         class="_label_eb6974"
-        for="text-field_1235_birthDate"
+        for="text-field_1235_birthdate"
       >
         personal_details.birth_date
       </label>
@@ -706,12 +706,12 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       >
         <input
           class="_hiddenInput_eb6974"
-          id="text-field_1235_birthDate-hidden"
+          id="text-field_1235_birthdate-hidden"
           name="birthDate"
         />
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-date"
+          id="text-field_1235_birthdate-date"
           maxlength="2"
           name="date"
           placeholder="dd"
@@ -721,7 +721,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
          / 
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-month"
+          id="text-field_1235_birthdate-month"
           maxlength="2"
           name="month"
           placeholder="mm"
@@ -731,7 +731,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
          / 
         <input
           class="_input_eb6974"
-          id="text-field_1235_birthDate-year"
+          id="text-field_1235_birthdate-year"
           maxlength="4"
           name="year"
           placeholder="yyyy"

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -102,14 +102,14 @@ exports[`User Component tests > Account Page 1`] = `
       class="_mainColumn_e9c5ca"
     >
       <section
-        aria-labelledby="account.about_you_1235"
+        aria-labelledby="account_about_you_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
           <h2
-            id="account.about_you_1235"
+            id="account_about_you_1235"
           >
             account.about_you
           </h2>
@@ -128,7 +128,7 @@ exports[`User Component tests > Account Page 1`] = `
           >
             <label
               class="_label_e16c1b"
-              for="text-field_1235_firstName"
+              for="text-field_1235_firstname"
             >
               account.firstname
             </label>
@@ -141,7 +141,7 @@ exports[`User Component tests > Account Page 1`] = `
           >
             <label
               class="_label_e16c1b"
-              for="text-field_1235_lastName"
+              for="text-field_1235_lastname"
             >
               account.lastname
             </label>
@@ -164,14 +164,14 @@ exports[`User Component tests > Account Page 1`] = `
         </div>
       </section>
       <section
-        aria-labelledby="account.email_1235"
+        aria-labelledby="account_email_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
           <h2
-            id="account.email_1235"
+            id="account_email_1235"
           >
             account.email
           </h2>
@@ -199,14 +199,14 @@ exports[`User Component tests > Account Page 1`] = `
         />
       </section>
       <section
-        aria-labelledby="account.security_1235"
+        aria-labelledby="account_security_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
           <h2
-            id="account.security_1235"
+            id="account_security_1235"
           >
             account.security
           </h2>
@@ -229,14 +229,14 @@ exports[`User Component tests > Account Page 1`] = `
         </div>
       </section>
       <section
-        aria-labelledby="account.terms_and_tracking_1235"
+        aria-labelledby="account_terms_and_tracking_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
           <h2
-            id="account.terms_and_tracking_1235"
+            id="account_terms_and_tracking_1235"
           >
             account.terms_and_tracking
           </h2>

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -642,13 +642,16 @@ exports[`User Component tests > Payments Page 1`] = `
       >
         nav.payments
       </h1>
-      <div
+      <section
+        aria-labelledby="subscription-details_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="subscription-details_1235"
+          >
             user:payment.subscription_details
           </h2>
         </div>
@@ -684,14 +687,17 @@ exports[`User Component tests > Payments Page 1`] = `
             user:payment.change_subscription
           </span>
         </button>
-      </div>
-      <div
+      </section>
+      <section
+        aria-labelledby="payment-method_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="payment-method_1235"
+          >
             user:payment.payment_method
           </h2>
         </div>
@@ -747,14 +753,17 @@ exports[`User Component tests > Payments Page 1`] = `
             </span>
           </button>
         </div>
-      </div>
-      <div
+      </section>
+      <section
+        aria-labelledby="billing-history_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="billing-history_1235"
+          >
             user:payment.billing_history
           </h2>
         </div>
@@ -810,7 +819,7 @@ exports[`User Component tests > Payments Page 1`] = `
             </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   </div>
 </div>

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -101,13 +101,16 @@ exports[`User Component tests > Account Page 1`] = `
     <div
       class="_mainColumn_e9c5ca"
     >
-      <div
+      <section
+        aria-labelledby="account.about_you_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="account.about_you_1235"
+          >
             account.about_you
           </h2>
         </div>
@@ -159,14 +162,17 @@ exports[`User Component tests > Account Page 1`] = `
             </span>
           </button>
         </div>
-      </div>
-      <div
+      </section>
+      <section
+        aria-labelledby="account.email_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="account.email_1235"
+          >
             account.email
           </h2>
         </div>
@@ -191,14 +197,17 @@ exports[`User Component tests > Account Page 1`] = `
         <div
           class="_controls_1c1c63"
         />
-      </div>
-      <div
+      </section>
+      <section
+        aria-labelledby="account.security_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="account.security_1235"
+          >
             account.security
           </h2>
         </div>
@@ -218,14 +227,17 @@ exports[`User Component tests > Account Page 1`] = `
             </span>
           </button>
         </div>
-      </div>
-      <div
+      </section>
+      <section
+        aria-labelledby="account.terms_and_tracking_1235"
         class="_panel_e9c5ca"
       >
         <div
           class="_panelHeader_e9c5ca"
         >
-          <h2>
+          <h2
+            id="account.terms_and_tracking_1235"
+          >
             account.terms_and_tracking
           </h2>
         </div>
@@ -236,7 +248,7 @@ exports[`User Component tests > Account Page 1`] = `
         <div
           class="_controls_1c1c63"
         />
-      </div>
+      </section>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Description:
This PR aims to improve accessibility for payments and account pages by updating the pages with a section tag where needed. Each `<section>` element has the `aria-labelledby` attribute pointing to its corresponding header element. These changes apply both to the Account and Payment pages.

Link to [Jira - OTT-417](https://videodock.atlassian.net/browse/OTT-417)

#### Changes:
1. **Usage of `<section>` Tags**: Introduced `<section>` tags to encapsulate each section of the  pages.

2. **`aria-labelledby` Implementation**: Added the `aria-labelledby` attribute to each `<section>`, referencing the `id` of the corresponding heading element.

**Example:**
```html
<section aria-labelledby={sectionId} className={className}>
  <div className={className}>
    <h2 id={sectionId}>{label}</h2>
  </div>
  <!-- Rest of the code remains unchanged -->
</section>
```

3. **useOpaqueId**: As `.` and whitespaces are not allowed as id i've implemented a fix for the useOpaqueId hook to replace all whitespaces and `.` with `_`. You can find an example [here](https://github.com/Videodock/ott-web-app/pull/15#discussion_r1447496364). 


#### Todo:
1. [x] **Screen Reader Testing**: Conduct thorough testing with various screen readers to ensure that the new `<section>` elements and `aria-labelledby` attributes enhance the navigational experience for users with visual impairments.

2. [x] ~~**Heading Level Navigation Testing**: Test screen reader navigation using heading levels. Ensure that users can efficiently navigate through different sections of the page using heading shortcuts (H key for headings, 1-6 keys for specific levels).~~  - Will be picked up in another [task](https://github.com/Videodock/ott-web-app/pull/15#pullrequestreview-1812800977)