### PR TITLE
Feat / Better url formatting

### DIFF
--- a/packages/common/src/utils/urlFormatting.test.ts
+++ b/packages/common/src/utils/urlFormatting.test.ts
@@ -11,4 +11,15 @@ describe('createUrl', () => {
 
     expect(url).toEqual('/test?existing-param=1&foo=bar');
   });
+
+  test('valid url from a path including params, removing one with a query param', async () => {
+    const url = createURL('/test?existing-param=1', { [`existing-param`]: null });
+
+    expect(url).toEqual('/test');
+  });
+  test('valid redirect url from a location including params, query params', async () => {
+    const url = createURL('https://app-preview.jwplayer.com/?existing-param=1&foo=bar', { u: 'payment-method-success' });
+
+    expect(url).toEqual('https://app-preview.jwplayer.com/?existing-param=1&foo=bar&u=payment-method-success');
+  });
 });

--- a/packages/common/src/utils/urlFormatting.test.ts
+++ b/packages/common/src/utils/urlFormatting.test.ts
@@ -1,0 +1,14 @@
+import { createURL } from './urlFormatting';
+
+describe('createUrl', () => {
+  test('valid url from a path, query params', async () => {
+    const url = createURL('/test', { foo: 'bar' });
+
+    expect(url).toEqual('/test?foo=bar');
+  });
+  test('valid url from a path including params, query params', async () => {
+    const url = createURL('/test?existing-param=1', { foo: 'bar' });
+
+    expect(url).toEqual('/test?existing-param=1&foo=bar');
+  });
+});

--- a/packages/common/src/utils/urlFormatting.ts
+++ b/packages/common/src/utils/urlFormatting.ts
@@ -2,14 +2,13 @@ import type { PlaylistItem } from '../../types/playlist';
 
 import { getLegacySeriesPlaylistIdFromEpisodeTags, getSeriesPlaylistIdFromCustomParams } from './media';
 
-// Creates a new URL from a url string, search string and an object to add and remove query params
-// For example:
-// createURL(window.location.pathname, { foo: 'bar' }, window.location.search);
-export const createURL = (url: string, queryParams: { [key: string]: string | number | string[] | undefined | null }, search: string | null = '') => {
-  const [baseUrl, urlQueryString = ''] = url.split('?');
-  const searchStringCombined = `${urlQueryString}${urlQueryString && search ? `&` : ''}${search}`;
+export type QueryParamsArg = { [key: string]: string | number | string[] | undefined | null };
 
-  const urlSearchParams = new URLSearchParams(searchStringCombined);
+// Creates a new URL from a url string (could include search params) and an object to add and remove query params
+// For example: createURL(window.location.pathname, { foo: 'bar' });
+export const createURL = (url: string, queryParams: QueryParamsArg) => {
+  const [baseUrl, urlQueryString = ''] = url.split('?');
+  const urlSearchParams = new URLSearchParams(urlQueryString);
 
   Object.entries(queryParams).forEach(([key, value]) => {
     if (value === null || value === undefined) {

--- a/packages/ui-react/src/components/Account/Account.tsx
+++ b/packages/ui-react/src/components/Account/Account.tsx
@@ -24,7 +24,7 @@ import Checkbox from '../Checkbox/Checkbox';
 import HelperText from '../HelperText/HelperText';
 import CustomRegisterField from '../CustomRegisterField/CustomRegisterField';
 import Icon from '../Icon/Icon';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './Account.module.scss';
 
@@ -186,10 +186,10 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
     }
     if (isSocialLogin && shouldAddPassword) {
       await accountController.resetPassword(customer.email, '');
-      return navigate(modalURL(location, 'add-password'));
+      return navigate(modalURLFromLocation(location, 'add-password'));
     }
 
-    navigate(modalURL(location, canChangePasswordWithOldPassword ? 'edit-password' : 'reset-password'));
+    navigate(modalURLFromLocation(location, canChangePasswordWithOldPassword ? 'edit-password' : 'reset-password'));
   };
 
   return (
@@ -367,7 +367,7 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
                       type="button"
                       variant="danger"
                       onClick={() => {
-                        navigate(modalURL(location, shouldAddPassword ? 'warning-account-deletion' : 'delete-account'));
+                        navigate(modalURLFromLocation(location, shouldAddPassword ? 'warning-account-deletion' : 'delete-account'));
                       }}
                     />
                   </div>

--- a/packages/ui-react/src/components/ConfirmationForm/ConfirmationForm.tsx
+++ b/packages/ui-react/src/components/ConfirmationForm/ConfirmationForm.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 
 import Button from '../Button/Button';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './ConfirmationForm.module.scss';
 
@@ -25,7 +25,7 @@ const ConfirmationForm: React.FC<Props> = ({ email, onBackToLogin, loggedIn }: P
       {!loggedIn && (
         <React.Fragment>
           <span className={styles.notSure}>{t('reset.not_sure')}</span>
-          <Link className={styles.link} to={modalURL(location, 'forgot-password')}>
+          <Link className={styles.link} to={modalURLFromLocation(location, 'forgot-password')}>
             {t('reset.try_again')}
           </Link>
         </React.Fragment>

--- a/packages/ui-react/src/components/DeleteAccountModal/DeleteAccountModal.tsx
+++ b/packages/ui-react/src/components/DeleteAccountModal/DeleteAccountModal.tsx
@@ -11,7 +11,7 @@ import useForm from '@jwp/ott-hooks-react/src/useForm';
 import PasswordField from '../PasswordField/PasswordField';
 import Button from '../Button/Button';
 import Alert from '../Alert/Alert';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './DeleteAccountModal.module.scss';
 
@@ -49,7 +49,7 @@ const DeleteAccountModal = () => {
     initialValues,
     () => {
       setEnteredPassword(values.password);
-      navigate(modalURL(location, 'delete-account-confirmation'), { replace: true });
+      navigate(modalURLFromLocation(location, 'delete-account-confirmation'), { replace: true });
     },
     validationSchema,
   );
@@ -61,7 +61,7 @@ const DeleteAccountModal = () => {
       resetForm();
     }
     if (location.search.includes('delete-account-confirmation') && !enteredPassword) {
-      navigate(modalURL(location, 'delete-account'), { replace: true });
+      navigate(modalURLFromLocation(location, 'delete-account'), { replace: true });
     }
   }, [location, location.search, navigate, enteredPassword, deleteAccount, resetForm]);
 
@@ -69,11 +69,11 @@ const DeleteAccountModal = () => {
     deleteAccount.reset();
     resetForm();
     setEnteredPassword('');
-    navigate(modalURL(location, 'delete-account'), { replace: true });
+    navigate(modalURLFromLocation(location, 'delete-account'), { replace: true });
   }, [location, navigate, setEnteredPassword, deleteAccount, resetForm]);
 
   const handleCancel = useCallback(() => {
-    navigate(modalURL(location, null), { replace: true });
+    navigate(modalURLFromLocation(location, null), { replace: true });
   }, [location, navigate]);
 
   if (deleteAccount.isError) {

--- a/packages/ui-react/src/components/DeleteAccountPasswordWarning/DeleteAccountPasswordWarning.tsx
+++ b/packages/ui-react/src/components/DeleteAccountPasswordWarning/DeleteAccountPasswordWarning.tsx
@@ -7,7 +7,7 @@ import AccountController from '@jwp/ott-common/src/stores/AccountController';
 
 import Button from '../Button/Button';
 import FormFeedback from '../FormFeedback/FormFeedback';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './DeleteAccountPasswordWarning.module.scss';
 
@@ -21,13 +21,13 @@ const DeleteAccountPasswordWarning = () => {
   const location = useLocation();
 
   const handleCancel = useCallback(() => {
-    navigate(modalURL(location, null), { replace: true });
+    navigate(modalURLFromLocation(location, null), { replace: true });
   }, [location, navigate]);
   const proceedToAddPasswordClickHandler = async () => {
     try {
       if (email) {
         await accountController.resetPassword(email, '');
-        navigate(modalURL(location, 'add-password'));
+        navigate(modalURLFromLocation(location, 'add-password'));
       }
     } catch (error: unknown) {
       setErrorMessage(t('account.add_password_error'));

--- a/packages/ui-react/src/components/FinalizePayment/FinalizePayment.tsx
+++ b/packages/ui-react/src/components/FinalizePayment/FinalizePayment.tsx
@@ -11,7 +11,7 @@ import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 
 import Button from '../Button/Button';
 import Spinner from '../Spinner/Spinner';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './FinalizePayment.module.scss';
 
@@ -31,7 +31,7 @@ const FinalizePayment = () => {
   const [errorMessage, setErrorMessage] = useState<string>();
 
   const paymentSuccessUrl = useMemo(() => {
-    return modalURL(location, accessModel === ACCESS_MODEL.SVOD ? 'welcome' : null);
+    return modalURLFromLocation(location, accessModel === ACCESS_MODEL.SVOD ? 'welcome' : null);
   }, [accessModel, location]);
 
   const checkPaymentResult = useEventCallback(async (redirectResult: string) => {
@@ -65,7 +65,7 @@ const FinalizePayment = () => {
             variant="contained"
             color="primary"
             size="large"
-            onClick={() => navigate(modalURL(location, 'checkout'))}
+            onClick={() => navigate(modalURLFromLocation(location, 'checkout'))}
             fullWidth
           />
         </>

--- a/packages/ui-react/src/components/LoginForm/LoginForm.tsx
+++ b/packages/ui-react/src/components/LoginForm/LoginForm.tsx
@@ -17,7 +17,7 @@ import FormFeedback from '../FormFeedback/FormFeedback';
 import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import SocialButtonsList from '../SocialButtonsList/SocialButtonsList';
 import Icon from '../Icon/Icon';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './LoginForm.module.scss';
 
@@ -86,12 +86,12 @@ const LoginForm: React.FC<Props> = ({ onSubmit, onChange, values, errors, submit
         testId="login-password-input"
       />
       {submitting && <LoadingOverlay transparentBackground inline />}
-      <Link className={styles.link} to={modalURL(location, 'forgot-password')}>
+      <Link className={styles.link} to={modalURLFromLocation(location, 'forgot-password')}>
         {t('login.forgot_password')}
       </Link>
       <Button type="submit" label={t('login.sign_in')} variant="contained" color="primary" size="large" disabled={submitting} fullWidth />
       <p className={styles.bottom}>
-        {t('login.not_registered', { siteName })} <Link to={modalURL(location, 'create-account')}>{t('login.sign_up')}</Link>
+        {t('login.not_registered', { siteName })} <Link to={modalURLFromLocation(location, 'create-account')}>{t('login.sign_up')}</Link>
       </p>
     </form>
   );

--- a/packages/ui-react/src/components/Payment/Payment.tsx
+++ b/packages/ui-react/src/components/Payment/Payment.tsx
@@ -18,7 +18,7 @@ import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import OfferSwitch from '../OfferSwitch/OfferSwitch';
 import TextField from '../TextField/TextField';
 import Icon from '../Icon/Icon';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './Payment.module.scss';
 
@@ -115,18 +115,18 @@ const Payment = ({
   }, [selectedOfferId, offers, activeSubscription, setIsUpgradeOffer]);
 
   function onCompleteSubscriptionClick() {
-    navigate(modalURL(location, 'choose-offer'));
+    navigate(modalURLFromLocation(location, 'choose-offer'));
   }
   function onEditCardDetailsClick() {
-    navigate(modalURL(location, 'edit-card'));
+    navigate(modalURLFromLocation(location, 'edit-card'));
   }
 
   function onCancelSubscriptionClick() {
-    navigate(modalURL(location, 'unsubscribe'));
+    navigate(modalURLFromLocation(location, 'unsubscribe'));
   }
 
   function onRenewSubscriptionClick() {
-    navigate(modalURL(location, 'renew-subscription'));
+    navigate(modalURLFromLocation(location, 'renew-subscription'));
   }
 
   function getTitle(period: Subscription['period']) {
@@ -303,7 +303,7 @@ const Payment = ({
           </div>
         )}
         {canUpdatePaymentMethod && (
-          <Button label={t('user:payment.update_payment_details')} type="button" onClick={() => navigate(modalURL(location, 'payment-method'))} />
+          <Button label={t('user:payment.update_payment_details')} type="button" onClick={() => navigate(modalURLFromLocation(location, 'payment-method'))} />
         )}
       </div>
       <div className={panelClassName}>

--- a/packages/ui-react/src/components/PaymentForm/PaymentForm.tsx
+++ b/packages/ui-react/src/components/PaymentForm/PaymentForm.tsx
@@ -14,7 +14,7 @@ import CreditCardCVCField from '../CreditCardCVCField/CreditCardCVCField';
 import CreditCardExpiryField from '../CreditCardExpiryField/CreditCardExpiryField';
 import CreditCardNumberField from '../CreditCardNumberField/CreditCardNumberField';
 import TextField from '../TextField/TextField';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './PaymentForm.module.scss';
 
@@ -43,7 +43,7 @@ const PaymentForm: React.FC<Props> = ({ couponCode, setUpdatingOrder }) => {
 
       intervalCheckAccess({
         interval: 15000,
-        callback: (hasAccess) => hasAccess && navigate(modalURL(location, 'welcome')),
+        callback: (hasAccess) => hasAccess && navigate(modalURLFromLocation(location, 'welcome')),
       });
     },
     object().shape({

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -18,7 +18,7 @@ import FormFeedback from '../FormFeedback/FormFeedback';
 import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import Link from '../Link/Link';
 import Icon from '../Icon/Icon';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 import styles from './RegistrationForm.module.scss';
 
@@ -152,7 +152,7 @@ const RegistrationForm: React.FC<Props> = ({
         fullWidth
       />
       <p className={styles.bottom}>
-        {t('registration.already_account')} <Link to={modalURL(location, 'login')}>{t('login.sign_in')}</Link>
+        {t('registration.already_account')} <Link to={modalURLFromLocation(location, 'login')}>{t('login.sign_in')}</Link>
       </p>
       {submitting && <LoadingOverlay transparentBackground inline />}
     </form>

--- a/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
+++ b/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import useCheckAccess from '@jwp/ott-hooks-react/src/useCheckAccess';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import Spinner from '../Spinner/Spinner';
 
@@ -18,7 +18,7 @@ const WaitingForPayment = () => {
     intervalCheckAccess({
       interval: 3000,
       iterations: 5,
-      callback: (hasAccess) => hasAccess && navigate(modalURL(location, 'welcome')),
+      callback: (hasAccess) => hasAccess && navigate(modalURLFromLocation(location, 'welcome')),
     });
     //eslint-disable-next-line
   }, []);

--- a/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
+++ b/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
@@ -3,8 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
-import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
+import { modalURLFromLocation, createURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 import useQueryParam from '@jwp/ott-ui-react/src/hooks/useQueryParam';
 
@@ -79,7 +78,7 @@ const AccountModal = () => {
   const isPublicView = viewParam && PUBLIC_VIEWS.includes(viewParam);
 
   const toLogin = useEventCallback(() => {
-    navigate(modalURL(location, 'login'));
+    navigate(modalURLFromLocation(location, 'login'));
   });
 
   useEffect(() => {
@@ -94,7 +93,7 @@ const AccountModal = () => {
   }, [viewParam, loading, isPublicView, user, toLogin]);
 
   const closeHandler = useEventCallback(() => {
-    navigate(createURL(location.pathname, { u: null, message: null }, location.search));
+    navigate(createURLFromLocation(location, { u: null, message: null }));
   });
 
   const renderForm = () => {

--- a/packages/ui-react/src/containers/AccountModal/forms/CancelSubscription.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/CancelSubscription.tsx
@@ -5,7 +5,7 @@ import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { formatLocalizedDate } from '@jwp/ott-common/src/utils/formatting';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import CancelSubscriptionForm from '../../../components/CancelSubscriptionForm/CancelSubscriptionForm';
 import LoadingOverlay from '../../../components/LoadingOverlay/LoadingOverlay';
@@ -37,7 +37,7 @@ const CancelSubscription = () => {
   };
 
   const closeHandler = () => {
-    navigate(modalURL(location, null), { replace: true });
+    navigate(modalURLFromLocation(location, null), { replace: true });
   };
 
   if (!subscription) return null;

--- a/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
@@ -7,7 +7,7 @@ import { useCheckoutStore } from '@jwp/ott-common/src/stores/CheckoutStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import CheckoutController from '@jwp/ott-common/src/stores/CheckoutController';
 import { isSVODOffer } from '@jwp/ott-common/src/utils/subscription';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import useForm from '@jwp/ott-hooks-react/src/useForm';
 import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
 
@@ -44,7 +44,7 @@ const Checkout = () => {
   const offerType = offer && !isSVODOffer(offer) ? 'tvod' : 'svod';
 
   const paymentSuccessUrl = useMemo(() => {
-    return modalURL(location, offerType === 'svod' ? 'welcome' : null);
+    return modalURLFromLocation(location, offerType === 'svod' ? 'welcome' : null);
   }, [location, offerType]);
 
   const couponCodeForm = useForm({ couponCode: '' }, async (values, { setSubmitting, setErrors }) => {
@@ -58,7 +58,7 @@ const Checkout = () => {
       } catch (error: unknown) {
         if (error instanceof Error) {
           if (error.message.includes(`Order with id ${order.id} not found`)) {
-            navigate(modalURL(location, 'choose-offer'), { replace: true });
+            navigate(modalURLFromLocation(location, 'choose-offer'), { replace: true });
           } else {
             setErrors({ couponCode: t('checkout.coupon_not_valid') });
           }
@@ -82,7 +82,7 @@ const Checkout = () => {
       } catch (error: unknown) {
         if (error instanceof Error) {
           if (error.message.includes(`Order with id ${order.id} not found`)) {
-            navigate(modalURL(location, 'choose-offer'), { replace: true });
+            navigate(modalURLFromLocation(location, 'choose-offer'), { replace: true });
           } else {
             couponCodeForm.setErrors({ couponCode: t('checkout.coupon_not_valid') });
           }
@@ -110,7 +110,7 @@ const Checkout = () => {
     }
 
     if (!offer) {
-      return navigate(modalURL(location, 'choose-offer'), { replace: true });
+      return navigate(modalURLFromLocation(location, 'choose-offer'), { replace: true });
     }
 
     // noinspection JSIgnoredPromiseFromCall
@@ -123,7 +123,7 @@ const Checkout = () => {
   }, [setOrder]);
 
   const backButtonClickHandler = () => {
-    navigate(modalURL(location, 'choose-offer'));
+    navigate(modalURLFromLocation(location, 'choose-offer'));
   };
 
   const handlePaymentMethodChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -139,7 +139,7 @@ const Checkout = () => {
         .updateOrder(order, toPaymentMethodId, couponCodeForm.values.couponCode)
         .catch((error: Error) => {
           if (error.message.includes(`Order with id ${order.id}} not found`)) {
-            navigate(modalURL(location, 'choose-offer'));
+            navigate(modalURLFromLocation(location, 'choose-offer'));
           }
         })
         .finally(() => setUpdatingOrder(false));

--- a/packages/ui-react/src/containers/AccountModal/forms/ChooseOffer.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/ChooseOffer.tsx
@@ -10,7 +10,7 @@ import { useCheckoutStore } from '@jwp/ott-common/src/stores/CheckoutStore';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import CheckoutController from '@jwp/ott-common/src/stores/CheckoutController';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { logDev } from '@jwp/ott-common/src/utils/common';
 import useOffers from '@jwp/ott-hooks-react/src/useOffers';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
@@ -57,7 +57,7 @@ const ChooseOffer = () => {
   };
 
   const updateAccountModal = useEventCallback((modal: keyof AccountModals) => {
-    navigate(modalURL(location, modal));
+    navigate(modalURLFromLocation(location, modal));
   });
 
   const chooseOfferSubmitHandler: UseFormOnSubmitHandler<ChooseOfferFormData> = useCallback(

--- a/packages/ui-react/src/containers/AccountModal/forms/EditCardDetails.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/EditCardDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import EditCardDetailsForm from '../../../components/EditForm/EditCardDetailsForm';
 import EditCardPaymentForm from '../../../components/EditCardPaymentForm/EditCardPaymentForm';
@@ -11,7 +11,7 @@ const EditCardDetails = () => {
   const [updatingCardDetails, setUpdatingCardDetails] = useState(false);
 
   const closeHandler = () => {
-    navigate(modalURL(location, null), { replace: false });
+    navigate(modalURLFromLocation(location, null), { replace: false });
   };
 
   const renderPaymentMethod = () => {

--- a/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
@@ -7,7 +7,7 @@ import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import useQueryParam from '@jwp/ott-ui-react/src/hooks/useQueryParam';
 
 import EditPasswordForm from '../../../components/EditPasswordForm/EditPasswordForm';
@@ -46,7 +46,7 @@ const ResetPassword = ({ type }: { type?: 'add' }) => {
         await accountController.changePasswordWithToken(emailParam || '', password, resetToken, passwordConfirmation);
       }
       await accountController.logout({ includeNetworkRequest: false });
-      navigate(modalURL(location, 'login'));
+      navigate(modalURLFromLocation(location, 'login'));
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.message.includes('invalid param password')) {

--- a/packages/ui-react/src/containers/AccountModal/forms/Login.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Login.tsx
@@ -8,7 +8,7 @@ import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import LoginForm from '../../../components/LoginForm/LoginForm';
 
@@ -32,7 +32,7 @@ const Login: React.FC<Props> = ({ messageKey }: Props) => {
       await queryClient.invalidateQueries(['listProfiles']);
 
       // close modal
-      navigate(modalURL(location, null));
+      navigate(modalURLFromLocation(location, null));
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.message.toLowerCase().includes('invalid param email')) {

--- a/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
@@ -7,7 +7,7 @@ import type { CaptureCustomAnswer, CleengCaptureQuestionField, PersonalDetailsFo
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
 import useOffers from '@jwp/ott-hooks-react/src/useOffers';
@@ -40,7 +40,7 @@ const PersonalDetails = () => {
   const nextStep = useCallback(() => {
     const hasOffers = accessModel === ACCESS_MODEL.SVOD || (accessModel === ACCESS_MODEL.AUTHVOD && hasTVODOffers);
 
-    navigate(modalURL(location, hasOffers ? 'choose-offer' : 'welcome'), { replace: true });
+    navigate(modalURLFromLocation(location, hasOffers ? 'choose-offer' : 'welcome'), { replace: true });
   }, [navigate, location, accessModel, hasTVODOffers]);
 
   useEffect(() => {

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -9,7 +9,7 @@ import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { checkConsentsFromValues, extractConsentValues } from '@jwp/ott-common/src/utils/collection';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import RegistrationForm from '../../../components/RegistrationForm/RegistrationForm';
 
@@ -63,7 +63,7 @@ const Registration = () => {
       await accountController.register(email, password, window.location.href, customerConsents);
       await queryClient.invalidateQueries(['listProfiles']);
 
-      navigate(modalURL(location, 'personal-details'));
+      navigate(modalURLFromLocation(location, 'personal-details'));
     } catch (error: unknown) {
       if (error instanceof Error) {
         const errorMessage = error.message.toLowerCase();

--- a/packages/ui-react/src/containers/AccountModal/forms/RenewSubscription.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/RenewSubscription.tsx
@@ -5,7 +5,7 @@ import { shallow } from '@jwp/ott-common/src/utils/compare';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import LoadingOverlay from '../../../components/LoadingOverlay/LoadingOverlay';
 import RenewSubscriptionForm from '../../../components/RenewSubscriptionForm/RenewSubscriptionForm';
@@ -37,7 +37,7 @@ const RenewSubscription = () => {
   };
 
   const closeHandler = () => {
-    navigate(modalURL(location, null), { replace: true });
+    navigate(modalURLFromLocation(location, null), { replace: true });
   };
 
   if (!subscription || !user) return null;

--- a/packages/ui-react/src/containers/AccountModal/forms/ResetPassword.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/ResetPassword.tsx
@@ -7,7 +7,7 @@ import type { ForgotPasswordFormData } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { logDev } from '@jwp/ott-common/src/utils/common';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
 
@@ -36,7 +36,7 @@ const ResetPassword: React.FC<Prop> = ({ type }: Prop) => {
     shallow,
   );
   const cancelClickHandler = () => {
-    navigate(modalURL(location, null));
+    navigate(modalURLFromLocation(location, null));
   };
 
   const backToLoginClickHandler = async () => {
@@ -66,7 +66,7 @@ const ResetPassword: React.FC<Prop> = ({ type }: Prop) => {
       await accountController.resetPassword(user.email, resetUrl);
 
       setResetPasswordSubmitting(false);
-      navigate(modalURL(location, 'send-confirmation'));
+      navigate(modalURLFromLocation(location, 'send-confirmation'));
     } catch (error: unknown) {
       logDev(error instanceof Error ? error.message : error);
     }
@@ -78,7 +78,7 @@ const ResetPassword: React.FC<Prop> = ({ type }: Prop) => {
     try {
       await accountController.resetPassword(formData.email, resetUrl);
       const modal = canChangePasswordWithOldPassword ? 'edit-password' : 'send-confirmation';
-      navigate(modalURL(location, modal));
+      navigate(modalURLFromLocation(location, modal));
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.message.toLowerCase().includes('invalid param email')) {

--- a/packages/ui-react/src/containers/AdyenPaymentDetails/AdyenPaymentDetails.tsx
+++ b/packages/ui-react/src/containers/AdyenPaymentDetails/AdyenPaymentDetails.tsx
@@ -6,7 +6,7 @@ import type { AdyenPaymentSession } from '@jwp/ott-common/types/checkout';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import CheckoutController from '@jwp/ott-common/src/stores/CheckoutController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { ADYEN_LIVE_CLIENT_KEY, ADYEN_TEST_CLIENT_KEY } from '@jwp/ott-common/src/constants';
 import useQueryParam from '@jwp/ott-ui-react/src/hooks/useQueryParam';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
@@ -33,7 +33,7 @@ export default function AdyenPaymentDetails({ setProcessing, type, setPaymentErr
 
   const redirectResult = useQueryParam('redirectResult');
   const finalize = !!redirectResult;
-  const paymentSuccessUrl = modalURL(location, 'payment-method-success');
+  const paymentSuccessUrl = modalURLFromLocation(location, 'payment-method-success');
 
   const finalizePaymentDetails = useEventCallback(async (redirectResult: string) => {
     try {
@@ -43,13 +43,13 @@ export default function AdyenPaymentDetails({ setProcessing, type, setPaymentErr
       await accountController.reloadActiveSubscription({ delay: 2000 });
 
       setProcessing(false);
-      navigate(modalURL(location, 'payment-method-success'));
+      navigate(modalURLFromLocation(location, 'payment-method-success'));
     } catch (error: unknown) {
       setProcessing(false);
 
       if (error instanceof Error) {
         setPaymentError(error.message);
-        navigate(modalURL(location, 'payment-method'), { replace: true });
+        navigate(modalURLFromLocation(location, 'payment-method'), { replace: true });
       }
     }
   });

--- a/packages/ui-react/src/containers/InlinePlayer/InlinePlayer.tsx
+++ b/packages/ui-react/src/containers/InlinePlayer/InlinePlayer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import Lock from '@jwp/ott-theme/assets/icons/lock.svg?react';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import Image from '../../components/Image/Image';
 import Fade from '../../components/Animation/Fade/Fade';
@@ -53,7 +53,7 @@ const InlinePlayer: React.FC<Props> = ({
   const location = useLocation();
 
   const loginButtonClickHandler = () => {
-    navigate(modalURL(location, 'login'));
+    navigate(modalURLFromLocation(location, 'login'));
   };
 
   return (

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -10,7 +10,7 @@ import { useUIStore } from '@jwp/ott-common/src/stores/UIStore';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { useProfileStore } from '@jwp/ott-common/src/stores/ProfileStore';
 import ProfileController from '@jwp/ott-common/src/stores/ProfileController';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { IS_DEVELOPMENT_BUILD } from '@jwp/ott-common/src/utils/common';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useSearchQueryUpdater from '@jwp/ott-ui-react/src/hooks/useSearchQueryUpdater';
@@ -103,11 +103,11 @@ const Layout = () => {
   };
 
   const loginButtonClickHandler = () => {
-    navigate(modalURL(location, 'login'));
+    navigate(modalURLFromLocation(location, 'login'));
   };
 
   const signUpButtonClickHandler = () => {
-    navigate(modalURL(location, 'create-account'));
+    navigate(modalURLFromLocation(location, 'create-account'));
   };
 
   const languageClickHandler = async (code: string) => {

--- a/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
+++ b/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
@@ -12,7 +12,7 @@ import { useSubscriptionChange } from '@jwp/ott-hooks-react/src/useSubscriptionC
 import styles from '../../pages/User/User.module.scss';
 import LoadingOverlay from '../../components/LoadingOverlay/LoadingOverlay';
 import Payment from '../../components/Payment/Payment';
-import { modalURL } from '../../utils/location';
+import { modalURLFromLocation } from '../../utils/location';
 
 /**
  * Handles billing receipts by either downloading the receipt directly if it is an instance of Blob,
@@ -69,7 +69,7 @@ const PaymentContainer = () => {
   const location = useLocation();
 
   const handleUpgradeSubscriptionClick = async () => {
-    navigate(modalURL(location, 'upgrade-subscription'));
+    navigate(modalURLFromLocation(location, 'upgrade-subscription'));
   };
 
   const handleShowReceiptClick = async (transactionId: string) => {

--- a/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
@@ -3,11 +3,11 @@ import { Navigate, useLocation, useNavigate, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import useQueryParam from '@jwp/ott-ui-react/src/hooks/useQueryParam';
 import { useDeleteProfile } from '@jwp/ott-hooks-react/src/useProfiles';
-import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
 
 import Button from '../../components/Button/Button';
 import Dialog from '../../components/Dialog/Dialog';
 import LoadingOverlay from '../../components/LoadingOverlay/LoadingOverlay';
+import { createURLFromLocation } from '../../utils/location';
 
 import styles from './Profiles.module.scss';
 
@@ -23,7 +23,7 @@ const DeleteProfile = () => {
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   const closeHandler = () => {
-    navigate(createURL(location.pathname, { action: null }, location.search));
+    navigate(createURLFromLocation(location, { action: null }));
   };
 
   const deleteProfile = useDeleteProfile({

--- a/packages/ui-react/src/containers/Profiles/EditProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/EditProfile.tsx
@@ -9,11 +9,11 @@ import type { UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
 import { useProfileErrorHandler, useUpdateProfile } from '@jwp/ott-hooks-react/src/useProfiles';
 import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 import type { ProfileFormValues } from '@jwp/ott-common/types/profiles';
-import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
 
 import styles from '../../pages/User/User.module.scss';
 import LoadingOverlay from '../../components/LoadingOverlay/LoadingOverlay';
 import Button from '../../components/Button/Button';
+import { createURLFromLocation } from '../../utils/location';
 
 import DeleteProfile from './DeleteProfile';
 import Form from './Form';
@@ -103,7 +103,7 @@ const EditProfile = ({ contained = false }: EditProfileProps) => {
           <div className={profileStyles.profileInfo}>{t(profileDetails?.default ? 'profile.delete_main' : 'profile.delete_description')}</div>
           {!profileDetails?.default && (
             <Button
-              onClick={() => navigate(createURL(location.pathname, { action: 'delete-profile' }, location.search))}
+              onClick={() => navigate(createURLFromLocation(location, { action: 'delete-profile' }))}
               label={t('profile.delete')}
               variant="contained"
               color="delete"

--- a/packages/ui-react/src/containers/StartWatchingButton/StartWatchingButton.tsx
+++ b/packages/ui-react/src/containers/StartWatchingButton/StartWatchingButton.tsx
@@ -5,7 +5,7 @@ import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import { useCheckoutStore } from '@jwp/ott-common/src/stores/CheckoutStore';
 import { useWatchHistoryStore } from '@jwp/ott-common/src/stores/WatchHistoryStore';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 import useEntitlement from '@jwp/ott-hooks-react/src/useEntitlement';
 import Play from '@jwp/ott-theme/assets/icons/play.svg?react';
@@ -57,8 +57,8 @@ const StartWatchingButton: React.VFC<Props> = ({ item, playUrl, disabled = false
       }
       return playUrl && navigate(playUrl);
     }
-    if (!isLoggedIn) return navigate(modalURL(location, 'create-account'));
-    if (hasMediaOffers) return navigate(modalURL(location, 'choose-offer'));
+    if (!isLoggedIn) return navigate(modalURLFromLocation(location, 'create-account'));
+    if (hasMediaOffers) return navigate(modalURLFromLocation(location, 'choose-offer'));
 
     return navigate('/u/payments');
   }, [isEntitled, playUrl, navigate, isLoggedIn, location, hasMediaOffers, onClick]);

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -12,7 +12,7 @@ import { generateEpisodeJSONLD } from '@jwp/ott-common/src/utils/structuredData'
 import { isLocked } from '@jwp/ott-common/src/utils/entitlements';
 import { getEpisodesInSeason, getFiltersFromSeries } from '@jwp/ott-common/src/utils/series';
 import { formatSeriesMetaString, formatVideoMetaString } from '@jwp/ott-common/src/utils/formatting';
-import { buildLegacySeriesUrlFromMediaItem, createURL, mediaURL } from '@jwp/ott-common/src/utils/urlFormatting';
+import { buildLegacySeriesUrlFromMediaItem, mediaURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import { VideoProgressMinMax } from '@jwp/ott-common/src/constants';
 import useEntitlement from '@jwp/ott-hooks-react/src/useEntitlement';
 import useMedia from '@jwp/ott-hooks-react/src/useMedia';
@@ -35,6 +35,7 @@ import FavoriteButton from '../../../../containers/FavoriteButton/FavoriteButton
 import Button from '../../../../components/Button/Button';
 import Loading from '../../../Loading/Loading';
 import Icon from '../../../../components/Icon/Icon';
+import { createURLFromLocation } from '../../../../utils/location';
 
 const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   const breakpoint = useBreakpoint();
@@ -111,7 +112,7 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
 
   const location = useLocation();
   const getURL = (toEpisode: PlaylistItem) => {
-    return createURL(location.pathname, { e: toEpisode.mediaid }, location.search);
+    return createURLFromLocation(location, { e: toEpisode.mediaid });
   };
 
   // Handlers

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -134,6 +134,7 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
     <ShareButton title={channelMediaItem.title} description={channelMediaItem.description} url={window.location.href} />
   ) : null;
 
+  // @todo
   const startWatchingButton = channelMediaItem ? (
     <>
       <StartWatchingButton

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -134,7 +134,7 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
     <ShareButton title={channelMediaItem.title} description={channelMediaItem.description} url={window.location.href} />
   ) : null;
 
-  // @todo
+  // @todo: bring all props to liveChannelsURL, so that createURL isn't needed
   const startWatchingButton = channelMediaItem ? (
     <>
       <StartWatchingButton

--- a/packages/ui-react/src/utils/location.test.ts
+++ b/packages/ui-react/src/utils/location.test.ts
@@ -1,0 +1,118 @@
+import type { Location } from 'react-router-dom';
+
+import { createURLFromLocation, modalURLFromLocation } from './location';
+
+describe('url from location', () => {
+  test('valid url from a location', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = createURLFromLocation(location);
+
+    expect(url).toEqual('/test');
+  });
+  test('valid url from a location with search query', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = createURLFromLocation(location);
+
+    expect(url).toEqual('/test?test-param=1');
+  });
+  test('valid url from a location with query params', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = createURLFromLocation(location, { foo: 'bar' });
+
+    expect(url).toEqual('/test?test-param=1&foo=bar');
+  });
+  test('valid url from a location with search query and query params', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = createURLFromLocation(location, { foo: 'bar' });
+
+    expect(url).toEqual('/test?test-param=1&foo=bar');
+  });
+  test('valid url from a location with search query and a query param that clears the saarch param', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = createURLFromLocation(location, { 'test-param': null });
+
+    expect(url).toEqual('/test');
+  });
+});
+
+describe('modal urls from location', () => {
+  test('valid modal url from a location', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = modalURLFromLocation(location, 'login');
+
+    expect(url).toEqual('/test?u=login');
+  });
+  test('valid modal url from a location with search query', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = modalURLFromLocation(location, 'login');
+
+    expect(url).toEqual('/test?test-param=1&u=login');
+  });
+  test('valid modal url from a location with query params', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = modalURLFromLocation(location, 'login', { foo: 'bar' });
+
+    expect(url).toEqual('/test?u=login&foo=bar');
+  });
+
+  test('valid modal url from a location with a search query and query params', async () => {
+    const location: Location = {
+      pathname: '/test',
+      search: '?test-param=1',
+      hash: '',
+      state: null,
+      key: '',
+    };
+    const url = modalURLFromLocation(location, 'login', { foo: 'bar' });
+
+    expect(url).toEqual('/test?test-param=1&u=login&foo=bar');
+  });
+});

--- a/packages/ui-react/src/utils/location.ts
+++ b/packages/ui-react/src/utils/location.ts
@@ -1,8 +1,12 @@
-import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
+import { createURL, type QueryParamsArg } from '@jwp/ott-common/src/utils/urlFormatting';
 import type { Location } from 'react-router-dom';
 
 import type { AccountModals } from '../containers/AccountModal/AccountModal';
 
-export const modalURL = (location: Location, u: keyof AccountModals | null, queryParams?: { [key: string]: string | number | string[] | undefined | null }) => {
-  return createURL(location.pathname, { u, ...queryParams }, location.search);
+export const createURLFromLocation = (location: Location, queryParams: QueryParamsArg = {}) => {
+  return createURL(`${location.pathname}${location.search || ''}`, queryParams);
+};
+
+export const modalURLFromLocation = (location: Location, u: keyof AccountModals | null, queryParams?: QueryParamsArg) => {
+  return createURL(`${location.pathname}${location.search || ''}`, { u, ...queryParams });
 };

--- a/platforms/web/src/hooks/useNotifications.ts
+++ b/platforms/web/src/hooks/useNotifications.ts
@@ -4,7 +4,7 @@ import { getModule } from '@jwp/ott-common/src/modules/container';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { queryClient } from '@jwp/ott-common/src/queryClient';
 import { simultaneousLoginWarningKey } from '@jwp/ott-common/src/constants';
-import { modalURL } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 enum NotificationsTypes {
   ACCESS_REVOKED = 'access.revoked',
@@ -38,11 +38,11 @@ export default function useNotifications(uuid: string = '') {
             case NotificationsTypes.FAILED:
             case NotificationsTypes.CARD_FAILED:
             case NotificationsTypes.SUBSCRIBE_FAILED:
-              navigate(modalURL(location, 'payment-error', { message: notification.resource?.message }));
+              navigate(modalURLFromLocation(location, 'payment-error', { message: notification.resource?.message }));
               break;
             case NotificationsTypes.CARD_SUCCESS:
               await queryClient.invalidateQueries(['entitlements']);
-              navigate(modalURL(location, null));
+              navigate(modalURLFromLocation(location, null));
               break;
             case NotificationsTypes.SUBSCRIBE_SUCCESS:
               await accountController.reloadActiveSubscription();
@@ -56,7 +56,7 @@ export default function useNotifications(uuid: string = '') {
               break;
             case NotificationsTypes.ACCOUNT_LOGOUT:
               if (notification.resource?.reason === 'sessions_limit') {
-                navigate(modalURL(location, 'login', { message: simultaneousLoginWarningKey }));
+                navigate(modalURLFromLocation(location, 'login', { message: simultaneousLoginWarningKey }));
               } else {
                 await accountController.logout();
               }


### PR DESCRIPTION
## Better URL formatting
I had refactored url formatting, but we still found that the `createURL` utility was having too many roles mixed up. Then I had the idea to simply split the location based url creation, because these are the only occasions where we need to take out the search string and put it back in (which made it weird, being mixed up with query params). It makes a lot of sense to me to leave that part to the `location` util in `ui-react` and let `urlFomatting` util in `common` do the actual parsing using URLSearchParams.

I also added unit tests, to make sure all cases work well.