### PR TITLE
rFix: Endless spinner on iPhone when going to Payments page

### DIFF
--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -472,7 +472,6 @@ export default class AccountController {
     useAccountStore.setState({
       subscription: activeSubscription,
       pendingOffer,
-      loading: false,
       transactions,
       activePayment,
     });
@@ -532,10 +531,12 @@ export default class AccountController {
       customerConsents,
     });
 
-    return await Promise.allSettled([
+    await Promise.allSettled([
       accessModel === ACCESS_MODEL.SVOD && shouldSubscriptionReload ? this.reloadActiveSubscription() : Promise.resolve(),
       this.getPublisherConsents(),
     ]);
+
+    useAccountStore.setState({ loading: false });
   }
 
   private validateInputLength = (values: { firstName: string; lastName: string }) => {


### PR DESCRIPTION
#### Description:
This PR enhances our `accountController` by streamlining the loading state management. Presently, the loading state update happens only in the `reloadActiveSubscription` method post-login. To improve consistency and user experience, I suggest resetting the loading state to false with a `.finally` block after `Promise.allSettled` in the `afterLogin` method.

   **Code Snippet**:
   ```typescript
 /*  packages/common/src/stores/AccountController.ts  */

  private async afterLogin(/* params */) {
   ... // existing Promise.allSettled logic
   .finally(() => {
     useAccountStore.setState({ loading: false });
   });
   ```
