### PR TITLE
Feat / a11y improve the contrast of non-texts

### DIFF
--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -35,7 +35,7 @@
       line-height: 36px;
       white-space: nowrap;
       text-overflow: ellipsis;
-      text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 4px 5px rgba(0, 0, 0, 0.12), 0 1px 10px rgba(0, 0, 0, 0.2);
+      text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
 
       @include responsive.mobile-only {
         font-size: 24px;
@@ -54,7 +54,7 @@
     .meta {
       justify-content: space-between;
       padding: 16px;
-      background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+      background: linear-gradient(to top, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0));
     }
 
     &:hover {

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -7,7 +7,7 @@
   color: var(--primary-color);
   font-family: var(--body-font-family);
   font-weight: 400;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
 }
 
 .mainPadding {
@@ -37,7 +37,7 @@
 
 .info {
   position: relative;
-  width: 70%;
+  width: 50%;
   max-width: 650px;
   min-height: 440px;
 

--- a/packages/ui-react/src/utils/theming.ts
+++ b/packages/ui-react/src/utils/theming.ts
@@ -18,5 +18,8 @@ export const setThemingVariables = (config: Config) => {
   if (root && headerBackground) {
     root.style.setProperty('--header-background', headerBackground);
     root.style.setProperty('--header-contrast-color', calculateContrastColor(headerBackground));
+  } else {
+    root.style.setProperty('--header-background', 'rgba(0, 0, 0, 0.85)');
+    root.style.setProperty('--header-contrast-color', '#ffff');
   }
 };


### PR DESCRIPTION
## This PR
[OTT-416](https://videodock.atlassian.net/browse/OTT-416)
- **Enhances the readability of the description of media items and the featured card title**
  - We do this by updating the `text-shadows`, `lineair-gradient` and decreasing the `max-width` of the `info` container 
- **Adds a solid background color to the header component if this is not set via the JW config**
  - I think that this change can be pretty opinionated, it has been discussed together with Stephan. This way we can ensure accessibility for now, but if we do not prefer this solution, we should discuss this a bit further.

**Before both these changes:**
![Screenshot 2024-01-25 at 20 08 00](https://github.com/Videodock/ott-web-app/assets/48496458/03f6a153-32c2-43f4-9959-61ea3e28c183)

**After the changes:**
![Screenshot 2024-01-25 at 20 08 06](https://github.com/Videodock/ott-web-app/assets/48496458/575501b9-c047-47d6-8743-a8a283318658)


[OTT-416]: https://videodock.atlassian.net/browse/OTT-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ