### PR TITLE
Refactor / revisit Cleeng and Inplayer typings

### DIFF
--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -42,7 +42,7 @@ export default class FavoriteService {
   }
 
   private async getFavoritesFromAccount(user: Customer) {
-    const favorites = await this.accountService?.getFavorites({ id: user.id });
+    const favorites = await this.accountService?.getFavorites({ user });
 
     return this.validateFavorites(favorites);
   }

--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -1,13 +1,16 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { object, array, string } from 'yup';
 
 import { MAX_WATCHLIST_ITEMS_COUNT } from '../constants';
 import type { Favorite, SerializedFavorite } from '../../types/favorite';
 import type { PlaylistItem } from '../../types/playlist';
 import type { Customer } from '../../types/account';
+import { getNamedModule } from '../modules/container';
+import { INTEGRATION_TYPE } from '../modules/types';
 
 import ApiService from './ApiService';
 import StorageService from './StorageService';
+import AccountService from './integrations/AccountService';
 
 const schema = array(
   object().shape({
@@ -22,39 +25,58 @@ export default class FavoriteService {
 
   private readonly apiService;
   private readonly storageService;
+  private readonly accountService;
 
-  constructor(apiService: ApiService, storageService: StorageService) {
+  constructor(@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
     this.apiService = apiService;
     this.storageService = storageService;
+    this.accountService = getNamedModule(AccountService, integrationType, false);
   }
 
-  private validateFavorites(user: Customer) {
-    if (schema.validateSync(user.metadata?.favorites)) {
-      return user.metadata.favorites as SerializedFavorite[];
+  private validateFavorites(favorites: unknown) {
+    if (schema.validateSync(favorites)) {
+      return favorites as SerializedFavorite[];
     }
 
     return [];
   }
 
+  private async getFavoritesFromAccount(user: Customer) {
+    const favorites = await this.accountService?.getFavorites({ id: user.id });
+
+    return this.validateFavorites(favorites);
+  }
+
+  private async getFavoritesFromStorage() {
+    const favorites = await this.storageService.getItem(this.PERSIST_KEY_FAVORITES, true);
+
+    return this.validateFavorites(favorites);
+  }
+
   getFavorites = async (user: Customer | null, favoritesList: string) => {
-    const savedItems = user ? this.validateFavorites(user) : await this.storageService.getItem<Favorite[]>(this.PERSIST_KEY_FAVORITES, true);
+    const savedItems = user ? await this.getFavoritesFromAccount(user) : await this.getFavoritesFromStorage();
 
-    if (savedItems?.length) {
-      const playlistItems = await this.apiService.getMediaByWatchlist(
-        favoritesList,
-        savedItems.map(({ mediaid }) => mediaid),
-      );
+    const playlistItems = await this.apiService.getMediaByWatchlist(
+      favoritesList,
+      savedItems.map(({ mediaid }) => mediaid),
+    );
 
-      return (playlistItems || []).map((item) => this.createFavorite(item));
-    }
+    return (playlistItems || []).map((item) => this.createFavorite(item));
   };
 
   serializeFavorites = (favorites: Favorite[]): SerializedFavorite[] => {
     return favorites.map(({ mediaid }) => ({ mediaid }));
   };
 
-  persistFavorites = (favorites: Favorite[]) => {
-    this.storageService.setItem(this.PERSIST_KEY_FAVORITES, JSON.stringify(this.serializeFavorites(favorites)));
+  persistFavorites = async (user: Customer | null, favorites: Favorite[]) => {
+    if (user?.id) {
+      return this.accountService?.updateFavorites({
+        id: user.id,
+        favorites: this.serializeFavorites(favorites),
+      });
+    } else {
+      await this.storageService.setItem(this.PERSIST_KEY_FAVORITES, JSON.stringify(this.serializeFavorites(favorites)));
+    }
   };
 
   getMaxFavoritesCount = () => {

--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -55,11 +55,13 @@ export default class FavoriteService {
 
   getFavorites = async (user: Customer | null, favoritesList: string) => {
     const savedItems = user ? await this.getFavoritesFromAccount(user) : await this.getFavoritesFromStorage();
+    const mediaIds = savedItems.map(({ mediaid }) => mediaid);
 
-    const playlistItems = await this.apiService.getMediaByWatchlist(
-      favoritesList,
-      savedItems.map(({ mediaid }) => mediaid),
-    );
+    if (!mediaIds) {
+      return [];
+    }
+
+    const playlistItems = await this.apiService.getMediaByWatchlist(favoritesList, mediaIds);
 
     return (playlistItems || []).map((item) => this.createFavorite(item));
   };

--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -70,11 +70,11 @@ export default class FavoriteService {
     return favorites.map(({ mediaid }) => ({ mediaid }));
   };
 
-  persistFavorites = async (user: Customer | null, favorites: Favorite[]) => {
-    if (user?.id) {
+  persistFavorites = async (favorites: Favorite[], user: Customer | null) => {
+    if (user) {
       return this.accountService?.updateFavorites({
-        id: user.id,
         favorites: this.serializeFavorites(favorites),
+        user,
       });
     } else {
       await this.storageService.setItem(this.PERSIST_KEY_FAVORITES, JSON.stringify(this.serializeFavorites(favorites)));

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -1,12 +1,15 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { array, number, object, string } from 'yup';
 
 import type { PlaylistItem } from '../../types/playlist';
 import type { SerializedWatchHistoryItem, WatchHistoryItem } from '../../types/watchHistory';
 import type { Customer } from '../../types/account';
+import { getNamedModule } from '../modules/container';
+import { INTEGRATION_TYPE } from '../modules/types';
 
 import ApiService from './ApiService';
 import StorageService from './StorageService';
+import AccountService from './integrations/AccountService';
 
 const schema = array(
   object().shape({
@@ -20,12 +23,14 @@ export default class WatchHistoryService {
   private PERSIST_KEY_WATCH_HISTORY = 'history';
   private MAX_WATCH_HISTORY_COUNT = 48;
 
-  private readonly apiService: ApiService;
-  private readonly storageService: StorageService;
+  private readonly apiService;
+  private readonly storageService;
+  private readonly accountService;
 
-  constructor(apiService: ApiService, storageService: StorageService) {
+  constructor(@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
     this.apiService = apiService;
     this.storageService = storageService;
+    this.accountService = getNamedModule(AccountService, integrationType);
   }
 
   // Retrieve watch history media items info using a provided watch list
@@ -55,35 +60,45 @@ export default class WatchHistoryService {
     return seriesItemsDict;
   };
 
-  private validateWatchHistory(user: Customer) {
-    if (schema.validateSync(user.metadata?.history)) {
-      return user.metadata.history as SerializedWatchHistoryItem[];
+  private validateWatchHistory(history: unknown) {
+    if (schema.validateSync(history)) {
+      return history as SerializedWatchHistoryItem[];
     }
 
     return [];
   }
 
+  private async getWatchHistoryFromAccount(user: Customer) {
+    const history = await this.accountService.getWatchHistory({ id: user.id });
+
+    return this.validateWatchHistory(history);
+  }
+
+  private async getWatchHistoryFromStorage() {
+    const history = await this.storageService.getItem(this.PERSIST_KEY_WATCH_HISTORY, true);
+
+    return this.validateWatchHistory(history);
+  }
+
   getWatchHistory = async (user: Customer | null, continueWatchingList: string) => {
-    const savedItems = user ? this.validateWatchHistory(user) : await this.storageService.getItem<WatchHistoryItem[]>(this.PERSIST_KEY_WATCH_HISTORY, true);
+    const savedItems = user ? await this.getWatchHistoryFromAccount(user) : await this.getWatchHistoryFromStorage();
 
-    if (savedItems?.length) {
-      // When item is an episode of the new flow -> show the card as a series one, but keep episode to redirect in a right way
-      const ids = savedItems.map(({ mediaid }) => mediaid);
+    // When item is an episode of the new flow -> show the card as a series one, but keep episode to redirect in a right way
+    const ids = savedItems.map(({ mediaid }) => mediaid);
 
-      const watchHistoryItems = await this.getWatchHistoryItems(continueWatchingList, ids);
-      const seriesItems = await this.getWatchHistorySeriesItems(continueWatchingList, ids);
+    const watchHistoryItems = await this.getWatchHistoryItems(continueWatchingList, ids);
+    const seriesItems = await this.getWatchHistorySeriesItems(continueWatchingList, ids);
 
-      const watchHistory = savedItems.map((item) => {
+    return savedItems
+      .map((item) => {
         const parentSeries = seriesItems?.[item.mediaid];
         const historyItem = watchHistoryItems[item.mediaid];
 
         if (historyItem) {
           return this.createWatchHistoryItem(parentSeries || historyItem, item.mediaid, parentSeries?.mediaid, item.progress);
         }
-      });
-
-      return watchHistory;
-    }
+      })
+      .filter((item): item is WatchHistoryItem => Boolean(item));
   };
 
   serializeWatchHistory = (watchHistory: WatchHistoryItem[]): SerializedWatchHistoryItem[] =>
@@ -92,8 +107,15 @@ export default class WatchHistoryService {
       progress,
     }));
 
-  persistWatchHistory = (watchHistory: WatchHistoryItem[]) => {
-    this.storageService.setItem(this.PERSIST_KEY_WATCH_HISTORY, JSON.stringify(this.serializeWatchHistory(watchHistory)));
+  persistWatchHistory = async (user: Customer | null, watchHistory: WatchHistoryItem[]) => {
+    if (user?.id) {
+      await this.accountService?.updateWatchHistory({
+        id: user.id,
+        history: this.serializeWatchHistory(watchHistory),
+      });
+    } else {
+      await this.storageService.setItem(this.PERSIST_KEY_WATCH_HISTORY, JSON.stringify(this.serializeWatchHistory(watchHistory)));
+    }
   };
 
   /** Use mediaid of originally watched movie / episode.

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -111,11 +111,11 @@ export default class WatchHistoryService {
       progress,
     }));
 
-  persistWatchHistory = async (user: Customer | null, watchHistory: WatchHistoryItem[]) => {
-    if (user?.id) {
+  persistWatchHistory = async (watchHistory: WatchHistoryItem[], user: Customer | null) => {
+    if (user) {
       await this.accountService?.updateWatchHistory({
-        id: user.id,
         history: this.serializeWatchHistory(watchHistory),
+        user,
       });
     } else {
       await this.storageService.setItem(this.PERSIST_KEY_WATCH_HISTORY, JSON.stringify(this.serializeWatchHistory(watchHistory)));

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -86,6 +86,10 @@ export default class WatchHistoryService {
     // When item is an episode of the new flow -> show the card as a series one, but keep episode to redirect in a right way
     const ids = savedItems.map(({ mediaid }) => mediaid);
 
+    if (!ids.length) {
+      return [];
+    }
+
     const watchHistoryItems = await this.getWatchHistoryItems(continueWatchingList, ids);
     const seriesItems = await this.getWatchHistorySeriesItems(continueWatchingList, ids);
 

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -69,7 +69,7 @@ export default class WatchHistoryService {
   }
 
   private async getWatchHistoryFromAccount(user: Customer) {
-    const history = await this.accountService.getWatchHistory({ id: user.id });
+    const history = await this.accountService.getWatchHistory({ user });
 
     return this.validateWatchHistory(history);
   }

--- a/packages/common/src/services/integrations/AccountService.ts
+++ b/packages/common/src/services/integrations/AccountService.ts
@@ -1,10 +1,7 @@
 import type { AccessModel, Config } from '../../../types/config';
 import type {
-  AuthData,
   ChangePassword,
   ChangePasswordWithOldPassword,
-  Customer,
-  CustomerConsent,
   DeleteAccount,
   ExportAccountData,
   GetCaptureStatus,
@@ -17,10 +14,15 @@ import type {
   GetSocialURLs,
   UpdateCaptureAnswers,
   UpdateCustomerConsents,
-  UpdateCustomerArgs,
+  Logout,
+  GetAuthData,
+  UpdateCustomer,
+  UpdateWatchHistory,
+  UpdateFavorites,
+  GetWatchHistory,
+  GetFavorites,
+  GetUser,
 } from '../../../types/account';
-import type { SerializedWatchHistoryItem } from '../../../types/watchHistory';
-import type { SerializedFavorite } from '../../../types/favorite';
 
 export type AccountServiceFeatures = {
   readonly canUpdateEmail: boolean;
@@ -48,15 +50,15 @@ export default abstract class AccountService {
 
   abstract initialize: (config: Config, url: string, logoutCallback: () => Promise<void>) => Promise<void>;
 
-  abstract getAuthData: () => Promise<AuthData | null>;
+  abstract getAuthData: GetAuthData;
 
   abstract login: Login;
 
   abstract register: Register;
 
-  abstract logout: () => Promise<void>;
+  abstract logout: Logout;
 
-  abstract getUser: ({ config }: { config: Config }) => Promise<{ user: Customer; customerConsents: CustomerConsent[] }>;
+  abstract getUser: GetUser;
 
   abstract getPublisherConsents: GetPublisherConsents;
 
@@ -74,15 +76,15 @@ export default abstract class AccountService {
 
   abstract changePasswordWithOldPassword: ChangePasswordWithOldPassword;
 
-  abstract updateCustomer: (payload: UpdateCustomerArgs) => Promise<Customer>;
+  abstract updateCustomer: UpdateCustomer;
 
-  abstract updateWatchHistory: ({ id, history }: { id: string; history: SerializedWatchHistoryItem[] }) => Promise<void>;
+  abstract updateWatchHistory: UpdateWatchHistory;
 
-  abstract updateFavorites: ({ id, favorites }: { id: string; favorites: SerializedFavorite[] }) => Promise<void>;
+  abstract updateFavorites: UpdateFavorites;
 
-  abstract getWatchHistory: ({ id }: { id: string }) => Promise<SerializedWatchHistoryItem[]>;
+  abstract getWatchHistory: GetWatchHistory;
 
-  abstract getFavorites: ({ id }: { id: string }) => Promise<SerializedFavorite[]>;
+  abstract getFavorites: GetFavorites;
 
   abstract subscribeToNotifications: NotificationsData;
 

--- a/packages/common/src/services/integrations/AccountService.ts
+++ b/packages/common/src/services/integrations/AccountService.ts
@@ -16,10 +16,11 @@ import type {
   ResetPassword,
   GetSocialURLs,
   UpdateCaptureAnswers,
-  UpdateCustomer,
   UpdateCustomerConsents,
-  UpdatePersonalShelves,
+  UpdateCustomerArgs,
 } from '../../../types/account';
+import type { SerializedWatchHistoryItem } from '../../../types/watchHistory';
+import type { SerializedFavorite } from '../../../types/favorite';
 
 export type AccountServiceFeatures = {
   readonly canUpdateEmail: boolean;
@@ -73,9 +74,15 @@ export default abstract class AccountService {
 
   abstract changePasswordWithOldPassword: ChangePasswordWithOldPassword;
 
-  abstract updateCustomer: UpdateCustomer;
+  abstract updateCustomer: (payload: UpdateCustomerArgs) => Promise<Customer>;
 
-  abstract updatePersonalShelves: UpdatePersonalShelves;
+  abstract updateWatchHistory: ({ id, history }: { id: string; history: SerializedWatchHistoryItem[] }) => Promise<void>;
+
+  abstract updateFavorites: ({ id, favorites }: { id: string; favorites: SerializedFavorite[] }) => Promise<void>;
+
+  abstract getWatchHistory: ({ id }: { id: string }) => Promise<SerializedWatchHistoryItem[]>;
+
+  abstract getFavorites: ({ id }: { id: string }) => Promise<SerializedFavorite[]>;
 
   abstract subscribeToNotifications: NotificationsData;
 

--- a/packages/common/src/services/integrations/ProfileService.ts
+++ b/packages/common/src/services/integrations/ProfileService.ts
@@ -1,4 +1,4 @@
-import type { CreateProfile, DeleteProfile, EnterProfile, GetProfileDetails, ListProfiles, UpdateProfile } from '../../../types/account';
+import type { CreateProfile, DeleteProfile, EnterProfile, GetProfileDetails, ListProfiles, UpdateProfile } from '../../../types/profiles';
 
 export default abstract class ProfileService {
   abstract listProfiles: ListProfiles;

--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -43,6 +43,7 @@ import type {
 } from './types/account';
 import { formatCustomer } from './formatters/customer';
 import { formatPublisherConsent } from './formatters/consents';
+import type { Response } from './types/api';
 
 @injectable()
 export default class CleengAccountService extends AccountService {
@@ -244,7 +245,7 @@ export default class CleengAccountService extends AccountService {
 
     this.handleErrors(response.errors);
 
-    return response;
+    return response.responseData;
   };
 
   updateCaptureAnswers: UpdateCaptureAnswers = async ({ customer, ...payload }) => {
@@ -262,30 +263,31 @@ export default class CleengAccountService extends AccountService {
   };
 
   resetPassword: ResetPassword = async (payload) => {
-    return this.cleengService.put(
+    const response = await this.cleengService.put<Response<unknown>>(
       '/customers/passwords',
       JSON.stringify({
         ...payload,
         publisherId: this.publisherId,
       }),
     );
+
+    this.handleErrors(response.errors);
   };
 
   changePasswordWithResetToken: ChangePassword = async (payload) => {
-    return this.cleengService.patch(
+    const response = await this.cleengService.patch<Response<unknown>>(
       '/customers/passwords',
       JSON.stringify({
         ...payload,
         publisherId: this.publisherId,
       }),
     );
+
+    this.handleErrors(response.errors);
   };
 
   changePasswordWithOldPassword: ChangePasswordWithOldPassword = async () => {
-    return {
-      errors: [],
-      responseData: {},
-    };
+    // Cleeng doesn't support this feature
   };
 
   updateCustomer = async (payload: UpdateCustomerArgs) => {

--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -19,10 +19,12 @@ import type {
   ResetPassword,
   UpdateCaptureAnswers,
   UpdateCaptureAnswersPayload,
-  UpdateCustomerArgs,
+  UpdateCustomer,
   UpdateCustomerConsents,
   UpdateCustomerConsentsPayload,
   UpdateCustomerPayload,
+  UpdateFavorites,
+  UpdateWatchHistory,
 } from '../../../../types/account';
 import AccountService from '../AccountService';
 import { GET_CUSTOMER_IP } from '../../../modules/types';
@@ -290,7 +292,7 @@ export default class CleengAccountService extends AccountService {
     // Cleeng doesn't support this feature
   };
 
-  updateCustomer = async (payload: UpdateCustomerArgs) => {
+  updateCustomer: UpdateCustomer = async (payload) => {
     const { id, metadata, fullName, ...rest } = payload;
     const params: UpdateCustomerPayload = {
       id,
@@ -309,9 +311,9 @@ export default class CleengAccountService extends AccountService {
     return formatCustomer(responseData);
   };
 
-  updateWatchHistory = async ({ id, history }: { id: string; history: SerializedWatchHistoryItem[] }) => {
-    const payload = { id, externalData: { ...this.externalData, history } };
-    const { errors, responseData } = await this.cleengService.patch<UpdateCustomerResponse>(`/customers/${id}`, JSON.stringify(payload), {
+  updateWatchHistory: UpdateWatchHistory = async ({ user, history }) => {
+    const payload = { id: user.id, externalData: { ...this.externalData, history } };
+    const { errors, responseData } = await this.cleengService.patch<UpdateCustomerResponse>(`/customers/${user.id}`, JSON.stringify(payload), {
       authenticate: true,
       keepalive: true,
     });
@@ -320,9 +322,9 @@ export default class CleengAccountService extends AccountService {
     this.externalData = responseData.externalData || {};
   };
 
-  updateFavorites = async ({ id, favorites }: { id: string; favorites: SerializedFavorite[] }) => {
-    const payload = { id, externalData: { ...this.externalData, favorites } };
-    const { errors, responseData } = await this.cleengService.patch<UpdateCustomerResponse>(`/customers/${id}`, JSON.stringify(payload), {
+  updateFavorites: UpdateFavorites = async ({ user, favorites }) => {
+    const payload = { id: user.id, externalData: { ...this.externalData, favorites } };
+    const { errors, responseData } = await this.cleengService.patch<UpdateCustomerResponse>(`/customers/${user.id}`, JSON.stringify(payload), {
       authenticate: true,
       keepalive: true,
     });

--- a/packages/common/src/services/integrations/cleeng/CleengService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengService.ts
@@ -363,13 +363,13 @@ export default class CleengService {
     return this.get(`/locales${customerIP ? '?customerIP=' + customerIP : ''}`);
   };
 
-  get = <T>(path: string, options?: RequestOptions) => this.performRequest(path, 'GET', undefined, options) as T;
+  get = <T>(path: string, options?: RequestOptions) => this.performRequest(path, 'GET', undefined, options) as Promise<T>;
 
-  patch = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'PATCH', body, options) as T;
+  patch = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'PATCH', body, options) as Promise<T>;
 
-  put = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'PUT', body, options) as T;
+  put = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'PUT', body, options) as Promise<T>;
 
-  post = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'POST', body, options) as T;
+  post = <T>(path: string, body?: string, options?: RequestOptions) => this.performRequest(path, 'POST', body, options) as Promise<T>;
 
-  remove = <T>(path: string, options?: RequestOptions) => this.performRequest(path, 'DELETE', undefined, options) as T;
+  remove = <T>(path: string, options?: RequestOptions) => this.performRequest(path, 'DELETE', undefined, options) as Promise<T>;
 }

--- a/packages/common/src/services/integrations/cleeng/CleengService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengService.ts
@@ -5,11 +5,13 @@ import { BroadcastChannel } from 'broadcast-channel';
 
 import { IS_DEVELOPMENT_BUILD, logDev } from '../../../utils/common';
 import { PromiseQueue } from '../../../utils/promiseQueue';
-import type { AuthData, GetLocales } from '../../../../types/account';
+import type { AuthData } from '../../../../types/account';
 import StorageService from '../../StorageService';
 import { GET_CUSTOMER_IP } from '../../../modules/types';
 import type { GetCustomerIP } from '../../../../types/get-customer-ip';
-import type { ServiceResponse } from '../../../../types/service';
+
+import type { GetLocalesResponse } from './types/account';
+import type { Response } from './types/api';
 
 const AUTH_PERSIST_KEY = 'auth';
 
@@ -120,7 +122,7 @@ export default class CleengService {
    */
   private getNewTokens: (tokens: Tokens) => Promise<Tokens | null> = async ({ refreshToken }) => {
     try {
-      const { responseData: newTokens } = await this.post<Promise<ServiceResponse<AuthData>>>('/auths/refresh_token', JSON.stringify({ refreshToken }));
+      const { responseData: newTokens } = await this.post<Response<AuthData>>('/auths/refresh_token', JSON.stringify({ refreshToken }));
 
       return {
         accessToken: newTokens.jwt,
@@ -357,10 +359,10 @@ export default class CleengService {
     return accessToken;
   };
 
-  getLocales: GetLocales = async () => {
+  getLocales = async () => {
     const customerIP = await this.getCustomerIP();
 
-    return this.get(`/locales${customerIP ? '?customerIP=' + customerIP : ''}`);
+    return this.get<GetLocalesResponse>(`/locales${customerIP ? '?customerIP=' + customerIP : ''}`);
   };
 
   get = <T>(path: string, options?: RequestOptions) => this.performRequest(path, 'GET', undefined, options) as Promise<T>;

--- a/packages/common/src/services/integrations/cleeng/formatters/consents.ts
+++ b/packages/common/src/services/integrations/cleeng/formatters/consents.ts
@@ -1,0 +1,16 @@
+import type { PublisherConsent } from '../types/models';
+import type { CustomFormField } from '../../../../../types/account';
+
+export const formatPublisherConsent = (consent: PublisherConsent): CustomFormField => {
+  return {
+    type: 'checkbox',
+    name: consent.name,
+    label: consent.label,
+    defaultValue: '',
+    required: consent.required,
+    placeholder: consent.placeholder,
+    options: {},
+    enabledByDefault: false,
+    version: consent.version,
+  };
+};

--- a/packages/common/src/services/integrations/cleeng/formatters/customer.ts
+++ b/packages/common/src/services/integrations/cleeng/formatters/customer.ts
@@ -1,0 +1,15 @@
+import type { CleengCustomer } from '../types/models';
+import type { Customer } from '../../../../../types/account';
+
+export const formatCustomer = (customer: CleengCustomer): Customer => {
+  return {
+    id: customer.id,
+    email: customer.email,
+    country: customer.country,
+    firstName: customer.firstName,
+    lastName: customer.lastName,
+    fullName: `${customer.firstName} ${customer.lastName}`,
+    // map `externalData` to `metadata` (NOTE; The Cleeng API returns parsed values)
+    metadata: customer.externalData || {},
+  };
+};

--- a/packages/common/src/services/integrations/cleeng/types/account.ts
+++ b/packages/common/src/services/integrations/cleeng/types/account.ts
@@ -1,0 +1,12 @@
+export interface CleengCustomer {
+  id: string;
+  email: string;
+  country: string;
+  regDate: string;
+  lastLoginDate?: string;
+  lastUserIp: string;
+  firstName?: string;
+  lastName?: string;
+  externalId?: string;
+  externalData?: Record<string, unknown>;
+}

--- a/packages/common/src/services/integrations/cleeng/types/account.ts
+++ b/packages/common/src/services/integrations/cleeng/types/account.ts
@@ -1,12 +1,11 @@
-export interface CleengCustomer {
-  id: string;
-  email: string;
-  country: string;
-  regDate: string;
-  lastLoginDate?: string;
-  lastUserIp: string;
-  firstName?: string;
-  lastName?: string;
-  externalId?: string;
-  externalData?: Record<string, unknown>;
-}
+import type { Response } from './api';
+import type { CleengCustomer, UpdateConfirmation } from './models';
+
+// Cleeng typings for the account endpoints
+
+// Customer
+export type GetCustomerResponse = Response<CleengCustomer>;
+export type UpdateCustomerResponse = Response<CleengCustomer>;
+
+// Consents
+export type UpdateConsentsResponse = Response<UpdateConfirmation>;

--- a/packages/common/src/services/integrations/cleeng/types/account.ts
+++ b/packages/common/src/services/integrations/cleeng/types/account.ts
@@ -1,7 +1,12 @@
+import type { AuthData } from '../../../../../types/account';
+
 import type { Response } from './api';
-import type { CleengCustomer, UpdateConfirmation } from './models';
+import type { CleengCustomer, LocalesData, PublisherConsent, CustomerConsent, UpdateConfirmation } from './models';
 
 // Cleeng typings for the account endpoints
+
+// Auth
+export type AuthResponse = Response<AuthData>;
 
 // Customer
 export type GetCustomerResponse = Response<CleengCustomer>;
@@ -9,3 +14,8 @@ export type UpdateCustomerResponse = Response<CleengCustomer>;
 
 // Consents
 export type UpdateConsentsResponse = Response<UpdateConfirmation>;
+export type GetPublisherConsentsResponse = Response<{ consents: PublisherConsent[] }>;
+export type GetCustomerConsentsResponse = Response<{ consents: CustomerConsent[] }>;
+
+// Locales
+export type GetLocalesResponse = Response<LocalesData>;

--- a/packages/common/src/services/integrations/cleeng/types/api.ts
+++ b/packages/common/src/services/integrations/cleeng/types/api.ts
@@ -1,0 +1,8 @@
+export type ApiResponse = { errors: string[] };
+
+export type CleengResponse<R> = { responseData: R; errors: string[] };
+
+// export type PromiseRequest<P, R> = (payload: P) => Promise<R>;
+// export type EmptyServiceRequest<R> = () => Promise<ServiceResponse<R>>;
+// export type EmptyEnvironmentServiceRequest<R> = () => Promise<ServiceResponse<R>>;
+// export type EnvironmentServiceRequest<P, R> = (payload: P) => Promise<ServiceResponse<R>>;

--- a/packages/common/src/services/integrations/cleeng/types/api.ts
+++ b/packages/common/src/services/integrations/cleeng/types/api.ts
@@ -1,8 +1,3 @@
-export type ApiResponse = { errors: string[] };
+// Cleeng typings for generic API response structures
 
-export type CleengResponse<R> = { responseData: R; errors: string[] };
-
-// export type PromiseRequest<P, R> = (payload: P) => Promise<R>;
-// export type EmptyServiceRequest<R> = () => Promise<ServiceResponse<R>>;
-// export type EmptyEnvironmentServiceRequest<R> = () => Promise<ServiceResponse<R>>;
-// export type EnvironmentServiceRequest<P, R> = (payload: P) => Promise<ServiceResponse<R>>;
+export type Response<R> = { responseData: R; errors: string[] };

--- a/packages/common/src/services/integrations/cleeng/types/models.ts
+++ b/packages/common/src/services/integrations/cleeng/types/models.ts
@@ -1,0 +1,18 @@
+// Cleeng typings for API models
+
+export interface CleengCustomer {
+  id: string;
+  email: string;
+  country: string;
+  regDate: string;
+  lastLoginDate?: string;
+  lastUserIp: string;
+  firstName?: string;
+  lastName?: string;
+  externalId?: string;
+  externalData?: Record<string, unknown>;
+}
+
+export interface UpdateConfirmation {
+  success: boolean;
+}

--- a/packages/common/src/services/integrations/cleeng/types/models.ts
+++ b/packages/common/src/services/integrations/cleeng/types/models.ts
@@ -16,3 +16,32 @@ export interface CleengCustomer {
 export interface UpdateConfirmation {
   success: boolean;
 }
+
+export interface LocalesData {
+  country: string;
+  currency: string;
+  locale: string;
+  ipAddress: string;
+}
+
+export interface PublisherConsent {
+  name: string;
+  label: string;
+  placeholder: string;
+  required: boolean;
+  version: string;
+  value: string;
+}
+
+export interface CustomerConsent {
+  customerId: string;
+  date: number;
+  label: string;
+  name: string;
+  needsUpdate: boolean;
+  newestVersion: string;
+  required: boolean;
+  state: 'accepted' | 'declined';
+  value: string | boolean;
+  version: string;
+}

--- a/packages/common/src/services/integrations/jwp/JWPAccountService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAccountService.ts
@@ -26,6 +26,9 @@ import type {
   UpdateCaptureAnswers,
   UpdateCustomerArgs,
   UpdateCustomerConsents,
+  UpdateFavorites,
+  UpdateWatchHistory,
+  UpdateCustomer,
 } from '../../../../types/account';
 import type { AccessModel, Config } from '../../../../types/config';
 import type { InPlayerAuthData } from '../../../../types/inplayer';
@@ -381,7 +384,7 @@ export default class JWPAccountService extends AccountService {
     }
   };
 
-  updateCustomer = async (customer: UpdateCustomerArgs) => {
+  updateCustomer: UpdateCustomer = async (customer) => {
     try {
       const response = await InPlayer.Account.updateAccount(this.formatUpdateAccount(customer));
 
@@ -466,7 +469,7 @@ export default class JWPAccountService extends AccountService {
     };
   };
 
-  updateWatchHistory = async ({ history }: { id: string; history: SerializedWatchHistoryItem[] }) => {
+  updateWatchHistory: UpdateWatchHistory = async ({ history }) => {
     const externalData = await this.getCustomerExternalData();
     const savedHistory = externalData.history?.map((e) => e.mediaid) || [];
 
@@ -479,7 +482,7 @@ export default class JWPAccountService extends AccountService {
     );
   };
 
-  updateFavorites = async ({ favorites }: { id: string; favorites: SerializedFavorite[] }) => {
+  updateFavorites: UpdateFavorites = async ({ favorites }) => {
     const externalData = await this.getCustomerExternalData();
     const currentFavoriteIds = externalData?.favorites?.map((e) => e.mediaid) || [];
     const payloadFavoriteIds = favorites.map((e) => e.mediaid);

--- a/packages/common/src/services/integrations/jwp/JWPAccountService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAccountService.ts
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 import { injectable } from 'inversify';
 
 import { formatConsentsToRegisterFields } from '../../../utils/collection';
-import { getCommonResponseData, isCommonError } from '../../../utils/api';
+import { isCommonError } from '../../../utils/api';
 import type {
   AuthData,
   ChangePassword,
@@ -273,16 +273,13 @@ export default class JWPAccountService extends AccountService {
 
   changePasswordWithOldPassword: ChangePasswordWithOldPassword = async (payload) => {
     const { oldPassword, newPassword, newPasswordConfirmation } = payload;
+
     try {
       await InPlayer.Account.changePassword({
         oldPassword,
         password: newPassword,
         passwordConfirmation: newPasswordConfirmation,
       });
-      return {
-        errors: [],
-        responseData: {},
-      };
     } catch (error: unknown) {
       if (isCommonError(error)) {
         throw new Error(error.response.data.message);
@@ -298,10 +295,6 @@ export default class JWPAccountService extends AccountService {
         merchantUuid: this.clientId,
         brandingId: 0,
       });
-      return {
-        errors: [],
-        responseData: {},
-      };
     } catch {
       throw new Error('Failed to reset password.');
     }
@@ -417,22 +410,19 @@ export default class JWPAccountService extends AccountService {
 
   getCaptureStatus: GetCaptureStatus = async ({ customer }) => {
     return {
-      errors: [],
-      responseData: {
-        isCaptureEnabled: true,
-        shouldCaptureBeDisplayed: true,
-        settings: [
-          {
-            answer: {
-              firstName: customer.firstName || null,
-              lastName: customer.lastName || null,
-            },
-            enabled: true,
-            key: 'firstNameLastName',
-            required: true,
+      isCaptureEnabled: true,
+      shouldCaptureBeDisplayed: true,
+      settings: [
+        {
+          answer: {
+            firstName: customer.firstName || null,
+            lastName: customer.lastName || null,
           },
-        ],
-      },
+          enabled: true,
+          key: 'firstNameLastName',
+          required: true,
+        },
+      ],
     };
   };
 
@@ -447,10 +437,6 @@ export default class JWPAccountService extends AccountService {
         },
         resetPasswordToken,
       );
-      return {
-        errors: [],
-        responseData: {},
-      };
     } catch (error: unknown) {
       if (isCommonError(error)) {
         throw new Error(error.response.data.message);
@@ -543,7 +529,8 @@ export default class JWPAccountService extends AccountService {
     // password is sent as undefined because it is now optional on BE
     try {
       const response = await InPlayer.Account.exportData({ password: undefined, brandingId: 0 });
-      return getCommonResponseData(response);
+
+      return response.data;
     } catch {
       throw new Error('Failed to export account data');
     }
@@ -552,7 +539,8 @@ export default class JWPAccountService extends AccountService {
   deleteAccount: DeleteAccount = async ({ password }) => {
     try {
       const response = await InPlayer.Account.deleteAccount({ password, brandingId: 0 });
-      return getCommonResponseData(response);
+
+      return response.data;
     } catch {
       throw new Error('Failed to delete account');
     }

--- a/packages/common/src/services/integrations/jwp/JWPProfileService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPProfileService.ts
@@ -2,9 +2,9 @@ import InPlayer from '@inplayer-org/inplayer.js';
 import { injectable } from 'inversify';
 import defaultAvatar from '@jwp/ott-theme/assets/profiles/default_avatar.png';
 
-import type { CreateProfile, DeleteProfile, EnterProfile, GetProfileDetails, ListProfiles, UpdateProfile } from '../../../../types/account';
 import ProfileService from '../ProfileService';
 import StorageService from '../../StorageService';
+import type { CreateProfile, DeleteProfile, EnterProfile, GetProfileDetails, ListProfiles, UpdateProfile } from '../../../../types/profiles';
 
 @injectable()
 export default class JWPProfileService extends ProfileService {
@@ -18,46 +18,38 @@ export default class JWPProfileService extends ProfileService {
   listProfiles: ListProfiles = async () => {
     try {
       const response = await InPlayer.Account.getProfiles();
+
       return {
-        responseData: {
-          canManageProfiles: true,
-          collection:
-            response.data.map((profile) => ({
-              ...profile,
-              avatar_url: profile?.avatar_url || defaultAvatar,
-            })) ?? [],
-        },
-        errors: [],
+        canManageProfiles: true,
+        collection:
+          response.data.map((profile) => ({
+            ...profile,
+            avatar_url: profile?.avatar_url || defaultAvatar,
+          })) ?? [],
       };
     } catch {
       console.error('Unable to list profiles.');
       return {
-        responseData: {
-          canManageProfiles: false,
-          collection: [],
-        },
-        errors: ['Unable to list profiles.'],
+        canManageProfiles: false,
+        collection: [],
       };
     }
   };
 
   createProfile: CreateProfile = async (payload) => {
     const response = await InPlayer.Account.createProfile(payload.name, payload.adult, payload.avatar_url, payload.pin);
-    return {
-      responseData: response.data,
-      errors: [],
-    };
+
+    return response.data;
   };
 
   updateProfile: UpdateProfile = async (payload) => {
     if (!payload.id) {
       throw new Error('Profile id is required.');
     }
+
     const response = await InPlayer.Account.updateProfile(payload.id, payload.name, payload.avatar_url, payload.adult);
-    return {
-      responseData: response.data,
-      errors: [],
-    };
+
+    return response.data;
   };
 
   enterProfile: EnterProfile = async ({ id, pin }) => {
@@ -76,10 +68,7 @@ export default class JWPProfileService extends ProfileService {
         await this.storageService.setItem('inplayer_token', tokenData, false);
       }
 
-      return {
-        responseData: profile,
-        errors: [],
-      };
+      return profile;
     } catch {
       throw new Error('Unable to enter profile.');
     }
@@ -88,10 +77,8 @@ export default class JWPProfileService extends ProfileService {
   getProfileDetails: GetProfileDetails = async ({ id }) => {
     try {
       const response = await InPlayer.Account.getProfileDetails(id);
-      return {
-        responseData: response.data,
-        errors: [],
-      };
+
+      return response.data;
     } catch {
       throw new Error('Unable to get profile details.');
     }
@@ -100,12 +87,10 @@ export default class JWPProfileService extends ProfileService {
   deleteProfile: DeleteProfile = async ({ id }) => {
     try {
       await InPlayer.Account.deleteProfile(id);
+
       return {
-        responseData: {
-          message: 'Profile deleted successfully',
-          code: 200,
-        },
-        errors: [],
+        message: 'Profile deleted successfully',
+        code: 200,
       };
     } catch {
       throw new Error('Unable to delete profile.');

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -15,8 +15,6 @@ import type {
   EmailConfirmPasswordInput,
   FirstLastNameInput,
   GetCaptureStatusResponse,
-  GetCustomerConsentsResponse,
-  GetPublisherConsentsResponse,
   SubscribeToNotificationsPayload,
 } from '../../types/account';
 import { assertFeature, assertModuleMethod, getNamedModule } from '../modules/container';
@@ -190,15 +188,15 @@ export default class AccountController {
     useAccountStore.setState({ loading: true });
 
     try {
-      const response = await this.accountService?.updateCustomerConsents({
+      const updatedConsents = await this.accountService?.updateCustomerConsents({
         customer,
         consents: customerConsents,
       });
 
-      if (response?.consents) {
-        useAccountStore.setState({ customerConsents: response.consents });
+      if (updatedConsents) {
+        useAccountStore.setState({ customerConsents: updatedConsents });
         return {
-          responseData: response.consents,
+          responseData: updatedConsents,
           errors: [],
         };
       }
@@ -213,27 +211,27 @@ export default class AccountController {
 
   // TODO: Decide if it's worth keeping this or just leave combined with getUser
   // noinspection JSUnusedGlobalSymbols
-  getCustomerConsents = async (): Promise<GetCustomerConsentsResponse> => {
+  getCustomerConsents = async () => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
-    const response = await this.accountService.getCustomerConsents({ customer });
+    const consents = await this.accountService.getCustomerConsents({ customer });
 
-    if (response?.consents) {
-      useAccountStore.setState({ customerConsents: response.consents });
+    if (consents) {
+      useAccountStore.setState({ customerConsents: consents });
     }
 
-    return response;
+    return consents;
   };
 
-  getPublisherConsents = async (): Promise<GetPublisherConsentsResponse> => {
+  getPublisherConsents = async () => {
     const { config } = useConfigStore.getState();
 
-    const response = await this.accountService.getPublisherConsents(config);
+    const consents = await this.accountService.getPublisherConsents(config);
 
-    useAccountStore.setState({ publisherConsents: response.consents });
+    useAccountStore.setState({ publisherConsents: consents });
 
-    return response;
+    return consents;
   };
 
   getCaptureStatus = async (): Promise<GetCaptureStatusResponse> => {

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -255,9 +255,7 @@ export default class AccountController {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
-    const { responseData } = await this.accountService.getCaptureStatus({ customer });
-
-    return responseData;
+    return this.accountService.getCaptureStatus({ customer });
   };
 
   updateCaptureAnswers = async (capture: Capture): Promise<Capture> => {
@@ -272,38 +270,27 @@ export default class AccountController {
   };
 
   resetPassword = async (email: string, resetUrl: string) => {
-    const response = await this.accountService.resetPassword({
+    await this.accountService.resetPassword({
       customerEmail: email,
       resetUrl,
     });
-
-    if (response.errors.length > 0) throw new Error(response.errors[0]);
-
-    return response.responseData;
   };
 
   changePasswordWithOldPassword = async (oldPassword: string, newPassword: string, newPasswordConfirmation: string) => {
-    const response = await this.accountService.changePasswordWithOldPassword({
+    await this.accountService.changePasswordWithOldPassword({
       oldPassword,
       newPassword,
       newPasswordConfirmation,
     });
-    if (response?.errors?.length > 0) throw new Error(response.errors[0]);
-
-    return response?.responseData;
   };
 
   changePasswordWithToken = async (customerEmail: string, newPassword: string, resetPasswordToken: string, newPasswordConfirmation: string) => {
-    const response = await this.accountService.changePasswordWithResetToken({
+    await this.accountService.changePasswordWithResetToken({
       customerEmail,
       newPassword,
       resetPasswordToken,
       newPasswordConfirmation,
     });
-
-    if (response?.errors?.length > 0) throw new Error(response.errors[0]);
-
-    return response?.responseData;
   };
 
   updateSubscription = async (status: 'active' | 'cancelled'): Promise<unknown> => {

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -23,41 +23,28 @@ import { assertFeature, assertModuleMethod, getNamedModule } from '../modules/co
 import { INTEGRATION_TYPE } from '../modules/types';
 import type { ServiceResponse } from '../../types/service';
 
-import { useWatchHistoryStore } from './WatchHistoryStore';
-import { useFavoritesStore } from './FavoritesStore';
 import { useAccountStore } from './AccountStore';
 import { useConfigStore } from './ConfigStore';
 import { useProfileStore } from './ProfileStore';
 import ProfileController from './ProfileController';
-import WatchHistoryController from './WatchHistoryController';
-import FavoritesController from './FavoritesController';
 
 @injectable()
 export default class AccountController {
   private readonly checkoutService: CheckoutService;
   private readonly accountService: AccountService;
   private readonly subscriptionService: SubscriptionService;
-  private readonly favoritesController: FavoritesController;
-  private readonly watchHistoryController: WatchHistoryController;
   private readonly profileController?: ProfileController;
   private readonly features: AccountServiceFeatures;
 
   // temporary callback for refreshing the query cache until we've updated to react-query v4 or v5
   private refreshEntitlements: (() => Promise<void>) | undefined;
 
-  constructor(
-    @inject(INTEGRATION_TYPE) integrationType: IntegrationType,
-    favoritesController: FavoritesController,
-    watchHistoryController: WatchHistoryController,
-    profileController?: ProfileController,
-  ) {
+  constructor(@inject(INTEGRATION_TYPE) integrationType: IntegrationType, profileController?: ProfileController) {
     this.checkoutService = getNamedModule(CheckoutService, integrationType);
     this.accountService = getNamedModule(AccountService, integrationType);
     this.subscriptionService = getNamedModule(SubscriptionService, integrationType);
 
     // @TODO refactor?
-    this.favoritesController = favoritesController;
-    this.watchHistoryController = watchHistoryController;
     this.profileController = profileController;
 
     this.features = integrationType ? this.accountService.features : DEFAULT_FEATURES;
@@ -69,8 +56,6 @@ export default class AccountController {
 
       if (authData) {
         await this.getAccount();
-        await this.watchHistoryController?.restoreWatchHistory();
-        await this.favoritesController?.restoreFavorites();
       }
     } catch (error: unknown) {
       logDev('Failed to get user', error);
@@ -104,26 +89,6 @@ export default class AccountController {
     return this.accountService.sandbox;
   }
 
-  updatePersonalShelves = async () => {
-    const { watchHistory } = useWatchHistoryStore.getState();
-    const { favorites } = useFavoritesStore.getState();
-    const { getAccountInfo } = useAccountStore.getState();
-
-    const { customer } = getAccountInfo();
-
-    if (!watchHistory && !favorites) return;
-
-    const personalShelfData = {
-      history: this.watchHistoryController?.serializeWatchHistory(watchHistory),
-      favorites: this.favoritesController?.serializeFavorites(favorites),
-    };
-
-    return this.accountService?.updatePersonalShelves({
-      id: customer.id,
-      externalData: personalShelfData,
-    });
-  };
-
   updateUser = async (values: FirstLastNameInput | EmailConfirmPasswordInput): Promise<ServiceResponse<Customer>> => {
     useAccountStore.setState({ loading: true });
 
@@ -152,17 +117,15 @@ export default class AccountController {
       payload = { ...values, email: user.email };
     }
 
-    const response = await this.accountService.updateCustomer({ ...payload, id: user.id.toString() });
+    const updatedUser = await this.accountService.updateCustomer({ ...payload, id: user.id.toString() });
 
-    if (!response) {
+    if (!updatedUser) {
       throw new Error('Unknown error');
     }
 
-    if (response.errors?.length === 0) {
-      useAccountStore.setState({ user: response.responseData });
-    }
+    useAccountStore.setState({ user: updatedUser });
 
-    return response;
+    return { errors: [], responseData: updatedUser };
   };
 
   getAccount = async () => {
@@ -195,9 +158,6 @@ export default class AccountController {
 
     if (response) {
       await this.afterLogin(response.user, response.customerConsents);
-
-      await this.favoritesController?.restoreFavorites().catch(logDev);
-      await this.watchHistoryController?.restoreWatchHistory().catch(logDev);
     }
 
     useAccountStore.setState({ loading: false });
@@ -220,7 +180,7 @@ export default class AccountController {
       await this.afterLogin(user, customerConsents);
     }
 
-    await this.updatePersonalShelves();
+    // @TODO save local shelves to account?
   };
 
   updateConsents = async (customerConsents: CustomerConsent[]): Promise<ServiceResponse<CustomerConsent[]>> => {
@@ -289,13 +249,11 @@ export default class AccountController {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer, customerConsents } = getAccountInfo();
 
-    const response = await this.accountService.updateCaptureAnswers({ customer, ...capture });
+    const updatedCustomer = await this.accountService.updateCaptureAnswers({ customer, ...capture });
 
-    if (response.errors.length > 0) throw new Error(response.errors[0]);
+    await this.afterLogin(updatedCustomer, customerConsents, false);
 
-    await this.afterLogin(response.responseData as Customer, customerConsents, false);
-
-    return response.responseData;
+    return updatedCustomer;
   };
 
   resetPassword = async (email: string, resetUrl: string) => {
@@ -547,8 +505,5 @@ export default class AccountController {
     });
 
     this.profileController?.unpersistProfile();
-
-    await this.favoritesController?.restoreFavorites();
-    await this.watchHistoryController?.restoreWatchHistory();
   };
 }

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -189,11 +189,9 @@ export default class AccountController {
   };
 
   login = async (email: string, password: string, referrer: string) => {
-    const { config } = useConfigStore.getState();
-
     useAccountStore.setState({ loading: true });
 
-    const response = await this.accountService.login({ config, email, password, referrer });
+    const response = await this.accountService.login({ email, password, referrer });
 
     if (response) {
       await this.afterLogin(response.user, response.customerConsents);
@@ -214,10 +212,8 @@ export default class AccountController {
   };
 
   register = async (email: string, password: string, referrer: string, consents: CustomerConsent[]) => {
-    const { config } = useConfigStore.getState();
-
     useAccountStore.setState({ loading: true });
-    const response = await this.accountService.register({ config, email, password, consents, referrer });
+    const response = await this.accountService.register({ email, password, consents, referrer });
 
     if (response) {
       const { user, customerConsents } = response;
@@ -229,14 +225,12 @@ export default class AccountController {
 
   updateConsents = async (customerConsents: CustomerConsent[]): Promise<ServiceResponse<CustomerConsent[]>> => {
     const { getAccountInfo } = useAccountStore.getState();
-    const { config } = useConfigStore.getState();
     const { customer } = getAccountInfo();
 
     useAccountStore.setState({ loading: true });
 
     try {
       const response = await this.accountService?.updateCustomerConsents({
-        config,
         customer,
         consents: customerConsents,
       });
@@ -261,10 +255,9 @@ export default class AccountController {
   // noinspection JSUnusedGlobalSymbols
   getCustomerConsents = async (): Promise<GetCustomerConsentsResponse> => {
     const { getAccountInfo } = useAccountStore.getState();
-    const { config } = useConfigStore.getState();
     const { customer } = getAccountInfo();
 
-    const response = await this.accountService.getCustomerConsents({ config, customer });
+    const response = await this.accountService.getCustomerConsents({ customer });
 
     if (response?.consents) {
       useAccountStore.setState({ customerConsents: response.consents });
@@ -478,13 +471,12 @@ export default class AccountController {
   };
 
   getSocialLoginUrls = (redirectUrl: string) => {
-    const { config } = useConfigStore.getState();
     const { hasSocialURLs } = this.getFeatures();
 
     assertModuleMethod(this.accountService.getSocialUrls, 'getSocialUrls is not available in account service');
     assertFeature(hasSocialURLs, 'Social logins');
 
-    return this.accountService.getSocialUrls({ config, redirectUrl });
+    return this.accountService.getSocialUrls({ redirectUrl });
   };
 
   deleteAccountData = async (password: string) => {

--- a/packages/common/src/stores/AccountStore.ts
+++ b/packages/common/src/stores/AccountStore.ts
@@ -1,4 +1,4 @@
-import type { Consent, Customer, CustomerConsent } from '../../types/account';
+import type { CustomFormField, Customer, CustomerConsent } from '../../types/account';
 import type { Offer } from '../../types/checkout';
 import type { PaymentDetail, Subscription, Transaction } from '../../types/subscription';
 
@@ -11,7 +11,7 @@ type AccountStore = {
   transactions: Transaction[] | null;
   activePayment: PaymentDetail | null;
   customerConsents: CustomerConsent[] | null;
-  publisherConsents: Consent[] | null;
+  publisherConsents: CustomFormField[] | null;
   pendingOffer: Offer | null;
   setLoading: (loading: boolean) => void;
   getAccountInfo: () => { customerId: string; customer: Customer; customerConsents: CustomerConsent[] | null };

--- a/packages/common/src/stores/AppController.ts
+++ b/packages/common/src/stores/AppController.ts
@@ -78,17 +78,17 @@ export default class AppController {
     // update settings in the config store
     useConfigStore.setState({ settings });
 
+    // when an integration is set, we initialize the AccountController
+    if (integrationType) {
+      await getModule(AccountController).initialize(url, refreshEntitlements);
+    }
+
     if (config.features?.continueWatchingList && config.content.some((el) => el.type === PersonalShelf.ContinueWatching)) {
       await getModule(WatchHistoryController).initialize();
     }
 
     if (config.features?.favoritesList && config.content.some((el) => el.type === PersonalShelf.Favorites)) {
       await getModule(FavoritesController).initialize();
-    }
-
-    // when an integration is set, we initialize the AccountController
-    if (integrationType) {
-      await getModule(AccountController).initialize(url, refreshEntitlements);
     }
 
     return { config, settings, configSource };

--- a/packages/common/src/stores/CheckoutController.ts
+++ b/packages/common/src/stores/CheckoutController.ts
@@ -49,12 +49,13 @@ export default class CheckoutController {
   createOrder = async (offer: Offer, paymentMethodId?: number): Promise<void> => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
+    const customerIP = typeof customer?.lastUserIp === 'string' && customer.lastUserIp ? customer.lastUserIp : '';
 
     const createOrderArgs: CreateOrderArgs = {
       offer,
       customerId: customer.id,
       country: customer?.country || '',
-      customerIP: customer?.lastUserIp || '',
+      customerIP,
       paymentMethodId,
     };
 

--- a/packages/common/src/stores/FavoritesController.ts
+++ b/packages/common/src/stores/FavoritesController.ts
@@ -3,7 +3,6 @@ import { injectable } from 'inversify';
 
 import FavoriteService from '../services/FavoriteService';
 import type { PlaylistItem } from '../../types/playlist';
-import { logDev } from '../utils/common';
 
 import { useAccountStore } from './AccountStore';
 import { useFavoritesStore } from './FavoritesStore';
@@ -15,16 +14,6 @@ export default class FavoritesController {
 
   constructor(favoritesService: FavoriteService) {
     this.favoritesService = favoritesService;
-
-    // restore watch history when the user changes
-    useAccountStore.subscribe((state, previousState) => {
-      const isLoggedIn = !!state.user && !previousState.user;
-      const isLoggedOut = !state.user && !!previousState.user;
-
-      if (isLoggedIn || isLoggedOut) {
-        this.restoreFavorites().catch(logDev);
-      }
-    });
   }
 
   initialize = async () => {

--- a/packages/common/src/stores/FavoritesController.ts
+++ b/packages/common/src/stores/FavoritesController.ts
@@ -32,7 +32,7 @@ export default class FavoritesController {
         ...state,
         user: {
           ...(state.user as Customer),
-          externalData: { ...state.user?.externalData, favorites: this.serializeFavorites(favorites) },
+          metadata: { ...state.user?.metadata, favorites: this.serializeFavorites(favorites) },
         },
       }));
     }

--- a/packages/common/src/stores/FavoritesController.ts
+++ b/packages/common/src/stores/FavoritesController.ts
@@ -37,7 +37,7 @@ export default class FavoritesController {
     const { favorites } = useFavoritesStore.getState();
     const { user } = useAccountStore.getState();
 
-    await this.favoritesService.persistFavorites(user, favorites);
+    await this.favoritesService.persistFavorites(favorites, user);
   };
 
   saveItem = async (item: PlaylistItem) => {

--- a/packages/common/src/stores/ProfileController.ts
+++ b/packages/common/src/stores/ProfileController.ts
@@ -2,12 +2,12 @@ import { inject, injectable } from 'inversify';
 import type { ProfilesData } from '@inplayer-org/inplayer.js';
 import * as yup from 'yup';
 
-import type { EnterProfilePayload, ProfileDetailsPayload, ProfilePayload } from '../../types/account';
 import ProfileService from '../services/integrations/ProfileService';
 import type { IntegrationType } from '../../types/config';
 import { assertModuleMethod, getNamedModule } from '../modules/container';
 import StorageService from '../services/StorageService';
 import { INTEGRATION_TYPE } from '../modules/types';
+import type { EnterProfilePayload, ProfileDetailsPayload, ProfilePayload } from '../../types/profiles';
 
 import { useProfileStore } from './ProfileStore';
 
@@ -68,9 +68,7 @@ export default class ProfileController {
   enterProfile = async ({ id, pin }: EnterProfilePayload) => {
     assertModuleMethod(this.profileService?.enterProfile, 'enterProfile is not available in profile service');
 
-    const response = await this.profileService.enterProfile({ id, pin });
-
-    const profile = response?.responseData;
+    const profile = await this.profileService.enterProfile({ id, pin });
 
     if (!profile) {
       throw new Error('Unable to enter profile');

--- a/packages/common/src/stores/ProfileStore.ts
+++ b/packages/common/src/stores/ProfileStore.ts
@@ -1,6 +1,6 @@
 import defaultAvatar from '@jwp/ott-theme/assets/profiles/default_avatar.png';
 
-import type { Profile } from '../../types/account';
+import type { Profile } from '../../types/profiles';
 
 import { createStore } from './utils';
 

--- a/packages/common/src/stores/WatchHistoryController.ts
+++ b/packages/common/src/stores/WatchHistoryController.ts
@@ -3,7 +3,6 @@ import { injectable } from 'inversify';
 import WatchHistoryService from '../services/WatchHistoryService';
 import type { PlaylistItem } from '../../types/playlist';
 import type { WatchHistoryItem } from '../../types/watchHistory';
-import { logDev } from '../utils/common';
 
 import { useAccountStore } from './AccountStore';
 import { useConfigStore } from './ConfigStore';
@@ -15,16 +14,6 @@ export default class WatchHistoryController {
 
   constructor(watchHistoryService: WatchHistoryService) {
     this.watchHistoryService = watchHistoryService;
-
-    // restore watch history when the user changes
-    useAccountStore.subscribe((state, previousState) => {
-      const isLoggedIn = !!state.user && !previousState.user;
-      const isLoggedOut = !state.user && !!previousState.user;
-
-      if (isLoggedIn || isLoggedOut) {
-        this.restoreWatchHistory().catch(logDev);
-      }
-    });
   }
 
   initialize = async () => {

--- a/packages/common/src/stores/WatchHistoryController.ts
+++ b/packages/common/src/stores/WatchHistoryController.ts
@@ -1,13 +1,9 @@
-import { inject, injectable } from 'inversify';
+import { injectable } from 'inversify';
 
 import WatchHistoryService from '../services/WatchHistoryService';
-import AccountService from '../services/integrations/AccountService';
 import type { PlaylistItem } from '../../types/playlist';
-import type { SerializedWatchHistoryItem, WatchHistoryItem } from '../../types/watchHistory';
-import type { Customer } from '../../types/account';
-import type { IntegrationType } from '../../types/config';
-import { getNamedModule } from '../modules/container';
-import { INTEGRATION_TYPE } from '../modules/types';
+import type { WatchHistoryItem } from '../../types/watchHistory';
+import { logDev } from '../utils/common';
 
 import { useAccountStore } from './AccountStore';
 import { useConfigStore } from './ConfigStore';
@@ -16,29 +12,19 @@ import { useWatchHistoryStore } from './WatchHistoryStore';
 @injectable()
 export default class WatchHistoryController {
   private readonly watchHistoryService: WatchHistoryService;
-  private readonly accountService?: AccountService;
 
-  constructor(@inject(INTEGRATION_TYPE) integrationType: IntegrationType, watchHistoryService: WatchHistoryService) {
+  constructor(watchHistoryService: WatchHistoryService) {
     this.watchHistoryService = watchHistoryService;
-    this.accountService = getNamedModule(AccountService, integrationType, false);
-  }
 
-  serializeWatchHistory = (watchHistory: WatchHistoryItem[]): SerializedWatchHistoryItem[] => {
-    return this.watchHistoryService.serializeWatchHistory(watchHistory);
-  };
+    // restore watch history when the user changes
+    useAccountStore.subscribe((state, previousState) => {
+      const isLoggedIn = !!state.user && !previousState.user;
+      const isLoggedOut = !state.user && !!previousState.user;
 
-  private updateUserWatchHistory(watchHistory: WatchHistoryItem[]) {
-    const { user } = useAccountStore.getState();
-
-    if (user) {
-      useAccountStore.setState((state) => ({
-        ...state,
-        user: {
-          ...(state.user as Customer),
-          metadata: { ...state.user?.metadata, history: this.serializeWatchHistory(watchHistory) },
-        },
-      }));
-    }
+      if (isLoggedIn || isLoggedOut) {
+        this.restoreWatchHistory().catch(logDev);
+      }
+    });
   }
 
   initialize = async () => {
@@ -55,24 +41,18 @@ export default class WatchHistoryController {
 
     const watchHistory = await this.watchHistoryService.getWatchHistory(user, continueWatchingList);
 
-    if (watchHistory?.length) {
-      useWatchHistoryStore.setState({
-        watchHistory: watchHistory.filter((item): item is WatchHistoryItem => !!item?.mediaid),
-        playlistItemsLoaded: true,
-        continueWatchingPlaylistId: continueWatchingList,
-      });
-    }
+    useWatchHistoryStore.setState({
+      watchHistory: watchHistory.filter((item): item is WatchHistoryItem => !!item?.mediaid),
+      playlistItemsLoaded: true,
+      continueWatchingPlaylistId: continueWatchingList,
+    });
   };
 
   persistWatchHistory = async () => {
     const { watchHistory } = useWatchHistoryStore.getState();
     const { user } = useAccountStore.getState();
 
-    if (user?.id && user?.externalData) {
-      return this.accountService?.updatePersonalShelves({ id: user.id, externalData: user.externalData });
-    }
-
-    this.watchHistoryService.persistWatchHistory(watchHistory);
+    await this.watchHistoryService.persistWatchHistory(user, watchHistory);
   };
 
   /**
@@ -92,7 +72,6 @@ export default class WatchHistoryController {
 
     if (updatedHistory) {
       useWatchHistoryStore.setState({ watchHistory: updatedHistory });
-      this.updateUserWatchHistory(updatedHistory);
       await this.persistWatchHistory();
     }
   };

--- a/packages/common/src/stores/WatchHistoryController.ts
+++ b/packages/common/src/stores/WatchHistoryController.ts
@@ -41,7 +41,7 @@ export default class WatchHistoryController {
     const { watchHistory } = useWatchHistoryStore.getState();
     const { user } = useAccountStore.getState();
 
-    await this.watchHistoryService.persistWatchHistory(user, watchHistory);
+    await this.watchHistoryService.persistWatchHistory(watchHistory, user);
   };
 
   /**

--- a/packages/common/src/stores/WatchHistoryController.ts
+++ b/packages/common/src/stores/WatchHistoryController.ts
@@ -35,7 +35,7 @@ export default class WatchHistoryController {
         ...state,
         user: {
           ...(state.user as Customer),
-          externalData: { ...state.user?.externalData, history: this.serializeWatchHistory(watchHistory) },
+          metadata: { ...state.user?.metadata, history: this.serializeWatchHistory(watchHistory) },
         },
       }));
     }

--- a/packages/common/src/utils/collection.ts
+++ b/packages/common/src/utils/collection.ts
@@ -1,4 +1,4 @@
-import type { Consent, CustomerConsent } from '../../types/account';
+import type { CustomFormField, CustomerConsent } from '../../types/account';
 import type { Config } from '../../types/config';
 import type { GenericFormValues } from '../../types/form';
 import type { Playlist, PlaylistItem } from '../../types/playlist';
@@ -57,7 +57,7 @@ const generatePlaylistPlaceholder = (playlistLength: number = 15): Playlist => (
   ),
 });
 
-const formatConsentValues = (publisherConsents: Consent[] | null = [], customerConsents: CustomerConsent[] | null = []) => {
+const formatConsentValues = (publisherConsents: CustomFormField[] | null = [], customerConsents: CustomerConsent[] | null = []) => {
   if (!publisherConsents || !customerConsents) {
     return {};
   }
@@ -76,7 +76,7 @@ const formatConsentValues = (publisherConsents: Consent[] | null = [], customerC
   return values;
 };
 
-const formatConsents = (publisherConsents: Consent[] | null = [], customerConsents: CustomerConsent[] | null = []) => {
+const formatConsents = (publisherConsents: CustomFormField[] | null = [], customerConsents: CustomerConsent[] | null = []) => {
   if (!publisherConsents || !customerConsents) {
     return {};
   }
@@ -90,7 +90,7 @@ const formatConsents = (publisherConsents: Consent[] | null = [], customerConsen
   return values;
 };
 
-const extractConsentValues = (consents?: Consent[]) => {
+const extractConsentValues = (consents?: CustomFormField[]) => {
   const values: Record<string, string | boolean> = {};
 
   if (!consents) {
@@ -104,7 +104,7 @@ const extractConsentValues = (consents?: Consent[]) => {
   return values;
 };
 
-const formatConsentsFromValues = (publisherConsents: Consent[] | null, values?: GenericFormValues) => {
+const formatConsentsFromValues = (publisherConsents: CustomFormField[] | null, values?: GenericFormValues) => {
   const consents: CustomerConsent[] = [];
 
   if (!publisherConsents || !values) return consents;
@@ -121,7 +121,7 @@ const formatConsentsFromValues = (publisherConsents: Consent[] | null, values?: 
   return consents;
 };
 
-const checkConsentsFromValues = (publisherConsents: Consent[], consents: Record<string, string | boolean>) => {
+const checkConsentsFromValues = (publisherConsents: CustomFormField[], consents: Record<string, string | boolean>) => {
   const customerConsents: CustomerConsent[] = [];
   const consentsErrors: string[] = [];
 

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -1,7 +1,5 @@
 import type { ProfilesData } from '@inplayer-org/inplayer.js';
 
-import type { SerializedWatchHistoryItem } from './watchHistory';
-import type { SerializedFavorite } from './favorite';
 import type { Config } from './config';
 import type { EmptyServiceRequest, EnvironmentServiceRequest, PromiseRequest } from './service';
 
@@ -89,15 +87,6 @@ export type RegisterPayload = PayloadWithIPOverride & {
   externalData?: string;
 };
 
-export type RegisterArgs = {
-  config: Config;
-  user: RegisterPayload;
-};
-export type CaptureFirstNameLastName = {
-  firstName: string;
-  lastName: string;
-};
-
 export type CleengCaptureField = {
   key: string;
   enabled: boolean;
@@ -128,16 +117,8 @@ export type PersonalDetailsFormData = {
   country: string;
 };
 
-export type GetPublisherConsentsPayload = {
-  publisherId: string;
-};
-
 export type GetPublisherConsentsResponse = {
   consents: Consent[];
-};
-
-export type GetCustomerConsentsPayload = {
-  customerId: string;
 };
 
 export type GetCustomerConsentsResponse = {
@@ -163,22 +144,12 @@ export type ChangePasswordWithOldPasswordPayload = {
   newPasswordConfirmation: string;
 };
 
-export type GetCustomerPayload = {
-  customerId: string;
-};
-
 export type UpdateCustomerPayload = {
   id?: string;
   email?: string;
   confirmationPassword?: string;
   firstName?: string;
   lastName?: string;
-  externalData?: ExternalData;
-};
-
-export type ExternalData = {
-  history?: SerializedWatchHistoryItem[];
-  favorites?: SerializedFavorite[];
 };
 
 export type UpdateCustomerConsentsPayload = {
@@ -203,7 +174,6 @@ export type UpdateCustomerArgs = {
   confirmationPassword?: string | undefined;
   firstName?: string | undefined;
   lastName?: string | undefined;
-  externalData?: ExternalData | undefined;
   metadata?: Record<string, unknown>;
   fullName?: string;
 };
@@ -253,10 +223,6 @@ export type LocalesData = {
   ipAddress: string;
 };
 
-export type GetCaptureStatusPayload = {
-  customerId: string;
-};
-
 export type GetCaptureStatusResponse = {
   isCaptureEnabled: boolean;
   shouldCaptureBeDisplayed: boolean;
@@ -294,14 +260,6 @@ export type UpdateCaptureStatusArgs = {
 export type UpdateCaptureAnswersPayload = {
   customerId: string;
 } & Capture;
-
-export type UpdatePersonalShelvesArgs = {
-  id: string;
-  externalData: {
-    history?: SerializedWatchHistoryItem[];
-    favorites?: SerializedFavorite[];
-  };
-};
 
 export type Profile = ProfilesData;
 
@@ -370,17 +328,14 @@ export type SocialURLs =
 
 export type Login = PromiseRequest<LoginArgs, AuthResponse>;
 export type Register = PromiseRequest<RegistrationArgs, AuthResponse>;
-export type GetCustomer = EnvironmentServiceRequest<GetCustomerPayload, Customer>;
-export type UpdateCustomer = EnvironmentServiceRequest<UpdateCustomerArgs, Customer>;
 export type GetPublisherConsents = PromiseRequest<Config, GetPublisherConsentsResponse>;
 export type GetCustomerConsents = PromiseRequest<CustomerConsentArgs, GetCustomerConsentsResponse>;
 export type UpdateCustomerConsents = PromiseRequest<UpdateCustomerConsentsArgs, GetCustomerConsentsResponse>;
 export type GetCaptureStatus = EnvironmentServiceRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
-export type UpdateCaptureAnswers = EnvironmentServiceRequest<UpdateCaptureStatusArgs, Capture>;
+export type UpdateCaptureAnswers = PromiseRequest<UpdateCaptureStatusArgs, Customer>;
 export type ResetPassword = EnvironmentServiceRequest<ResetPasswordPayload, Record<string, unknown>>;
 export type ChangePassword = EnvironmentServiceRequest<ChangePasswordWithTokenPayload, unknown>;
 export type ChangePasswordWithOldPassword = EnvironmentServiceRequest<ChangePasswordWithOldPasswordPayload, unknown>;
-export type UpdatePersonalShelves = EnvironmentServiceRequest<UpdatePersonalShelvesArgs, Customer | Record<string, unknown>>;
 export type GetLocales = EmptyServiceRequest<LocalesData>;
 export type ExportAccountData = EnvironmentServiceRequest<undefined, CommonAccountResponse>;
 export type GetSocialURLs = PromiseRequest<GetSocialURLsPayload, SocialURLs[]>;

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -1,7 +1,7 @@
 import type { ProfilesData } from '@inplayer-org/inplayer.js';
 
 import type { Config } from './config';
-import type { EmptyServiceRequest, EnvironmentServiceRequest, PromiseRequest } from './service';
+import type { EnvironmentServiceRequest, PromiseRequest } from './service';
 
 export type AuthData = {
   jwt: string;
@@ -117,10 +117,6 @@ export type PersonalDetailsFormData = {
   country: string;
 };
 
-export type GetPublisherConsentsResponse = {
-  consents: Consent[];
-};
-
 export type GetCustomerConsentsResponse = {
   consents: CustomerConsent[];
 };
@@ -180,8 +176,8 @@ export type UpdateCustomerArgs = {
 
 export type CustomRegisterFieldVariant = 'input' | 'select' | 'country' | 'us_state' | 'radio' | 'checkbox' | 'datepicker';
 
-export interface Consent {
-  type?: CustomRegisterFieldVariant;
+export interface CustomFormField {
+  type: CustomRegisterFieldVariant;
   isCustomRegisterField?: boolean;
   enabledByDefault?: boolean;
   defaultValue?: string;
@@ -214,13 +210,6 @@ export type CustomerConsentArgs = {
 export type UpdateCustomerConsentsArgs = {
   customer: Customer;
   consents: CustomerConsent[];
-};
-
-export type LocalesData = {
-  country: string;
-  currency: string;
-  locale: string;
-  ipAddress: string;
 };
 
 export type GetCaptureStatusResponse = {
@@ -328,15 +317,16 @@ export type SocialURLs =
 
 export type Login = PromiseRequest<LoginArgs, AuthResponse>;
 export type Register = PromiseRequest<RegistrationArgs, AuthResponse>;
-export type GetPublisherConsents = PromiseRequest<Config, GetPublisherConsentsResponse>;
-export type GetCustomerConsents = PromiseRequest<CustomerConsentArgs, GetCustomerConsentsResponse>;
-export type UpdateCustomerConsents = PromiseRequest<UpdateCustomerConsentsArgs, GetCustomerConsentsResponse>;
+export type GetPublisherConsents = PromiseRequest<Config, CustomFormField[]>;
+export type GetCustomerConsents = PromiseRequest<CustomerConsentArgs, CustomerConsent[]>;
+export type UpdateCustomerConsents = PromiseRequest<UpdateCustomerConsentsArgs, CustomerConsent[]>;
+
+// todo
 export type GetCaptureStatus = EnvironmentServiceRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
 export type UpdateCaptureAnswers = PromiseRequest<UpdateCaptureStatusArgs, Customer>;
 export type ResetPassword = EnvironmentServiceRequest<ResetPasswordPayload, Record<string, unknown>>;
 export type ChangePassword = EnvironmentServiceRequest<ChangePasswordWithTokenPayload, unknown>;
 export type ChangePasswordWithOldPassword = EnvironmentServiceRequest<ChangePasswordWithOldPasswordPayload, unknown>;
-export type GetLocales = EmptyServiceRequest<LocalesData>;
 export type ExportAccountData = EnvironmentServiceRequest<undefined, CommonAccountResponse>;
 export type GetSocialURLs = PromiseRequest<GetSocialURLsPayload, SocialURLs[]>;
 export type NotificationsData = PromiseRequest<SubscribeToNotificationsPayload, boolean>;

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -1,7 +1,7 @@
-import type { ProfilesData } from '@inplayer-org/inplayer.js';
-
 import type { Config } from './config';
-import type { EnvironmentServiceRequest, PromiseRequest } from './service';
+import type { PromiseRequest } from './service';
+import type { SerializedWatchHistoryItem } from './watchHistory';
+import type { SerializedFavorite } from './favorite';
 
 export type AuthData = {
   jwt: string;
@@ -71,6 +71,15 @@ export type OfferType = 'svod' | 'tvod';
 
 export type ChooseOfferFormData = {
   offerId?: string;
+};
+
+export type GetUserArgs = {
+  config: Config;
+};
+
+export type GetUserPayload = {
+  user: Customer;
+  customerConsents: CustomerConsent[];
 };
 
 export type RegisterPayload = PayloadWithIPOverride & {
@@ -203,8 +212,7 @@ export type CustomerConsent = {
 };
 
 export type CustomerConsentArgs = {
-  customerId?: string;
-  customer?: Customer;
+  customer: Customer;
 };
 
 export type UpdateCustomerConsentsArgs = {
@@ -250,30 +258,6 @@ export type UpdateCaptureAnswersPayload = {
   customerId: string;
 } & Capture;
 
-export type Profile = ProfilesData;
-
-export type ProfilePayload = {
-  id?: string;
-  name: string;
-  adult: boolean;
-  avatar_url?: string;
-  pin?: number;
-};
-
-export type EnterProfilePayload = {
-  id: string;
-  pin?: number;
-};
-
-export type ProfileDetailsPayload = {
-  id: string;
-};
-
-export type ListProfilesResponse = {
-  canManageProfiles: boolean;
-  collection: ProfilesData[];
-};
-
 export type FirstLastNameInput = {
   firstName: string;
   lastName: string;
@@ -315,25 +299,43 @@ export type SocialURLs =
       google: string;
     };
 
+export type UpdateWatchHistoryArgs = {
+  id: string;
+  history: SerializedWatchHistoryItem[];
+};
+
+export type UpdateFavoritesArgs = {
+  id: string;
+  favorites: SerializedFavorite[];
+};
+
+export type GetFavoritesArgs = {
+  user: Customer;
+};
+
+export type GetWatchHistoryArgs = {
+  user: Customer;
+};
+
+export type GetAuthData = () => Promise<AuthData | null>;
 export type Login = PromiseRequest<LoginArgs, AuthResponse>;
 export type Register = PromiseRequest<RegistrationArgs, AuthResponse>;
+export type GetUser = PromiseRequest<GetUserArgs, GetUserPayload>;
+export type Logout = () => Promise<void>;
+export type UpdateCustomer = PromiseRequest<UpdateCustomerArgs, Customer>;
 export type GetPublisherConsents = PromiseRequest<Config, CustomFormField[]>;
 export type GetCustomerConsents = PromiseRequest<CustomerConsentArgs, CustomerConsent[]>;
 export type UpdateCustomerConsents = PromiseRequest<UpdateCustomerConsentsArgs, CustomerConsent[]>;
-
-// todo
-export type GetCaptureStatus = EnvironmentServiceRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
+export type GetCaptureStatus = PromiseRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
 export type UpdateCaptureAnswers = PromiseRequest<UpdateCaptureStatusArgs, Customer>;
-export type ResetPassword = EnvironmentServiceRequest<ResetPasswordPayload, Record<string, unknown>>;
-export type ChangePassword = EnvironmentServiceRequest<ChangePasswordWithTokenPayload, unknown>;
-export type ChangePasswordWithOldPassword = EnvironmentServiceRequest<ChangePasswordWithOldPasswordPayload, unknown>;
-export type ExportAccountData = EnvironmentServiceRequest<undefined, CommonAccountResponse>;
+export type ResetPassword = PromiseRequest<ResetPasswordPayload, void>;
+export type ChangePassword = PromiseRequest<ChangePasswordWithTokenPayload, void>;
+export type ChangePasswordWithOldPassword = PromiseRequest<ChangePasswordWithOldPasswordPayload, void>;
 export type GetSocialURLs = PromiseRequest<GetSocialURLsPayload, SocialURLs[]>;
 export type NotificationsData = PromiseRequest<SubscribeToNotificationsPayload, boolean>;
-export type DeleteAccount = EnvironmentServiceRequest<DeleteAccountPayload, CommonAccountResponse>;
-export type ListProfiles = EnvironmentServiceRequest<undefined, ListProfilesResponse>;
-export type CreateProfile = EnvironmentServiceRequest<ProfilePayload, ProfilesData>;
-export type UpdateProfile = EnvironmentServiceRequest<ProfilePayload, ProfilesData>;
-export type EnterProfile = EnvironmentServiceRequest<EnterProfilePayload, ProfilesData>;
-export type GetProfileDetails = EnvironmentServiceRequest<ProfileDetailsPayload, ProfilesData>;
-export type DeleteProfile = EnvironmentServiceRequest<ProfileDetailsPayload, CommonAccountResponse>;
+export type UpdateWatchHistory = PromiseRequest<UpdateWatchHistoryArgs, void>;
+export type UpdateFavorites = PromiseRequest<UpdateFavoritesArgs, void>;
+export type GetWatchHistory = PromiseRequest<GetWatchHistoryArgs, SerializedWatchHistoryItem[]>;
+export type GetFavorites = PromiseRequest<GetFavoritesArgs, SerializedFavorite[]>;
+export type ExportAccountData = PromiseRequest<undefined, CommonAccountResponse>;
+export type DeleteAccount = PromiseRequest<DeleteAccountPayload, CommonAccountResponse>;

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -300,12 +300,12 @@ export type SocialURLs =
     };
 
 export type UpdateWatchHistoryArgs = {
-  id: string;
+  user: Customer;
   history: SerializedWatchHistoryItem[];
 };
 
 export type UpdateFavoritesArgs = {
-  id: string;
+  user: Customer;
   favorites: SerializedFavorite[];
 };
 

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -21,7 +21,6 @@ export type PayloadWithIPOverride = {
 };
 
 export type LoginArgs = {
-  config: Config;
   email: string;
   password: string;
   referrer: string;
@@ -190,17 +189,12 @@ export type UpdateCustomerConsentsPayload = {
 export type Customer = {
   id: string;
   email: string;
-  country: string;
-  regDate: string;
-  lastLoginDate?: string;
-  lastUserIp: string;
   firstName?: string;
-  metadata?: Record<string, unknown>;
+  country?: string;
+  metadata: Record<string, unknown>;
   lastName?: string;
   fullName?: string;
-  uuid?: string;
-  externalId?: string;
-  externalData?: ExternalData;
+  [key: string]: unknown;
 };
 
 export type UpdateCustomerArgs = {
@@ -243,13 +237,11 @@ export type CustomerConsent = {
 };
 
 export type CustomerConsentArgs = {
-  config: Config;
   customerId?: string;
   customer?: Customer;
 };
 
 export type UpdateCustomerConsentsArgs = {
-  config: Config;
   customer: Customer;
   consents: CustomerConsent[];
 };
@@ -362,7 +354,6 @@ export type SubscribeToNotificationsPayload = {
 };
 
 export type GetSocialURLsPayload = {
-  config: Config;
   redirectUrl: string;
 };
 

--- a/packages/common/types/inplayer.ts
+++ b/packages/common/types/inplayer.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from 'axios';
-
 export type InPlayerAuthData = {
   access_token: string;
   expires?: number;
@@ -12,11 +10,4 @@ export type InPlayerError = {
       message: string;
     };
   };
-};
-
-export type InPlayerResponse<T> = {
-  data: T;
-  status: number;
-  statusText: string;
-  config: AxiosRequestConfig;
 };

--- a/packages/common/types/profiles.ts
+++ b/packages/common/types/profiles.ts
@@ -1,8 +1,42 @@
-import type { ProfilePayload } from './account';
+import type { ProfilesData } from '@inplayer-org/inplayer.js';
 
-export type ProfileFormValues = Omit<ProfilePayload, 'adult'> & { adult: string };
+import type { PromiseRequest } from './service';
+import type { CommonAccountResponse } from './account';
+
+export type Profile = ProfilesData;
+
+export type ProfilePayload = {
+  id?: string;
+  name: string;
+  adult: boolean;
+  avatar_url?: string;
+  pin?: number;
+};
+
+export type EnterProfilePayload = {
+  id: string;
+  pin?: number;
+};
+
+export type ProfileDetailsPayload = {
+  id: string;
+};
+
+export type ListProfilesResponse = {
+  canManageProfiles: boolean;
+  collection: ProfilesData[];
+};
 
 export type ProfileFormSubmitError = {
   code: number;
   message: string;
 };
+
+export type ProfileFormValues = Omit<ProfilePayload, 'adult'> & { adult: string };
+
+export type ListProfiles = PromiseRequest<undefined, ListProfilesResponse>;
+export type CreateProfile = PromiseRequest<ProfilePayload, ProfilesData>;
+export type UpdateProfile = PromiseRequest<ProfilePayload, ProfilesData>;
+export type EnterProfile = PromiseRequest<EnterProfilePayload, ProfilesData>;
+export type GetProfileDetails = PromiseRequest<ProfileDetailsPayload, ProfilesData>;
+export type DeleteProfile = PromiseRequest<ProfileDetailsPayload, CommonAccountResponse>;

--- a/packages/hooks-react/src/useProfiles.ts
+++ b/packages/hooks-react/src/useProfiles.ts
@@ -2,15 +2,14 @@ import type { ProfilesData } from '@inplayer-org/inplayer.js';
 import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions } from 'react-query';
 import { useTranslation } from 'react-i18next';
 import type { GenericFormErrors } from '@jwp/ott-common/types/form';
-import type { CommonAccountResponse, ListProfilesResponse, ProfileDetailsPayload, ProfilePayload } from '@jwp/ott-common/types/account';
-import type { ProfileFormSubmitError, ProfileFormValues } from '@jwp/ott-common/types/profiles';
+import type { CommonAccountResponse } from '@jwp/ott-common/types/account';
+import type { ListProfilesResponse, ProfileDetailsPayload, ProfileFormSubmitError, ProfileFormValues, ProfilePayload } from '@jwp/ott-common/types/profiles';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useProfileStore } from '@jwp/ott-common/src/stores/ProfileStore';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import ProfileController from '@jwp/ott-common/src/stores/ProfileController';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { logDev } from '@jwp/ott-common/src/utils/common';
-import type { ServiceResponse } from '@jwp/ott-common/types/service';
 
 export const useSelectProfile = (options?: { onSuccess: () => void; onError: () => void }) => {
   const accountController = getModule(AccountController, false);
@@ -33,12 +32,12 @@ export const useSelectProfile = (options?: { onSuccess: () => void; onError: () 
   });
 };
 
-export const useCreateProfile = (options?: UseMutationOptions<ServiceResponse<ProfilesData> | undefined, unknown, ProfilePayload, unknown>) => {
+export const useCreateProfile = (options?: UseMutationOptions<ProfilesData | undefined, unknown, ProfilePayload, unknown>) => {
   const { query: listProfiles } = useProfiles();
 
   const profileController = getModule(ProfileController, false);
 
-  return useMutation<ServiceResponse<ProfilesData> | undefined, unknown, ProfilePayload, unknown>(async (data) => profileController?.createProfile(data), {
+  return useMutation<ProfilesData | undefined, unknown, ProfilePayload, unknown>(async (data) => profileController?.createProfile(data), {
     ...options,
     onSuccess: (data, variables, context) => {
       listProfiles.refetch();
@@ -48,7 +47,7 @@ export const useCreateProfile = (options?: UseMutationOptions<ServiceResponse<Pr
   });
 };
 
-export const useUpdateProfile = (options?: UseMutationOptions<ServiceResponse<ProfilesData> | undefined, unknown, ProfilePayload, unknown>) => {
+export const useUpdateProfile = (options?: UseMutationOptions<ProfilesData | undefined, unknown, ProfilePayload, unknown>) => {
   const { query: listProfiles } = useProfiles();
 
   const profileController = getModule(ProfileController, false);
@@ -63,22 +62,19 @@ export const useUpdateProfile = (options?: UseMutationOptions<ServiceResponse<Pr
   });
 };
 
-export const useDeleteProfile = (options?: UseMutationOptions<ServiceResponse<CommonAccountResponse> | undefined, unknown, ProfileDetailsPayload, unknown>) => {
+export const useDeleteProfile = (options?: UseMutationOptions<CommonAccountResponse | undefined, unknown, ProfileDetailsPayload, unknown>) => {
   const { query: listProfiles } = useProfiles();
 
   const profileController = getModule(ProfileController, false);
 
-  return useMutation<ServiceResponse<CommonAccountResponse> | undefined, unknown, ProfileDetailsPayload, unknown>(
-    async (id) => profileController?.deleteProfile(id),
-    {
-      ...options,
-      onSuccess: (...args) => {
-        listProfiles.refetch();
+  return useMutation<CommonAccountResponse | undefined, unknown, ProfileDetailsPayload, unknown>(async (id) => profileController?.deleteProfile(id), {
+    ...options,
+    onSuccess: (...args) => {
+      listProfiles.refetch();
 
-        options?.onSuccess?.(...args);
-      },
+      options?.onSuccess?.(...args);
     },
-  );
+  });
 };
 
 export const isProfileFormSubmitError = (e: unknown): e is ProfileFormSubmitError => {
@@ -97,9 +93,7 @@ export const useProfileErrorHandler = () => {
   };
 };
 
-export const useProfiles = (
-  options?: UseQueryOptions<ServiceResponse<ListProfilesResponse> | undefined, unknown, ServiceResponse<ListProfilesResponse> | undefined, string[]>,
-) => {
+export const useProfiles = (options?: UseQueryOptions<ListProfilesResponse | undefined, unknown, ListProfilesResponse | undefined, string[]>) => {
   const { user } = useAccountStore();
   const isLoggedIn = !!user;
 
@@ -114,6 +108,6 @@ export const useProfiles = (
 
   return {
     query,
-    profilesEnabled: !!query.data?.responseData.canManageProfiles,
+    profilesEnabled: !!query.data?.canManageProfiles,
   };
 };

--- a/packages/testing/fixtures/customer.json
+++ b/packages/testing/fixtures/customer.json
@@ -8,35 +8,23 @@
   "lastLoginDate": "2021-07-26 16:54:38",
   "lastUserIp": "123.123.123.123",
   "externalId": "",
-  "externalData": {
+  "metadata": {
     "history": [
       {
-        "tags": "Movie,Drama",
-        "title": "The Omega Code",
         "mediaid": "YzUqQnrx",
-        "duration": 5968,
         "progress": 0.3710328907847994
       },
       {
-        "tags": "Trailer",
-        "title": "The Omega Code Official Trailer",
         "mediaid": "k6K5ugEC",
-        "duration": 113,
         "progress": 0.448087431693989
       }
     ],
     "favorites": [
       {
-        "tags": "Movie",
-        "title": "Megiddo The Omega Code 2",
-        "mediaid": "2v7rOqOE",
-        "duration": 6341
+        "mediaid": "2v7rOqOE"
       },
       {
-        "tags": "Laurie Crouch,Matt Crouch,Ron Luce,Episode,The State of Faith,seriesId_740sLvW8",
-        "title": "Praise | State Of Faith: China | March 25, 2021",
-        "mediaid": "5cMy3jIp",
-        "duration": 3376
+        "mediaid": "5cMy3jIp"
       }
     ]
   }

--- a/packages/ui-react/src/components/Account/Account.test.tsx
+++ b/packages/ui-react/src/components/Account/Account.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Consent } from '@jwp/ott-common/types/account';
+import type { CustomFormField } from '@jwp/ott-common/types/account';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import customer from '@jwp/ott-testing/fixtures/customer.json';
@@ -19,7 +19,7 @@ describe('<Account>', () => {
   test('renders and matches snapshot', () => {
     useAccountStore.setState({
       user: customer,
-      publisherConsents: Array.of({ name: 'marketing', label: 'Receive Marketing Emails' } as Consent),
+      publisherConsents: Array.of({ name: 'marketing', label: 'Receive Marketing Emails' } as CustomFormField),
     });
 
     const { container } = renderWithRouter(<Account panelClassName={'panel-class'} panelHeaderClassName={'header-class'} canUpdateEmail={true} />);

--- a/packages/ui-react/src/components/Account/Account.tsx
+++ b/packages/ui-react/src/components/Account/Account.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
 import DOMPurify from 'dompurify';
 import { useMutation } from 'react-query';
-import type { Consent } from '@jwp/ott-common/types/account';
+import type { CustomFormField } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
@@ -75,8 +75,8 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
   const shouldAddPassword = (isSocialLogin && !customer?.metadata?.has_password) || false;
 
   const [termsConsents, nonTermsConsents] = useMemo(() => {
-    const terms: Consent[] = [];
-    const nonTerms: Consent[] = [];
+    const terms: CustomFormField[] = [];
+    const nonTerms: CustomFormField[] = [];
 
     publisherConsents?.forEach((consent) => {
       if (!consent?.type || consent?.type === 'checkbox') {

--- a/packages/ui-react/src/components/Header/Header.tsx
+++ b/packages/ui-react/src/components/Header/Header.tsx
@@ -1,13 +1,13 @@
 import React, { type ReactNode, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import type { Profile } from '@jwp/ott-common/types/account';
 import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 import type { LanguageDefinition } from '@jwp/ott-common/types/i18n';
 import Menu from '@jwp/ott-theme/assets/icons/menu.svg?react';
 import SearchIcon from '@jwp/ott-theme/assets/icons/search.svg?react';
 import CloseIcon from '@jwp/ott-theme/assets/icons/close.svg?react';
 import AccountCircle from '@jwp/ott-theme/assets/icons/account_circle.svg?react';
+import type { Profile } from '@jwp/ott-common/types/profiles';
 
 import SearchBar, { type Props as SearchBarProps } from '../SearchBar/SearchBar';
 import Logo from '../Logo/Logo';

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import DOMPurify from 'dompurify';
 import type { FormErrors } from '@jwp/ott-common/types/form';
-import type { Consent, RegistrationFormData } from '@jwp/ott-common/types/account';
+import type { CustomFormField, RegistrationFormData } from '@jwp/ott-common/types/account';
 import { testId } from '@jwp/ott-common/src/utils/common';
 import useToggle from '@jwp/ott-hooks-react/src/useToggle';
 import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
@@ -34,7 +34,7 @@ type Props = {
   consentErrors: string[];
   submitting: boolean;
   canSubmit: boolean;
-  publisherConsents?: Consent[];
+  publisherConsents?: CustomFormField[];
 };
 
 const RegistrationForm: React.FC<Props> = ({

--- a/packages/ui-react/src/components/UserMenu/ProfilesMenu/ProfilesMenu.tsx
+++ b/packages/ui-react/src/components/UserMenu/ProfilesMenu/ProfilesMenu.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type { UseMutateFunction } from 'react-query';
-import type { Profile } from '@jwp/ott-common/types/account';
 import Plus from '@jwp/ott-theme/assets/icons/plus.svg?react';
+import type { Profile } from '@jwp/ott-common/types/profiles';
 
 import styles from '../UserMenu.module.scss';
 import LoadingOverlay from '../../LoadingOverlay/LoadingOverlay';

--- a/packages/ui-react/src/components/UserMenu/UserMenu.tsx
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import type { Profile } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import AccountCircle from '@jwp/ott-theme/assets/icons/account_circle.svg?react';
@@ -11,6 +10,7 @@ import BalanceWallet from '@jwp/ott-theme/assets/icons/balance_wallet.svg?react'
 import Exit from '@jwp/ott-theme/assets/icons/exit.svg?react';
 import { PATH_USER_ACCOUNT, PATH_USER_FAVORITES, PATH_USER_PAYMENTS, PATH_USER_PROFILES_CREATE } from '@jwp/ott-common/src/paths';
 import { userProfileURL } from '@jwp/ott-common/src/utils/urlFormatting';
+import type { Profile } from '@jwp/ott-common/types/profiles';
 
 import MenuButton from '../MenuButton/MenuButton';
 import Icon from '../Icon/Icon';

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -25,7 +25,7 @@ const Registration = () => {
   const appConfigId = useConfigStore(({ config }) => config.id);
   const { data, isLoading: publisherConsentsLoading } = useQuery(['consents', appConfigId], accountController.getPublisherConsents);
 
-  const publisherConsents = useMemo(() => data?.consents || [], [data]);
+  const publisherConsents = useMemo(() => data || [], [data]);
 
   const queryClient = useQueryClient();
 

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -50,7 +50,7 @@ const Layout = () => {
   const currentLanguage = useMemo(() => supportedLanguages.find(({ code }) => code === i18n.language), [i18n.language, supportedLanguages]);
 
   const {
-    query: { data: { responseData: { collection: profiles = [] } = {} } = {} },
+    query: { data: { collection: profiles = [] } = {} },
     profilesEnabled,
   } = useProfiles();
 

--- a/packages/ui-react/src/containers/Profiles/CreateProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/CreateProfile.tsx
@@ -38,7 +38,7 @@ const CreateProfile = () => {
 
   const createProfile = useCreateProfile({
     onSuccess: (res) => {
-      const id = res?.responseData?.id;
+      const id = res?.id;
 
       !!id && navigate(createURL(PATH_USER_PROFILES, { success: 'true', id }));
     },

--- a/packages/ui-react/src/containers/Profiles/EditProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/EditProfile.tsx
@@ -36,11 +36,13 @@ const EditProfile = ({ contained = false }: EditProfileProps) => {
   const breakpoint: Breakpoint = useBreakpoint();
   const isMobile = breakpoint === Breakpoint.xs;
 
-  const { data, isLoading, isFetching } = useQuery(['getProfileDetails'], () => profileController.getProfileDetails({ id: id || '' }), {
+  const {
+    data: profileDetails,
+    isLoading,
+    isFetching,
+  } = useQuery(['getProfileDetails'], () => profileController.getProfileDetails({ id: id || '' }), {
     staleTime: 0,
   });
-
-  const profileDetails = data?.responseData;
 
   const initialValues = useMemo(() => {
     return {

--- a/packages/ui-react/src/containers/Profiles/Profiles.tsx
+++ b/packages/ui-react/src/containers/Profiles/Profiles.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from 'react-router';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
-import type { Profile } from '@jwp/ott-common/types/account';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import { useProfiles, useSelectProfile } from '@jwp/ott-hooks-react/src/useProfiles';
 import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 import { PATH_USER_PROFILES, PATH_USER_PROFILES_CREATE, PATH_USER_PROFILES_EDIT } from '@jwp/ott-common/src/paths';
+import type { Profile } from '@jwp/ott-common/types/profiles';
 
 import ProfileBox from '../../components/ProfileBox/ProfileBox';
 import AddNewProfile from '../../components/ProfileBox/AddNewProfile';
@@ -40,7 +40,7 @@ const Profiles = ({ editMode = false }: Props) => {
     profilesEnabled,
   } = useProfiles();
 
-  const activeProfiles = data?.responseData.collection.length || 0;
+  const activeProfiles = data?.collection.length || 0;
   const canAddNew = activeProfiles < MAX_PROFILES;
 
   useEffect(() => {
@@ -54,7 +54,7 @@ const Profiles = ({ editMode = false }: Props) => {
     onError: () => navigate(PATH_USER_PROFILES),
   });
 
-  const createdProfileData = data?.responseData.collection.find((profile: Profile) => profile.id === createdProfileId);
+  const createdProfileData = data?.collection.find((profile: Profile) => profile.id === createdProfileId);
 
   if (loading || isLoading || isFetching) return <LoadingOverlay />;
 
@@ -70,7 +70,7 @@ const Profiles = ({ editMode = false }: Props) => {
           <h2 className={styles.heading}>{t('account.who_is_watching')}</h2>
         )}
         <div className={styles.flex}>
-          {data?.responseData.collection?.map((profile: Profile) => (
+          {data?.collection?.map((profile: Profile) => (
             <ProfileBox
               editMode={editMode}
               onEdit={() => navigate(`/u/profiles/edit/${profile.id}`)}

--- a/packages/ui-react/src/pages/User/User.test.tsx
+++ b/packages/ui-react/src/pages/User/User.test.tsx
@@ -27,8 +27,8 @@ const data = {
     country: 'us',
     firstName: 'User',
     lastName: 'Person',
-    regDate: 'Jan 1, 2000',
     lastUserIp: '192.0.0.1',
+    metadata: {},
   },
   subscription: {
     subscriptionId: 90210,

--- a/platforms/web/src/containers/AppRoutes/AppRoutes.tsx
+++ b/platforms/web/src/containers/AppRoutes/AppRoutes.tsx
@@ -50,7 +50,7 @@ export default function AppRoutes() {
   const userData = useAccountStore((s) => ({ loading: s.loading, user: s.user }));
 
   // listen to websocket notifications
-  useNotifications(userData.user?.uuid);
+  useNotifications();
 
   if (userData.user && !userData.loading && window.location.href.includes('#token')) {
     return <Navigate to="/" />; // component instead of hook to prevent extra re-renders

--- a/platforms/web/src/hooks/useNotifications.ts
+++ b/platforms/web/src/hooks/useNotifications.ts
@@ -5,6 +5,7 @@ import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { queryClient } from '@jwp/ott-ui-react/src/containers/QueryProvider/QueryProvider';
 import { simultaneousLoginWarningKey } from '@jwp/ott-common/src/constants';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
+import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 
 enum NotificationsTypes {
   ACCESS_REVOKED = 'access.revoked',
@@ -18,9 +19,10 @@ enum NotificationsTypes {
   ACCOUNT_LOGOUT = 'account.logout',
 }
 
-export default function useNotifications(uuid: string = '') {
+export default function useNotifications() {
   const navigate = useNavigate();
   const location = useLocation();
+  const uuid = useAccountStore((s) => (typeof s.user?.uuid === 'string' ? s.user.uuid : undefined));
 
   const accountController = getModule(AccountController);
   const { hasNotifications } = accountController?.getFeatures() || {};


### PR DESCRIPTION
## Description

I'm in the process of refactoring the integration types and methods to make them more universal and more accessible to follow.

The biggest change I want to make is to separate the integration and application types. Because we initially started with the Cleeng integration, all typings used in the UI are based on Cleeng types. After the InPlayer integration, most types were mapped to these Cleeng types, but this didn't work for everything. So, some Cleeng types have been changed to allow InPlayer to work. But this means the Cleeng typings can't be trusted as solely Cleeng typings anymore.

I would like to:

- Add separate Cleeng typings for all API responses and payloads `./packages/common/services/integrations/cleeng/types`
- Update OTT typings to be more generic (clean and generalized)
- Format Cleeng data to OTT data in the Cleeng services
- Format InPlayer data to OTT data in the JWP services

I've made the above change for the customer type. Doing this, a few problems popped up;

- InPlayer has `metadata` and Cleeng has `externalData` for custom data
- Favorites and history are stored via API for InPlayer users
- Favorites and history are stored in user#externalData for Cleeng users
- Consents are stored via API for Cleeng users
- Consents are stored in user#metadata for InPlayer users
- InPlayer has an extra `uuid` property for users

For now, this PR only addresses the refactoring of the account and profile typings for Cleeng. The above problems will be solved in a different PR.

Related OTT-488
