### PR TITLE
Fix / load subscription after restoring SVOD session

### DIFF
--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -88,14 +88,14 @@ export default class AccountController {
 
     await this.profileController?.loadPersistedProfile();
     await this.accountService.initialize(config, url, this.logout);
+
+    // set the accessModel before restoring the user session
+    useConfigStore.setState({ accessModel: this.accountService.accessModel });
+
     await this.loadUserData();
 
     useAccountStore.setState({ loading: false });
   };
-
-  getAccessModel() {
-    return this.accountService.accessModel || 'AVOD';
-  }
 
   getSandbox() {
     return this.accountService.sandbox;

--- a/packages/common/src/stores/AppController.ts
+++ b/packages/common/src/stores/AppController.ts
@@ -88,11 +88,7 @@ export default class AppController {
 
     // when an integration is set, we initialize the AccountController
     if (integrationType) {
-      const accountController = getModule(AccountController);
-
-      await accountController.initialize(url);
-
-      useConfigStore.setState({ accessModel: accountController.getAccessModel() });
+      await getModule(AccountController).initialize(url);
     }
 
     return { config, settings, configSource };


### PR DESCRIPTION
## Description

The web app didn't load the active subscriptions when the session was restored (refreshing the page). This was caused by the `accessModel` not being set on time, which muted the `reloadActiveSubscriptions` call.

This fix ensures the `accessModel` is set before the `loadUserData` call.

Fixes OTT-546