### PR TITLE
Feat / Footer via env-var

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,8 +160,7 @@ Use the `styling` object to define extra styles for your application.
   "styling": {
     "backgroundColor": null,
     "highlightColor": null,
-    "headerBackground": null,
-    "footerText": "Blender Foundation"
+    "headerBackground": null
 }
 ```
 
@@ -184,12 +183,6 @@ Specify the color in hexadecimal format. For example, if you want bright yellow,
 **styling.headerBackground** (optional)
 
 Use this parameter to change the background color of the header. By default, the header is transparent. Recommended is to use a HEX color (e.g. `#1a1a1a`) so that the contrast color of the buttons and links can be calculated.
-
----
-
-**styling.footerText** (optional)
-
-Text that will be placed in the footer of the site. Markdown links are supported.
 
 ---
 

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -2,7 +2,7 @@ export type Env = {
   APP_VERSION: string;
   APP_API_BASE_URL: string;
   APP_PLAYER_ID: string;
-
+  APP_FOOTER_TEXT: string;
   APP_DEFAULT_CONFIG_SOURCE?: string;
   APP_PLAYER_LICENSE_KEY?: string;
 };
@@ -11,12 +11,14 @@ const env: Env = {
   APP_VERSION: '',
   APP_API_BASE_URL: 'https://cdn.jwplayer.com',
   APP_PLAYER_ID: 'M4qoGvUk',
+  APP_FOOTER_TEXT: '',
 };
 
 export const configureEnv = (options: Partial<Env>) => {
   env.APP_VERSION = options.APP_VERSION || env.APP_VERSION;
   env.APP_API_BASE_URL = options.APP_API_BASE_URL || env.APP_API_BASE_URL;
   env.APP_PLAYER_ID = options.APP_PLAYER_ID || env.APP_PLAYER_ID;
+  env.APP_FOOTER_TEXT = options.APP_FOOTER_TEXT || env.APP_FOOTER_TEXT;
 
   env.APP_DEFAULT_CONFIG_SOURCE ||= options.APP_DEFAULT_CONFIG_SOURCE;
   env.APP_PLAYER_LICENSE_KEY ||= options.APP_PLAYER_LICENSE_KEY;

--- a/packages/common/src/services/ConfigService.ts
+++ b/packages/common/src/services/ConfigService.ts
@@ -28,9 +28,7 @@ export default class ConfigService {
     content: [],
     menu: [],
     integrations: {},
-    styling: {
-      footerText: '',
-    },
+    styling: {},
     features: {},
   };
 

--- a/packages/common/src/stores/ConfigStore.ts
+++ b/packages/common/src/stores/ConfigStore.ts
@@ -34,9 +34,7 @@ export const useConfigStore = createStore<ConfigState>('ConfigStore', () => ({
         useSandbox: true,
       },
     },
-    styling: {
-      footerText: '',
-    },
+    styling: {},
   },
   settings: {
     additionalAllowedConfigSources: [],

--- a/packages/common/src/utils/common.ts
+++ b/packages/common/src/utils/common.ts
@@ -6,6 +6,12 @@ export function debounce<T extends (...args: any[]) => void>(callback: T, wait =
   };
 }
 
+export const unicodeToChar = (text: string) => {
+  return text.replace(/\\u[\dA-F]{4}/gi, (match) => {
+    return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
+  });
+};
+
 /**
  * Parse hex color and return the RGB colors
  * @param color

--- a/packages/common/src/utils/configSchema.ts
+++ b/packages/common/src/utils/configSchema.ts
@@ -41,7 +41,6 @@ const stylingSchema: SchemaOf<Styling> = object({
   backgroundColor: string().nullable(),
   highlightColor: string().nullable(),
   headerBackground: string().nullable(),
-  footerText: string().nullable(),
 });
 
 export const configSchema: SchemaOf<Config> = object({

--- a/packages/common/types/config.ts
+++ b/packages/common/types/config.ts
@@ -59,7 +59,6 @@ export type Styling = {
   backgroundColor?: string | null;
   highlightColor?: string | null;
   headerBackground?: string | null;
-  footerText?: string | null;
 };
 
 export type Cleeng = {

--- a/packages/testing/fixtures/config.json
+++ b/packages/testing/fixtures/config.json
@@ -55,8 +55,7 @@
   "styling": {
     "backgroundColor": null,
     "highlightColor": null,
-    "headerBackground": null,
-    "footerText": "\u00a9 Blender Foundation | [cloud.blender.org](https://cloud.blender.org)"
+    "headerBackground": null
   },
   "description": "Blender demo site",
   "analyticsToken": "lDd_MCg4EeuMunbqcIJccw",

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -11,12 +11,13 @@ import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { useProfileStore } from '@jwp/ott-common/src/stores/ProfileStore';
 import ProfileController from '@jwp/ott-common/src/stores/ProfileController';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
-import { IS_DEVELOPMENT_BUILD } from '@jwp/ott-common/src/utils/common';
+import { IS_DEVELOPMENT_BUILD, unicodeToChar } from '@jwp/ott-common/src/utils/common';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useSearchQueryUpdater from '@jwp/ott-ui-react/src/hooks/useSearchQueryUpdater';
 import { useProfiles, useSelectProfile } from '@jwp/ott-hooks-react/src/useProfiles';
 import { PATH_HOME, PATH_USER_PROFILES } from '@jwp/ott-common/src/paths';
 import { playlistURL } from '@jwp/ott-common/src/utils/urlFormatting';
+import env from '@jwp/ott-common/src/env';
 
 import MarkdownComponent from '../../components/MarkdownComponent/MarkdownComponent';
 import Header from '../../components/Header/Header';
@@ -38,13 +39,13 @@ const Layout = () => {
   );
   const isLoggedIn = !!useAccountStore(({ user }) => user);
   const favoritesEnabled = !!config.features?.favoritesList;
-  const { menu, assets, siteName, description, styling, features } = config;
+  const { menu, assets, siteName, description, features } = config;
   const metaDescription = description || t('default_description');
 
   const profileController = getModule(ProfileController, false);
 
   const { searchPlaylist } = features || {};
-  const { footerText } = styling || {};
+  const footerText = useMemo(() => unicodeToChar(env.APP_FOOTER_TEXT), []);
   const currentLanguage = useMemo(() => supportedLanguages.find(({ code }) => code === i18n.language), [i18n.language, supportedLanguages]);
 
   const {

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -28,6 +28,8 @@ import Button from '../../components/Button/Button';
 
 import styles from './Layout.module.scss';
 
+const footerText = unicodeToChar(env.APP_FOOTER_TEXT);
+
 const Layout = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -45,7 +47,6 @@ const Layout = () => {
   const profileController = getModule(ProfileController, false);
 
   const { searchPlaylist } = features || {};
-  const footerText = useMemo(() => unicodeToChar(env.APP_FOOTER_TEXT), []);
   const currentLanguage = useMemo(() => supportedLanguages.find(({ code }) => code === i18n.language), [i18n.language, supportedLanguages]);
 
   const {

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -17,6 +17,8 @@ configureEnv({
 
   APP_DEFAULT_CONFIG_SOURCE: import.meta.env.APP_DEFAULT_CONFIG_SOURCE,
   APP_PLAYER_LICENSE_KEY: import.meta.env.APP_PLAYER_LICENSE_KEY,
+
+  APP_FOOTER_TEXT: import.meta.env.APP_FOOTER_TEXT,
 });
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
This change will make it possible to change the content in the footer through a env-var. Example:
```bash
export APP_FOOTER_TEXT="\u00a9 Blender Foundation | [cloud.blender.org](https://cloud.blender.org)" && yarn start
```

I removed the old approach `styling.footerText`. This custom field is removed from the JW dashboard.

There are two things that needs to be done that should be planned for another time:
- [ ] Hide the footer on the Capacitor platform (iOS/Android) **1 [OTT-699](https://videodock.atlassian.net/browse/OTT-699)
- [ ] Improve list of links for accessibility in the footer **2 [OTT-700](https://videodock.atlassian.net/browse/OTT-700)

**1 This change should be done in our private repo. I cannot determine it from this repo.
**2 IMHO it's a bit excessive to determine if a list of links is defined within the Markdown syntax and rewriting the HTML to a `<nav> <ul> <li>` structure. Let me know if you disagree!

Originally I stated that I wanted to show the brand name when `APP_FOOTER_TEXT` is empty. But I wanted to keep it close to how it originally was. I was a little bit surprised that a `MarkdownComponent` was already implemented for the footer. 

Ticket: https://videodock.atlassian.net/browse/OTT-636

[OTT-699]: https://videodock.atlassian.net/browse/OTT-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-700]: https://videodock.atlassian.net/browse/OTT-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ