### PR TITLE
Feat / Keyboard accessible LayoutGrid

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -60,7 +60,7 @@ export const CACHE_TIME = 60 * 1000 * 20; // 20 minutes
 
 export const STALE_TIME = 60 * 1000 * 20;
 
-export const CARD_ASPECT_RATIOS = ['2:1', '16:9', '5:3', '4:3', '1:1', '9:13', '2:3', '9:16'] as const;
+export const CARD_ASPECT_RATIOS = ['1:1', '2:1', '2:3', '4:3', '5:3', '16:9', '9:13', '9:16'] as const;
 
 export const DEFAULT_FEATURES = {
   canUpdateEmail: false,

--- a/packages/common/src/utils/common.ts
+++ b/packages/common/src/utils/common.ts
@@ -5,6 +5,30 @@ export function debounce<T extends (...args: any[]) => void>(callback: T, wait =
     timeout = setTimeout(() => callback(...args), wait);
   };
 }
+export function throttle<T extends (...args: any[]) => unknown>(func: T, limit: number): (...args: Parameters<T>) => void {
+  let lastFunc: NodeJS.Timeout | undefined;
+  let lastRan: number | undefined;
+
+  return function (this: ThisParameterType<T>, ...args: Parameters<T>): void {
+    const timeSinceLastRan = lastRan ? Date.now() - lastRan : limit;
+
+    if (timeSinceLastRan >= limit) {
+      func.apply(this, args);
+      lastRan = Date.now();
+    } else if (!lastFunc) {
+      lastFunc = setTimeout(() => {
+        if (lastRan) {
+          const timeSinceLastRan = Date.now() - lastRan;
+          if (timeSinceLastRan >= limit) {
+            func.apply(this, args);
+            lastRan = Date.now();
+          }
+        }
+        lastFunc = undefined;
+      }, limit - timeSinceLastRan);
+    }
+  };
+}
 
 /**
  * Parse hex color and return the RGB colors

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -9,17 +9,21 @@ import { MediaStatus } from '@jwp/ott-common/src/utils/liveEvent';
 import Lock from '@jwp/ott-theme/assets/icons/lock.svg?react';
 import Today from '@jwp/ott-theme/assets/icons/today.svg?react';
 import { testId } from '@jwp/ott-common/src/utils/common';
+import type { PosterAspectRatio } from '@jwp/ott-common/src/utils/collection';
 
 import Image from '../Image/Image';
 import Icon from '../Icon/Icon';
 
 import styles from './Card.module.scss';
 
+type ReplaceColon<T> = T extends `${infer Left}:${infer Right}` ? `${Left}${Right}` : T;
+type PosterAspectRatioClass = ReplaceColon<PosterAspectRatio>;
+
 type CardProps = {
   item: PlaylistItem;
   onHover?: () => void;
   progress?: number;
-  posterAspect?: string;
+  posterAspect?: PosterAspectRatio;
   featured?: boolean;
   disabled?: boolean;
   loading?: boolean;
@@ -29,7 +33,6 @@ type CardProps = {
   url: string;
   headingLevel?: number;
   tabIndex?: number;
-  focused?: boolean;
 };
 
 function Card({
@@ -46,7 +49,6 @@ function Card({
   headingLevel = 3,
   url,
   tabIndex = 0,
-  focused,
 }: CardProps): JSX.Element {
   const { title, duration, episodeNumber, seasonNumber, cardImage: image, mediaStatus, scheduledStart } = item;
   const {
@@ -60,7 +62,8 @@ function Card({
     [styles.featured]: featured,
     [styles.disabled]: disabled,
   });
-  const posterClassNames = classNames(styles.poster, styles[`aspect${posterAspect.replace(':', '')}`], {
+  const aspectRatioClass = styles[`aspect${posterAspect.replace(':', '') as PosterAspectRatioClass}`];
+  const posterClassNames = classNames(styles.poster, aspectRatioClass, {
     [styles.current]: isCurrent,
   });
   const posterImageClassNames = classNames(styles.posterImage, {
@@ -75,7 +78,7 @@ function Card({
     if (loading || disabled || !title) return null;
 
     if (isSeriesItem) {
-      return <div className={styles.tag}>Series</div>;
+      return <div className={styles.tag}>{t('video:series')}</div>;
     } else if (episodeNumber) {
       return <div className={styles.tag}>{formatSeriesMetaString(seasonNumber, episodeNumber)}</div>;
     } else if (duration) {
@@ -92,17 +95,8 @@ function Card({
     }
   };
 
-  const ref = useRef<HTMLAnchorElement>();
-
-  useEffect(() => {
-    if (focused) {
-      ref.current?.focus();
-    }
-  }, [focused]);
-
   return (
     <Link
-      ref={ref}
       role="button"
       to={url}
       className={cardClassName}

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -62,7 +62,7 @@ function Card({
     [styles.featured]: featured,
     [styles.disabled]: disabled,
   });
-  const aspectRatioClass = styles[`aspect${posterAspect.replace(':', '') as PosterAspectRatioClass}`];
+  const aspectRatioClass = posterAspect ? styles[`aspect${posterAspect.replace(':', '') as PosterAspectRatioClass}`] : undefined;
   const posterClassNames = classNames(styles.poster, aspectRatioClass, {
     [styles.current]: isCurrent,
   });
@@ -107,7 +107,7 @@ function Card({
     >
       {!featured && !disabled && (
         <div className={styles.titleContainer}>
-          {React.createElement(`h${headingLevel}`, { className: `${styles.title} ${loading && styles.loading}` }, title)}
+          {React.createElement(`h${headingLevel}`, { className: classNames(styles.title, { [styles.loading]: loading }) }, title)}
           {!!scheduledStart && (
             <div className={classNames(styles.scheduledStart, { [styles.loading]: loading })}>{formatLocalizedDateTime(scheduledStart, language)}</div>
           )}

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -28,6 +28,8 @@ type CardProps = {
   currentLabel?: string;
   url: string;
   headingLevel?: number;
+  tabIndex?: number;
+  focused?: boolean;
 };
 
 function Card({
@@ -43,6 +45,8 @@ function Card({
   currentLabel,
   headingLevel = 3,
   url,
+  tabIndex = 0,
+  focused,
 }: CardProps): JSX.Element {
   const { title, duration, episodeNumber, seasonNumber, cardImage: image, mediaStatus, scheduledStart } = item;
   const {
@@ -88,14 +92,23 @@ function Card({
     }
   };
 
+  const ref = useRef<HTMLAnchorElement>();
+
+  useEffect(() => {
+    if (focused) {
+      ref.current?.focus();
+    }
+  }, [focused]);
+
   return (
     <Link
+      ref={ref}
       role="button"
       to={url}
       className={cardClassName}
       onClick={disabled ? (e) => e.preventDefault() : undefined}
       onMouseEnter={onHover}
-      tabIndex={disabled ? -1 : 0}
+      tabIndex={disabled ? -1 : tabIndex}
       data-testid={testId(title)}
     >
       {!featured && !disabled && (

--- a/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<Card> > should render anchor tag 1`] = `
       class="_titleContainer_d75732"
     >
       <h3
-        class="_title_d75732 false"
+        class="_title_d75732"
       >
         This is a movie
       </h3>

--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -64,7 +64,7 @@ function CardGrid({
   const visibleTiles: VisibleTiles = (cols[breakpoint] + parseTilesDelta(posterAspect)) as VisibleTiles;
   const [rowCount, setRowCount] = useState(INITIAL_ROW_COUNT);
 
-  const defaultLoadMore = () => setTimeout(() => setRowCount((current) => current + LOAD_ROWS_COUNT), 4000);
+  const defaultLoadMore = () => setRowCount((current) => current + LOAD_ROWS_COUNT);
   const defaultHasMore = rowCount * visibleTiles < playlist.playlist.length;
 
   useEffect(() => {

--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -61,7 +61,7 @@ function CardGrid({
 }: CardGridProps) {
   const breakpoint: Breakpoint = useBreakpoint();
   const posterAspect = parseAspectRatio(playlist.cardImageAspectRatio || playlist.shelfImageAspectRatio);
-  const visibleTiles: VisibleTiles = (cols[breakpoint] + parseTilesDelta(posterAspect)) as VisibleTiles;
+  const visibleTiles = (cols[breakpoint] + parseTilesDelta(posterAspect)) as VisibleTiles;
   const [rowCount, setRowCount] = useState(INITIAL_ROW_COUNT);
 
   const defaultLoadMore = () => setRowCount((current) => current + LOAD_ROWS_COUNT);

--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -9,6 +9,7 @@ import useBreakpoint, { Breakpoint, type Breakpoints } from '@jwp/ott-ui-react/s
 
 import Card from '../Card/Card';
 import InfiniteScrollLoader from '../InfiniteScrollLoader/InfiniteScrollLoader';
+import LayoutGrid from '../LayoutGrid/LayoutGrid';
 
 import styles from './CardGrid.module.scss';
 
@@ -69,36 +70,35 @@ function CardGrid({
     setRowCount(INITIAL_ROW_COUNT);
   }, [playlist.feedid]);
 
-  const renderTile = (playlistItem: PlaylistItem) => {
+  const renderTile = (playlistItem: PlaylistItem, tabIndex: number, focused: boolean) => {
     const { mediaid } = playlistItem;
 
     return (
-      <div className={styles.cell} key={mediaid} role="row">
-        <div role="cell">
-          <Card
-            progress={watchHistory ? watchHistory[mediaid] : undefined}
-            url={getUrl(playlistItem)}
-            onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
-            loading={isLoading}
-            isCurrent={currentCardItem && currentCardItem.mediaid === mediaid}
-            currentLabel={currentCardLabel}
-            isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
-            posterAspect={posterAspect}
-            item={playlistItem}
-            headingLevel={headingLevel}
-          />
-        </div>
-      </div>
+      <Card
+        focused={focused}
+        tabIndex={tabIndex}
+        progress={watchHistory ? watchHistory[mediaid] : undefined}
+        url={getUrl(playlistItem)}
+        onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
+        loading={isLoading}
+        isCurrent={currentCardItem && currentCardItem.mediaid === mediaid}
+        currentLabel={currentCardLabel}
+        isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
+        posterAspect={posterAspect}
+        item={playlistItem}
+        headingLevel={headingLevel}
+      />
     );
   };
 
   return (
     <InfiniteScroll pageStart={0} loadMore={loadMore ?? defaultLoadMore} hasMore={hasMore ?? defaultHasMore} loader={<InfiniteScrollLoader key="loader" />}>
-      <div className={classNames(styles.container, styles[`cols-${visibleTiles}`])} role="grid">
-        {/* When loadMore is present -> we get accumulated data (playlist.playlist) from the outside (we do it for series)
-            When not -> we hide some cards visually to save some computing resources spent on rendering */}
-        {(loadMore ? playlist.playlist : playlist.playlist.slice(0, rowCount * visibleTiles)).map(renderTile)}
-      </div>
+      <LayoutGrid
+        className={classNames(styles.container, styles[`cols-${visibleTiles}`])}
+        data={loadMore ? playlist.playlist : playlist.playlist.slice(0, rowCount * visibleTiles)}
+        columnCount={visibleTiles}
+        renderCell={renderTile}
+      />
     </InfiniteScroll>
   );
 }

--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -16,6 +16,8 @@ import styles from './CardGrid.module.scss';
 const INITIAL_ROW_COUNT = 6;
 const LOAD_ROWS_COUNT = 4;
 
+type VisibleTiles = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
 const defaultCols: Breakpoints = {
   [Breakpoint.xs]: 2,
   [Breakpoint.sm]: 2,
@@ -59,10 +61,10 @@ function CardGrid({
 }: CardGridProps) {
   const breakpoint: Breakpoint = useBreakpoint();
   const posterAspect = parseAspectRatio(playlist.cardImageAspectRatio || playlist.shelfImageAspectRatio);
-  const visibleTiles = cols[breakpoint] + parseTilesDelta(posterAspect);
+  const visibleTiles: VisibleTiles = (cols[breakpoint] + parseTilesDelta(posterAspect)) as VisibleTiles;
   const [rowCount, setRowCount] = useState(INITIAL_ROW_COUNT);
 
-  const defaultLoadMore = () => setRowCount((current) => current + LOAD_ROWS_COUNT);
+  const defaultLoadMore = () => setTimeout(() => setRowCount((current) => current + LOAD_ROWS_COUNT), 4000);
   const defaultHasMore = rowCount * visibleTiles < playlist.playlist.length;
 
   useEffect(() => {
@@ -70,34 +72,27 @@ function CardGrid({
     setRowCount(INITIAL_ROW_COUNT);
   }, [playlist.feedid]);
 
-  const renderTile = (playlistItem: PlaylistItem, tabIndex: number, focused: boolean) => {
-    const { mediaid } = playlistItem;
-
-    return (
-      <Card
-        focused={focused}
-        tabIndex={tabIndex}
-        progress={watchHistory ? watchHistory[mediaid] : undefined}
-        url={getUrl(playlistItem)}
-        onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
-        loading={isLoading}
-        isCurrent={currentCardItem && currentCardItem.mediaid === mediaid}
-        currentLabel={currentCardLabel}
-        isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
-        posterAspect={posterAspect}
-        item={playlistItem}
-        headingLevel={headingLevel}
-      />
-    );
-  };
-
   return (
     <InfiniteScroll pageStart={0} loadMore={loadMore ?? defaultLoadMore} hasMore={hasMore ?? defaultHasMore} loader={<InfiniteScrollLoader key="loader" />}>
       <LayoutGrid
         className={classNames(styles.container, styles[`cols-${visibleTiles}`])}
         data={loadMore ? playlist.playlist : playlist.playlist.slice(0, rowCount * visibleTiles)}
         columnCount={visibleTiles}
-        renderCell={renderTile}
+        renderCell={(playlistItem: PlaylistItem, tabIndex: number) => (
+          <Card
+            tabIndex={tabIndex}
+            progress={watchHistory ? watchHistory[playlistItem.mediaid] : undefined}
+            url={getUrl(playlistItem)}
+            onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
+            loading={isLoading}
+            isCurrent={currentCardItem && currentCardItem.mediaid === playlistItem.mediaid}
+            currentLabel={currentCardLabel}
+            isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
+            posterAspect={posterAspect}
+            item={playlistItem}
+            headingLevel={headingLevel}
+          />
+        )}
       />
     </InfiniteScroll>
   );

--- a/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
+++ b/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
@@ -4,15 +4,21 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
 <div>
   <div>
     <div
+      aria-rowcount="1"
       class="_container_7175d1 _cols-5_7175d1"
       role="grid"
     >
       <div
-        class="_cell_7175d1"
+        aria-rowindex="0"
+        class="_row_19b484"
         role="row"
       >
         <div
-          role="cell"
+          aria-colindex="0"
+          class="_cell_19b484"
+          id="layout_grid_0-0"
+          role="gridcell"
+          style="width: 20%;"
         >
           <a
             class="_card_d75732"
@@ -25,7 +31,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
               class="_titleContainer_d75732"
             >
               <h3
-                class="_title_d75732 false"
+                class="_title_d75732"
               >
                 Agent 327
               </h3>
@@ -49,26 +55,25 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
             </div>
           </a>
         </div>
-      </div>
-      <div
-        class="_cell_7175d1"
-        role="row"
-      >
         <div
-          role="cell"
+          aria-colindex="1"
+          class="_cell_19b484"
+          id="layout_grid_0-1"
+          role="gridcell"
+          style="width: 20%;"
         >
           <a
             class="_card_d75732"
             data-testid="Big Buck Bunny"
             href="/m/awWEFyPu"
             role="button"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="_titleContainer_d75732"
             >
               <h3
-                class="_title_d75732 false"
+                class="_title_d75732"
               >
                 Big Buck Bunny
               </h3>
@@ -92,26 +97,25 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
             </div>
           </a>
         </div>
-      </div>
-      <div
-        class="_cell_7175d1"
-        role="row"
-      >
         <div
-          role="cell"
+          aria-colindex="2"
+          class="_cell_19b484"
+          id="layout_grid_0-2"
+          role="gridcell"
+          style="width: 20%;"
         >
           <a
             class="_card_d75732"
             data-testid="Elephants Dream"
             href="/m/eFPH2tVG"
             role="button"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="_titleContainer_d75732"
             >
               <h3
-                class="_title_d75732 false"
+                class="_title_d75732"
               >
                 Elephants Dream
               </h3>

--- a/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
+++ b/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
               data-testid="SVOD 002: Caminandes 1 llama drama"
               href="/m/1TJAvj2S/svod-002-caminandes-1-llama-drama?r=bdH6HTUi"
               role="button"
-              tabindex="-1"
+              tabindex="0"
             >
               <div
                 class="_titleContainer_d75732"

--- a/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
+++ b/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   SVOD 002: Caminandes 1 llama drama
                 </h3>
@@ -94,7 +94,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   SVOD 003: Caminandes 2 gran dillama
                 </h3>
@@ -141,7 +141,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   SVOD 001: Tears of Steel
                 </h3>

--- a/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
+++ b/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
@@ -20,22 +20,28 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
     </div>
     <div>
       <div
+        aria-rowcount="1"
         class="_container_7175d1 _cols-3_7175d1"
         role="grid"
       >
         <div
-          class="_cell_7175d1"
+          aria-rowindex="0"
+          class="_row_19b484"
           role="row"
         >
           <div
-            role="cell"
+            aria-colindex="0"
+            class="_cell_19b484"
+            id="layout_grid_0-0"
+            role="gridcell"
+            style="width: 33%;"
           >
             <a
               class="_card_d75732"
               data-testid="SVOD 002: Caminandes 1 llama drama"
               href="/m/1TJAvj2S/svod-002-caminandes-1-llama-drama?r=bdH6HTUi"
               role="button"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="_titleContainer_d75732"
@@ -70,20 +76,19 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
               </div>
             </a>
           </div>
-        </div>
-        <div
-          class="_cell_7175d1"
-          role="row"
-        >
           <div
-            role="cell"
+            aria-colindex="1"
+            class="_cell_19b484"
+            id="layout_grid_0-1"
+            role="gridcell"
+            style="width: 33%;"
           >
             <a
               class="_card_d75732"
               data-testid="SVOD 003: Caminandes 2 gran dillama"
               href="/m/rnibIt0n/svod-003-caminandes-2-gran-dillama?r=bdH6HTUi"
               role="button"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="_titleContainer_d75732"
@@ -118,20 +123,19 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
               </div>
             </a>
           </div>
-        </div>
-        <div
-          class="_cell_7175d1"
-          role="row"
-        >
           <div
-            role="cell"
+            aria-colindex="2"
+            class="_cell_19b484"
+            id="layout_grid_0-2"
+            role="gridcell"
+            style="width: 33%;"
           >
             <a
               class="_card_d75732"
               data-testid="SVOD 001: Tears of Steel"
               href="/m/MaCvdQdE/svod-001-tears-of-steel?r=E2uaFiUM"
               role="button"
-              tabindex="0"
+              tabindex="-1"
             >
               <div
                 class="_titleContainer_d75732"

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.module.scss
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.module.scss
@@ -1,0 +1,8 @@
+.row {
+  display: flex;  
+}
+
+.cell {
+  display: inline-block;
+  padding: 4px;
+}

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -1,52 +1,125 @@
 // Keyboard-accessible grid layout, with focus management
 
-import { useEffect, useState } from 'react';
+import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import styles from './LayoutGrid.module.scss';
 
-type Props = {
+type Props<Item> = {
   className?: string;
   columnCount: number;
-  data: any[];
-  renderCell: (item: any, tabIndex: number, focused: boolean) => JSX.Element;
+  data: Item[];
+  renderCell: (item: Item, tabIndex: number) => JSX.Element;
 };
 
-const LayoutGrid = ({ className, columnCount, data, renderCell }: Props) => {
+const LayoutGrid = <Item extends object>({ className, columnCount, data, renderCell }: Props<Item>) => {
   const [focused, setFocused] = useState(false);
   const [currentRowIndex, setCurrentRowIndex] = useState(0);
   const [currentColumnIndex, setCurrentColumnIndex] = useState(0);
 
   const rowCount = Math.ceil(data.length / columnCount);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'ArrowUp') {
-        setCurrentRowIndex((current) => Math.max(current - 1, 0));
-      } else if (event.key === 'ArrowDown') {
-        setCurrentRowIndex((current) => Math.min(current + 1, rowCount - 1));
-      } else if (event.key === 'ArrowLeft') {
-        setCurrentColumnIndex((current) => Math.max(current - 1, 0));
-      } else if (event.key === 'ArrowRight') {
-        setCurrentColumnIndex((current) => Math.min(current + 1, columnCount - 1));
-      }
-    };
+  const handleKeyDown = useEventCallback(({ key, ctrlKey }: KeyboardEvent) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'].includes(key)) return;
 
-    document.addEventListener('keydown', handleKeyDown);
+    const isOnMostLeft = currentColumnIndex === 0;
+    const isOnMostRight = currentColumnIndex === columnCount - 1;
+    const isOnMostTop = currentRowIndex === 0;
+    const isOnMostBottom = currentRowIndex === rowCount - 1;
+    const maxRightBottom = (data.length % columnCount) - 1; // Never go beyond last item
+    const maxRight = isOnMostBottom ? maxRightBottom : columnCount - 1;
+
+    switch (key) {
+      case 'ArrowLeft':
+        if (isOnMostLeft && !isOnMostTop) {
+          // Move to last of previous row
+          setCurrentColumnIndex(columnCount - 1);
+          setCurrentRowIndex((current) => Math.max(current - 1, 0));
+
+          return;
+        }
+        return setCurrentColumnIndex((current) => Math.max(current - 1, 0));
+      case 'ArrowRight':
+        if (isOnMostRight && !isOnMostBottom) {
+          // Move to first of next row
+          setCurrentColumnIndex(0);
+          setCurrentRowIndex((current) => Math.min(current + 1, rowCount - 1));
+
+          return;
+        }
+        return setCurrentColumnIndex((current) => Math.min(current + 1, maxRight));
+      case 'ArrowUp':
+        return setCurrentRowIndex((current) => Math.max(current - 1, 0));
+      case 'ArrowDown':
+        return setCurrentRowIndex((current) => Math.min(current + 1, rowCount - 1));
+      case 'Home':
+        if (ctrlKey) {
+          setCurrentRowIndex(0);
+        }
+        return setCurrentColumnIndex(0);
+      case 'End':
+        if (ctrlKey) {
+          setCurrentRowIndex(maxRight);
+          setCurrentColumnIndex(maxRightBottom);
+
+          return;
+        }
+        return setCurrentColumnIndex(rowCount - 1);
+      case 'PageUp':
+        return setCurrentRowIndex((current) => Math.max(current - 1, 0));
+      case 'PageDown':
+        return setCurrentRowIndex((current) => Math.min(current + 1, rowCount - 1));
+      default:
+        return;
+    }
+  });
+
+  useEffect(() => {
+    if (focused) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
 
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [columnCount, rowCount]);
+  }, [focused, handleKeyDown, columnCount, rowCount]);
+
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Focus the button (or other focusable element) in the currently focused grid cell
+  useLayoutEffect(() => {
+    const gridCell = document.getElementById(`layout_grid_${currentRowIndex}-${currentColumnIndex}`) as HTMLDivElement | null;
+    const focusableElement = gridCell?.querySelector('button, a, input, [tabindex]:not([tabindex="-1"])') as HTMLElement | null;
+    const elementToFocus = focusableElement || gridCell;
+
+    elementToFocus?.focus();
+  }, [currentRowIndex, currentColumnIndex]);
+
+  useEffect(() => {
+    // When the window size changes, correct indexes if necessary
+    const maxRightBottom = (data.length % columnCount) - 1;
+
+    if (currentColumnIndex > columnCount - 1) {
+      setCurrentColumnIndex(columnCount - 1);
+    }
+    if (currentRowIndex === rowCount - 1 && currentColumnIndex > maxRightBottom) {
+      setCurrentColumnIndex(maxRightBottom);
+    }
+  }, [currentColumnIndex, currentRowIndex, columnCount, rowCount, data.length]);
 
   return (
-    <div role="grid" aria-rowcount={rowCount} className={className} onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
+    <div role="grid" ref={gridRef} aria-rowcount={rowCount} className={className} onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
       {Array.from({ length: rowCount }).map((_, rowIndex) => (
         <div role="row" key={rowIndex} aria-rowindex={rowIndex} className={styles.row}>
           {data.slice(rowIndex * columnCount, rowIndex * columnCount + columnCount).map((item, columnIndex) => (
-            <div role="gridcell" key={columnIndex} aria-colindex={columnIndex} className={styles.cell} style={{ width: `${Math.round(100 / rowCount)}%` }}>
-              {renderCell(
-                item,
-                currentRowIndex === rowIndex && currentColumnIndex === columnIndex ? 0 : -1,
-                focused && currentRowIndex === rowIndex && currentColumnIndex === columnIndex,
-              )}
+            <div
+              role="gridcell"
+              onFocus={(event) => event.target.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+              id={`layout_grid_${rowIndex}-${columnIndex}`}
+              key={columnIndex}
+              aria-colindex={columnIndex}
+              className={styles.cell}
+              style={{ width: `${Math.round(100 / columnCount)}%` }}
+            >
+              {renderCell(item, currentRowIndex === rowIndex && currentColumnIndex === columnIndex ? 0 : -1)}
             </div>
           ))}
         </div>

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -1,0 +1,58 @@
+// Keyboard-accessible grid layout, with focus management
+
+import { useEffect, useState } from 'react';
+
+import styles from './LayoutGrid.module.scss';
+
+type Props = {
+  className?: string;
+  columnCount: number;
+  data: any[];
+  renderCell: (item: any, tabIndex: number, focused: boolean) => JSX.Element;
+};
+
+const LayoutGrid = ({ className, columnCount, data, renderCell }: Props) => {
+  const [focused, setFocused] = useState(false);
+  const [currentRowIndex, setCurrentRowIndex] = useState(0);
+  const [currentColumnIndex, setCurrentColumnIndex] = useState(0);
+
+  const rowCount = Math.ceil(data.length / columnCount);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowUp') {
+        setCurrentRowIndex((current) => Math.max(current - 1, 0));
+      } else if (event.key === 'ArrowDown') {
+        setCurrentRowIndex((current) => Math.min(current + 1, rowCount - 1));
+      } else if (event.key === 'ArrowLeft') {
+        setCurrentColumnIndex((current) => Math.max(current - 1, 0));
+      } else if (event.key === 'ArrowRight') {
+        setCurrentColumnIndex((current) => Math.min(current + 1, columnCount - 1));
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [columnCount, rowCount]);
+
+  return (
+    <div role="grid" aria-rowcount={rowCount} className={className} onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}>
+      {Array.from({ length: rowCount }).map((_, rowIndex) => (
+        <div role="row" key={rowIndex} aria-rowindex={rowIndex} className={styles.row}>
+          {data.slice(rowIndex * columnCount, rowIndex * columnCount + columnCount).map((item, columnIndex) => (
+            <div role="gridcell" key={columnIndex} aria-colindex={columnIndex} className={styles.cell} style={{ width: `${Math.round(100 / rowCount)}%` }}>
+              {renderCell(
+                item,
+                currentRowIndex === rowIndex && currentColumnIndex === columnIndex ? 0 : -1,
+                focused && currentRowIndex === rowIndex && currentColumnIndex === columnIndex,
+              )}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LayoutGrid;

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -84,7 +84,7 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
 
   const gridRef = useRef<HTMLDivElement>(null);
 
-  // Focus the button (or other focusable element) in the currently focused grid cell
+  // Set DOM focus to a focusable element within the currently focusable grid cell
   useLayoutEffect(() => {
     const gridCell = document.getElementById(`layout_grid_${currentRowIndex}-${currentColumnIndex}`) as HTMLDivElement | null;
     const focusableElement = gridCell?.querySelector('button, a, input, [tabindex]:not([tabindex="-1"])') as HTMLElement | null;
@@ -93,8 +93,8 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
     elementToFocus?.focus();
   }, [currentRowIndex, currentColumnIndex]);
 
+  // When the window size changes, correct indexes if necessary
   useEffect(() => {
-    // When the window size changes, correct indexes if necessary
     const maxRightBottom = (data.length % columnCount) - 1;
 
     if (currentColumnIndex > columnCount - 1) {

--- a/packages/ui-react/src/components/Shelf/Shelf.tsx
+++ b/packages/ui-react/src/components/Shelf/Shelf.tsx
@@ -9,6 +9,7 @@ import { PersonalShelf } from '@jwp/ott-common/src/constants';
 import ChevronLeft from '@jwp/ott-theme/assets/icons/chevron_left.svg?react';
 import ChevronRight from '@jwp/ott-theme/assets/icons/chevron_right.svg?react';
 import useBreakpoint, { Breakpoint, type Breakpoints } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
+import type { PosterAspectRatio } from '@jwp/ott-common/src/utils/collection';
 
 import TileDock from '../TileDock/TileDock';
 import Card from '../Card/Card';
@@ -46,7 +47,7 @@ export type ShelfProps = {
   accessModel: AccessModel;
   isLoggedIn: boolean;
   hasSubscription: boolean;
-  posterAspect?: string;
+  posterAspect?: PosterAspectRatio;
   visibleTilesDelta?: number;
 };
 
@@ -73,6 +74,7 @@ const Shelf = ({
   const renderTile = useCallback(
     (item: PlaylistItem, isInView: boolean) => {
       const url = mediaURL({ media: item, playlistId: playlist.feedid, play: type === PersonalShelf.ContinueWatching });
+
       return (
         <Card
           key={item.mediaid}

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   Movie 1
                 </h3>
@@ -279,7 +279,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   Movie 2
                 </h3>
@@ -318,7 +318,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   Third movie
                 </h3>
@@ -357,7 +357,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                 class="_titleContainer_d75732"
               >
                 <h3
-                  class="_title_d75732 false"
+                  class="_title_d75732"
                 >
                   Last playlist item
                 </h3>

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -13,7 +13,7 @@ import { testId } from '@jwp/ott-common/src/utils/common';
 import { PersonalShelf } from '@jwp/ott-common/src/constants';
 import usePlaylists from '@jwp/ott-hooks-react/src/usePlaylists';
 
-import ShelfComponent from '../../components/Shelf/Shelf';
+import Shelf from '../../components/Shelf/Shelf';
 import InfiniteScrollLoader from '../../components/InfiniteScrollLoader/InfiniteScrollLoader';
 import ErrorPage from '../../components/ErrorPage/ErrorPage';
 
@@ -77,7 +77,7 @@ const ShelfList = ({ rows }: Props) => {
               data-testid={testId(`shelf-${featured ? 'featured' : type === 'playlist' ? slugify(title || playlist?.title) : type}`)}
             >
               <div role="cell">
-                <ShelfComponent
+                <Shelf
                   loading={isLoading}
                   error={error}
                   type={type}

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Home Component tests > Home test 1`] = `
                         class="_titleContainer_d75732"
                       >
                         <h3
-                          class="_title_d75732 false"
+                          class="_title_d75732"
                         >
                           My video
                         </h3>
@@ -91,7 +91,7 @@ exports[`Home Component tests > Home test 1`] = `
                         class="_titleContainer_d75732"
                       >
                         <h3
-                          class="_title_d75732 false"
+                          class="_title_d75732"
                         >
                           Other Vids
                         </h3>
@@ -159,7 +159,7 @@ exports[`Home Component tests > Home test 1`] = `
                         class="_titleContainer_d75732"
                       >
                         <h3
-                          class="_title_d75732 false"
+                          class="_title_d75732"
                         >
                           My video
                         </h3>
@@ -198,7 +198,7 @@ exports[`Home Component tests > Home test 1`] = `
                         class="_titleContainer_d75732"
                       >
                         <h3
-                          class="_title_d75732 false"
+                          class="_title_d75732"
                         >
                           Other Vids
                         </h3>

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -418,7 +418,7 @@ exports[`User Component tests > Favorites Page 1`] = `
                   data-testid="Fav 1"
                   href="/m/aaabbbcc/fav-1?r=abcdffff"
                   role="button"
-                  tabindex="-1"
+                  tabindex="0"
                 >
                   <div
                     class="_titleContainer_d75732"

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -397,28 +397,34 @@ exports[`User Component tests > Favorites Page 1`] = `
         </div>
         <div>
           <div
+            aria-rowcount="1"
             class="_container_7175d1 _cols-3_7175d1"
             role="grid"
           >
             <div
-              class="_cell_7175d1"
+              aria-rowindex="0"
+              class="_row_19b484"
               role="row"
             >
               <div
-                role="cell"
+                aria-colindex="0"
+                class="_cell_19b484"
+                id="layout_grid_0-0"
+                role="gridcell"
+                style="width: 33%;"
               >
                 <a
                   class="_card_d75732"
                   data-testid="Fav 1"
                   href="/m/aaabbbcc/fav-1?r=abcdffff"
                   role="button"
-                  tabindex="0"
+                  tabindex="-1"
                 >
                   <div
                     class="_titleContainer_d75732"
                   >
                     <h3
-                      class="_title_d75732 false"
+                      class="_title_d75732"
                     >
                       Fav 1
                     </h3>
@@ -442,26 +448,25 @@ exports[`User Component tests > Favorites Page 1`] = `
                   </div>
                 </a>
               </div>
-            </div>
-            <div
-              class="_cell_7175d1"
-              role="row"
-            >
               <div
-                role="cell"
+                aria-colindex="1"
+                class="_cell_19b484"
+                id="layout_grid_0-1"
+                role="gridcell"
+                style="width: 33%;"
               >
                 <a
                   class="_card_d75732"
                   data-testid="Big Buck Bunny"
                   href="/m/aaabbbcd/big-buck-bunny?r=bbbdddff"
                   role="button"
-                  tabindex="0"
+                  tabindex="-1"
                 >
                   <div
                     class="_titleContainer_d75732"
                   >
                     <h3
-                      class="_title_d75732 false"
+                      class="_title_d75732"
                     >
                       Big Buck Bunny
                     </h3>
@@ -485,26 +490,25 @@ exports[`User Component tests > Favorites Page 1`] = `
                   </div>
                 </a>
               </div>
-            </div>
-            <div
-              class="_cell_7175d1"
-              role="row"
-            >
               <div
-                role="cell"
+                aria-colindex="2"
+                class="_cell_19b484"
+                id="layout_grid_0-2"
+                role="gridcell"
+                style="width: 33%;"
               >
                 <a
                   class="_card_d75732"
                   data-testid="My last favorite"
                   href="/m/ggaaccvv/my-last-favorite?r=bbbbbbbb"
                   role="button"
-                  tabindex="0"
+                  tabindex="-1"
                 >
                   <div
                     class="_titleContainer_d75732"
                   >
                     <h3
-                      class="_title_d75732 false"
+                      class="_title_d75732"
                     >
                       My last favorite
                     </h3>

--- a/platforms/web/public/locales/en/video.json
+++ b/platforms/web/public/locales/en/video.json
@@ -19,6 +19,7 @@
   "remove_from_favorites": "Remove from favorites",
   "season": "season",
   "season_number_filter_template": "Season {{seasonNumber}}",
+  "series": "Series",
   "series_error": "An error occurred while requesting series",
   "share": "Share",
   "share_video": "Share this video",

--- a/platforms/web/public/locales/es/video.json
+++ b/platforms/web/public/locales/es/video.json
@@ -20,6 +20,7 @@
   "season": "temporada",
   "season_number_filter_template": "Temporada {{seasonNumber}}",
   "series_error": "Se produjo un error al solicitar la serie",
+  "series": "Serie",
   "share": "Compartir",
   "share_video": "Compartir este video",
   "sign_up_to_start_watching": "¡Regístrate para comenzar a ver!",


### PR DESCRIPTION
##  Keyboard accessible LayoutGrid

We've discussed ways to create a keyboard accessible CardGrid. I found [this example](https://www.w3.org/WAI/ARIA/apg/patterns/grid/examples/layout-grids/#:~:text=action%20was%20completed.-,Example%203%3A%20Scrollable%20Search%20Results,-Open%20In%20CodePen) the clearest and perhaps best example and copied its behaviour. 
You can find a description of what all handled keypresses (left, right, up, down, pageUp, pageDown, Home, End, Ctrl+Home, Ctrl+End) do [here](https://www.w3.org/WAI/ARIA/apg/patterns/grid/examples/layout-grids/#:~:text=type%20of%20wrapping.-,Keyboard%20Support,-NOTE%3A%20The): 

### DOM
The DOM looks like this and should be fully accessible:

```html
<div role=“grid” aria-rowcount=“2” aria-labelledby=“grid_title”>
  <div role=“row” aria-rowindex=“0”>
    <div role=“gridcell” aria-colindex=“0”></div>
    <div role=“gridcell” aria-colindex-“1”></div>
  </div>
  <div role=“row” aria-rowindex=“1”>
    <div role=“gridcell” aria-colindex=“0”></div>
    <div role=“gridcell” aria-colindex-“1”></div>
  </div>
</div>
```

### TV
I've added simple keyboard listeners for web. For tv devices, we could extract these listeners for web, and make alternative tv listeners. We could then add props to LayoutGrid such as `onLeft`, `onRight`, `onUp`, etc.

### Performance
I can acknowledge that on focus change, only the previous and next cell (Cards) re-render, so I assume we're not unnecessarily losing performance.

### Still to be improved (anyone?)
I would like to block DOM scrolling while handling the key events, so that we can control the scrolling (otherwise Up, Down, PageUp/PageDown do too much of it). However, if I add `preventDefault()` to the listener, the whole key handling doesn't work and the scrolling still happens. It would be nice if we could fix this. Anyone?



