### PR TITLE
Fix / move code to prevent misleading “wrong combination” error

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@inplayer-org/inplayer.js": "^3.13.24",
-    "@tanstack/query-core": "^4.36.1",
     "broadcast-channel": "^7.0.0",
     "date-fns": "^2.28.0",
     "fast-xml-parser": "^4.3.2",

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -198,8 +198,8 @@ export default class AccountController {
     if (response) {
       await this.afterLogin(response.user, response.customerConsents, accessModel);
 
-      await this.favoritesController?.restoreFavorites();
-      await this.watchHistoryController?.restoreWatchHistory();
+      await this.favoritesController?.restoreFavorites().catch(logDev);
+      await this.watchHistoryController?.restoreWatchHistory().catch(logDev);
     }
 
     useAccountStore.setState({ loading: false });


### PR DESCRIPTION
When you login, a API call to `/apps/watchlists/{playlist_id}` is performed with a double media ID within the `media_ids` query string parameter, causing an error to be thrown.

This only happens for certain users.

By moving fetching the user watch history/favorites code outside the `try...catch` block, we prevent a faulty/incorrect "Incorrect email/password combination" message to be shown.

This fix is not complete but is a intermediate solution. The error still occurs, but it will at least cause a fluent login experience.

Ideally we want the following:
- [x] ~Prevent double media IDs to be added in the watch history~ -> This is not the cause of the error. See PR #95.
- [x] Prevent double media IDs called in the API by undoubling them before -> fixed in PR #95
- [ ] Improve if/else statement because it will show "wrong combination" message on every unknown error. We should make this more specific and fallback to something like a "An unexpected error occurred. Please try again" message when something else happened.

Since this bug is already happening in production, I propose we will fix these 3 issues later. Since I already invested time in to this, I think it is a waste to not improve the current situation, because it's such a small change and has a big impact. So therefore this PR.

Bug: [OTT-560](https://videodock.atlassian.net/browse/OTT-560)
Todo: [OTT-695](https://videodock.atlassian.net/browse/OTT-695)

[OTT-560]: https://videodock.atlassian.net/browse/OTT-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-695]: https://videodock.atlassian.net/browse/OTT-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ