### PR TITLE
feat(i18n): add default language to html tag.

### DIFF
--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -77,16 +77,9 @@ const Layout = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onLanguageChanged = useCallback((language: string) => {
-    if (document.documentElement.lang !== language) {
-      document.documentElement.lang = language;
-    }
-  }, []);
-
   useEffect(() => {
-    i18n.on('languageChanged', onLanguageChanged);
-    return () => i18n.off('languageChanged', onLanguageChanged);
-  }, [onLanguageChanged, i18n]);
+    document.documentElement.setAttribute('lang', i18n.language);
+  }, [i18n.language]);
 
   useEffect(() => {
     if (searchActive && searchInputRef.current) {

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -77,6 +77,17 @@ const Layout = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const onLanguageChanged = useCallback((language: string) => {
+    if (document.documentElement.lang !== language) {
+      document.documentElement.lang = language;
+    }
+  }, []);
+
+  useEffect(() => {
+    i18n.on('languageChanged', onLanguageChanged);
+    return () => i18n.off('languageChanged', onLanguageChanged);
+  }, [onLanguageChanged, i18n]);
+
   useEffect(() => {
     if (searchActive && searchInputRef.current) {
       searchInputRef.current.focus();

--- a/packages/ui-react/vitest.setup.ts
+++ b/packages/ui-react/vitest.setup.ts
@@ -45,8 +45,6 @@ vi.mock('react-i18next', () => ({
     return {
       t: (str: string) => str,
       i18n: {
-        on: (_event: string, callback: () => void) => callback(),
-        off: (_event: string, callback: () => void) => callback(),
         changeLanguage: () =>
           new Promise(() => {
             /* */

--- a/packages/ui-react/vitest.setup.ts
+++ b/packages/ui-react/vitest.setup.ts
@@ -45,6 +45,8 @@ vi.mock('react-i18next', () => ({
     return {
       t: (str: string) => str,
       i18n: {
+        on: (_event: string, callback: () => void) => callback(),
+        off: (_event: string, callback: () => void) => callback(),
         changeLanguage: () =>
           new Promise(() => {
             /* */

--- a/platforms/web/src/i18n/config.ts
+++ b/platforms/web/src/i18n/config.ts
@@ -25,12 +25,16 @@ export const DEFINED_LANGUAGES: LanguageDefinition[] = [
 const initI18n = async () => {
   const enabledLanguages = import.meta.env.APP_ENABLED_LANGUAGES?.split(',') || [];
   const defaultLanguage = import.meta.env.APP_DEFAULT_LANGUAGE || 'en';
+
   const supportedLanguages = filterSupportedLanguages(DEFINED_LANGUAGES, enabledLanguages);
 
   useConfigStore.setState({ supportedLanguages });
 
   if (!supportedLanguages.some(({ code }) => code === defaultLanguage)) {
     throw new Error(`The default language is not enabled: ${defaultLanguage}`);
+  } else {
+    // Set the default language on the HTML element
+    document.documentElement.lang = defaultLanguage;
   }
 
   await i18next
@@ -38,6 +42,7 @@ const initI18n = async () => {
     .use(LanguageDetector)
     .use(initReactI18next)
     .init({
+      // lng: htmlLang,
       supportedLngs: supportedLanguages.map(({ code }) => code),
       fallbackLng: defaultLanguage,
       // this option ensures that empty strings in translations will fall back to the default language

--- a/platforms/web/src/i18n/config.ts
+++ b/platforms/web/src/i18n/config.ts
@@ -32,9 +32,6 @@ const initI18n = async () => {
 
   if (!supportedLanguages.some(({ code }) => code === defaultLanguage)) {
     throw new Error(`The default language is not enabled: ${defaultLanguage}`);
-  } else {
-    // Set the default language on the HTML element
-    document.documentElement.lang = defaultLanguage;
   }
 
   await i18next
@@ -42,7 +39,6 @@ const initI18n = async () => {
     .use(LanguageDetector)
     .use(initReactI18next)
     .init({
-      // lng: htmlLang,
       supportedLngs: supportedLanguages.map(({ code }) => code),
       fallbackLng: defaultLanguage,
       // this option ensures that empty strings in translations will fall back to the default language


### PR DESCRIPTION
#### Description:
This PR implements a vital modification to improve screen reader accessibility. It dynamically adjusts the HTML `lang` attribute when there's a change in the user-selected language, ensuring accurate pronunciation for screen readers.

#### Changes:
1. **Language Change Event Handler in Layout.tsx**:
   - Path: `src/components/Layout/Layout.tsx`
   - The `useEffect` hook now sets the HTML `lang` attribute based on the `i18n.language` variable.
   - Ensures that the `lang` attribute is only modified when it differs from the current setting.

    Example:
    ```jsx
    useEffect(() => {
      document.documentElement.setAttribute('lang', i18n.language);
    }, [i18n.language]);
    ```

#### To-Do Items:
- [x] Resolve Pr Comments and Suggestions.

#### Test Cases:
- [x] Test case ensuring that the `lang` attribute updates correctly on language change.
- [x] Test case verifying the default language is set on initialization.

#### Related Story:
This PR addresses the requirements outlined in [Jira - OTT-397](https://videodock.atlassian.net/browse/OTT-397).

#### Request for Review:
Your feedback is crucial in fine-tuning these enhancements and ensuring the best user experience. Eager to hear your thoughts and suggestions. Thanks in advance for your valuable input!