### PR TITLE
Fix / a11y prevent double ids on inputs by requiring a name

### DIFF
--- a/packages/ui-react/src/components/Payment/Payment.tsx
+++ b/packages/ui-react/src/components/Payment/Payment.tsx
@@ -292,13 +292,25 @@ const Payment = ({
             <div key={activePaymentDetail.id}>
               <TextField
                 label={t('user:payment.card_number')}
+                name="cardNumber"
                 value={`•••• •••• •••• ${activePaymentDetail.paymentMethodSpecificParams.lastCardFourDigits || ''}`}
                 aria-label={t('user:payment.card_number_hidden', { number: activePaymentDetail.paymentMethodSpecificParams.lastCardFourDigits })}
                 editing={false}
               />
               <div className={styles.cardDetails}>
-                <TextField label={t('user:payment.expiry_date')} value={activePaymentDetail.paymentMethodSpecificParams.cardExpirationDate} editing={false} />
-                <TextField label={t('user:payment.security_code')} value={'******'} editing={false} aria-label={t('user:payment.security_code_hidden')} />
+                <TextField
+                  label={t('user:payment.expiry_date')}
+                  name="cardExpiry"
+                  value={activePaymentDetail.paymentMethodSpecificParams.cardExpirationDate}
+                  editing={false}
+                />
+                <TextField
+                  label={t('user:payment.security_code')}
+                  name="cardSecurityCode"
+                  value={'******'}
+                  editing={false}
+                  aria-label={t('user:payment.security_code_hidden')}
+                />
               </div>
               <Button label={t('account:payment.edit_card')} variant="outlined" onClick={onEditCardDetailsClick} />
             </div>

--- a/packages/ui-react/src/components/Payment/__snapshots__/Payment.test.tsx.snap
+++ b/packages/ui-react/src/components/Payment/__snapshots__/Payment.test.tsx.snap
@@ -23,14 +23,15 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
       >
         <label
           class="_label_e16c1b"
-          for="text-field_1235"
+          for="text-field_1235_cardnumber"
         >
           user:payment.card_number
         </label>
         <input
           aria-label="user:payment.card_number_hidden"
           class="_input_e16c1b"
-          id="text-field_1235"
+          id="text-field_1235_cardnumber"
+          name="cardNumber"
           readonly=""
           type="text"
           value="•••• •••• •••• 0002"
@@ -44,13 +45,14 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         >
           <label
             class="_label_e16c1b"
-            for="text-field_1235"
+            for="text-field_1235_cardexpiry"
           >
             user:payment.expiry_date
           </label>
           <input
             class="_input_e16c1b"
-            id="text-field_1235"
+            id="text-field_1235_cardexpiry"
+            name="cardExpiry"
             readonly=""
             type="text"
             value="03/2030"
@@ -61,14 +63,15 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         >
           <label
             class="_label_e16c1b"
-            for="text-field_1235"
+            for="text-field_1235_cardsecuritycode"
           >
             user:payment.security_code
           </label>
           <input
             aria-label="user:payment.security_code_hidden"
             class="_input_e16c1b"
-            id="text-field_1235"
+            id="text-field_1235_cardsecuritycode"
+            name="cardSecurityCode"
             readonly=""
             type="text"
             value="******"

--- a/packages/ui-react/src/components/TextField/TextField.test.tsx
+++ b/packages/ui-react/src/components/TextField/TextField.test.tsx
@@ -32,7 +32,7 @@ describe('<TextField>', () => {
 
   test('triggers an onChange event when the input value changes', () => {
     const onChange = vi.fn();
-    const { getByPlaceholderText } = render(<TextField value="" onChange={onChange} placeholder="Enter your name" />);
+    const { getByPlaceholderText } = render(<TextField name="name" value="" onChange={onChange} placeholder="Enter your name" />);
 
     fireEvent.change(getByPlaceholderText('Enter your name'), { target: { value: 'John Doe' } });
 
@@ -40,7 +40,7 @@ describe('<TextField>', () => {
   });
 
   test('shows the helper text below the input', () => {
-    const { queryByText } = render(<TextField value="" onChange={vi.fn()} helperText="Assertive text" />);
+    const { queryByText } = render(<TextField name="name" value="" onChange={vi.fn()} helperText="Assertive text" />);
 
     expect(queryByText('Assertive text')).toBeDefined();
   });

--- a/packages/ui-react/src/components/TextField/TextField.tsx
+++ b/packages/ui-react/src/components/TextField/TextField.tsx
@@ -16,6 +16,7 @@ type InputOrTextAreaProps =
   | ({ multiline: true; inputRef?: never; textAreaRef?: RefObject<HTMLTextAreaElement> } & TextAreaProps);
 
 type Props = {
+  name: string;
   className?: string;
   label?: ReactNode;
   helperText?: React.ReactNode;

--- a/packages/ui-react/src/components/TextField/TextField.tsx
+++ b/packages/ui-react/src/components/TextField/TextField.tsx
@@ -8,8 +8,8 @@ import HelperText from '../HelperText/HelperText';
 
 import styles from './TextField.module.scss';
 
-type InputProps = Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, 'id' | 'ref' | 'className'>;
-type TextAreaProps = Omit<React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>, 'id' | 'ref' | 'className'>;
+type InputProps = Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, 'id' | 'ref' | 'className' | 'name'>;
+type TextAreaProps = Omit<React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>, 'id' | 'ref' | 'className' | 'name'>;
 
 type InputOrTextAreaProps =
   | ({ multiline?: never; inputRef?: RefObject<HTMLInputElement>; textAreaRef?: never } & InputProps)
@@ -29,6 +29,7 @@ type Props = {
 } & InputOrTextAreaProps;
 
 const TextField: React.FC<Props> = ({
+  name,
   className,
   label,
   error,
@@ -42,7 +43,7 @@ const TextField: React.FC<Props> = ({
   multiline,
   ...inputProps
 }: Props) => {
-  const id = useOpaqueId('text-field', inputProps.name);
+  const id = useOpaqueId('text-field', name);
   const { t } = useTranslation('common');
 
   const isInputOrTextArea = (item: unknown): item is InputOrTextAreaProps => !!item && typeof item === 'object';
@@ -61,9 +62,9 @@ const TextField: React.FC<Props> = ({
 
   const renderInput = () => {
     return isTextArea(inputProps) ? (
-      <textarea id={id} className={styles.input} rows={3} readOnly={!editing} ref={textAreaRef} {...inputProps} />
+      <textarea id={id} className={styles.input} rows={3} readOnly={!editing} ref={textAreaRef} name={name} {...inputProps} />
     ) : (
-      <input id={id} className={styles.input} type={'text'} readOnly={!editing} ref={inputRef} {...inputProps} />
+      <input id={id} className={styles.input} type={'text'} readOnly={!editing} ref={inputRef} name={name} {...inputProps} />
     );
   };
 

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -696,14 +696,15 @@ exports[`User Component tests > Payments Page 1`] = `
           >
             <label
               class="_label_e16c1b"
-              for="text-field_1235"
+              for="text-field_1235_cardnumber"
             >
               user:payment.card_number
             </label>
             <input
               aria-label="user:payment.card_number_hidden"
               class="_input_e16c1b"
-              id="text-field_1235"
+              id="text-field_1235_cardnumber"
+              name="cardNumber"
               readonly=""
               type="text"
               value="•••• •••• •••• 9888"
@@ -717,13 +718,14 @@ exports[`User Component tests > Payments Page 1`] = `
             >
               <label
                 class="_label_e16c1b"
-                for="text-field_1235"
+                for="text-field_1235_cardexpiry"
               >
                 user:payment.expiry_date
               </label>
               <input
                 class="_input_e16c1b"
-                id="text-field_1235"
+                id="text-field_1235_cardexpiry"
+                name="cardExpiry"
                 readonly=""
                 type="text"
                 value="03/30"
@@ -734,14 +736,15 @@ exports[`User Component tests > Payments Page 1`] = `
             >
               <label
                 class="_label_e16c1b"
-                for="text-field_1235"
+                for="text-field_1235_cardsecuritycode"
               >
                 user:payment.security_code
               </label>
               <input
                 aria-label="user:payment.security_code_hidden"
                 class="_input_e16c1b"
-                id="text-field_1235"
+                id="text-field_1235_cardsecuritycode"
+                name="cardSecurityCode"
                 readonly=""
                 type="text"
                 value="******"


### PR DESCRIPTION
Two e2e tests  failed because all the read-only`<input>`s on the page had the same ID. Causing Playwright to fail.

Happened because of this call:
```js
cardInfo.forEach(([label, value]) => I.seeInField(label, value));
```
Applying a name fixed this, but I  also marked the `name` property required, to prevent this issue from happening in the future. Double IDs can also lead to issues with clicking on a `<label>` which is linked to the wrong `<input>`.

Caused by: PR #38

I accidentally created a PR in the original repo: https://github.com/jwplayer/ott-web-app/pull/441