### PR TITLE
Feat/accessible sidebar & `<main>` landmark

### DIFF
--- a/packages/ui-react/src/components/DevConfigSelector/DevConfigSelector.tsx
+++ b/packages/ui-react/src/components/DevConfigSelector/DevConfigSelector.tsx
@@ -31,6 +31,7 @@ const DevConfigSelector = ({ selectedConfig }: Props) => {
       value={selectedConfig || ''}
       onChange={onChange}
       required={true}
+      aria-hidden={true}
     />
   );
 };

--- a/packages/ui-react/src/components/ErrorPage/ErrorPage.tsx
+++ b/packages/ui-react/src/components/ErrorPage/ErrorPage.tsx
@@ -37,27 +37,23 @@ export const ErrorPageWithoutTranslation = ({ title, children, message, learnMor
     <div className={styles.errorPage}>
       <div className={styles.box}>
         <img className={styles.image} src={logo || '/images/logo.png'} alt={'Logo'} />
-        <header>
-          <h1 className={styles.title}>{title || 'An error occurred'}</h1>
-        </header>
-        <main className={styles.main}>
-          <>
-            <p className={styles.message}>{message || 'Try refreshing this page or come back later.'}</p>
-            {children}
-            {(IS_DEVELOPMENT_BUILD || IS_DEMO_MODE || IS_PREVIEW_MODE) && helpLink && (
-              <div className={styles.links}>
-                <a href={helpLink} target={'_blank'} rel={'noreferrer'}>
-                  {learnMoreLabel || 'Learn More'}
-                </a>
-                {(IS_DEVELOPMENT_BUILD || IS_PREVIEW_MODE) && error?.stack && (
-                  <span className={styles.stack}>
-                    <DevStackTrace error={error} />
-                  </span>
-                )}
-              </div>
-            )}
-          </>
-        </main>
+        <h1 className={styles.title}>{title || 'An error occurred'}</h1>
+        <div className={styles.main}>
+          <p className={styles.message}>{message || 'Try refreshing this page or come back later.'}</p>
+          {children}
+          {(IS_DEVELOPMENT_BUILD || IS_DEMO_MODE || IS_PREVIEW_MODE) && helpLink && (
+            <div className={styles.links}>
+              <a href={helpLink} target={'_blank'} rel={'noreferrer'}>
+                {learnMoreLabel || 'Learn More'}
+              </a>
+              {(IS_DEVELOPMENT_BUILD || IS_PREVIEW_MODE) && error?.stack && (
+                <span className={styles.stack}>
+                  <DevStackTrace error={error} />
+                </span>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/ui-react/src/components/ErrorPage/__snapshots__/ErrorPage.test.tsx.snap
+++ b/packages/ui-react/src/components/ErrorPage/__snapshots__/ErrorPage.test.tsx.snap
@@ -13,14 +13,12 @@ exports[`<ErrorPage> > renders and matches snapshot 1`] = `
         class="_image_8c5621"
         src="/images/logo.png"
       />
-      <header>
-        <h1
-          class="_title_8c5621"
-        >
-          This is the title
-        </h1>
-      </header>
-      <main
+      <h1
+        class="_title_8c5621"
+      >
+        This is the title
+      </h1>
+      <div
         class="_main_8c5621"
       >
         <p
@@ -29,7 +27,7 @@ exports[`<ErrorPage> > renders and matches snapshot 1`] = `
           generic_error_description
         </p>
         This is the content
-      </main>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/ui-react/src/components/Header/Header.test.tsx
+++ b/packages/ui-react/src/components/Header/Header.test.tsx
@@ -33,6 +33,7 @@ describe('<Header />', () => {
         onCloseSearchButtonClick={vi.fn()}
         onLoginButtonClick={vi.fn()}
         userMenuOpen={false}
+        sideBarOpen={false}
         openUserMenu={vi.fn()}
         closeUserMenu={vi.fn()}
         openLanguageMenu={vi.fn()}

--- a/packages/ui-react/src/components/Header/Header.tsx
+++ b/packages/ui-react/src/components/Header/Header.tsx
@@ -41,6 +41,7 @@ type Props = {
   closeLanguageMenu: () => void;
   children?: ReactNode;
   isLoggedIn: boolean;
+  sideBarOpen: boolean;
   userMenuOpen: boolean;
   languageMenuOpen: boolean;
   canLogin: boolean;
@@ -48,7 +49,6 @@ type Props = {
   supportedLanguages: LanguageDefinition[];
   currentLanguage: LanguageDefinition | undefined;
   onLanguageClick: (code: string) => void;
-
   favoritesEnabled?: boolean;
 
   profilesData?: {
@@ -73,6 +73,7 @@ const Header: React.FC<Props> = ({
   onCloseSearchButtonClick,
   onSignUpButtonClick,
   isLoggedIn,
+  sideBarOpen,
   userMenuOpen,
   languageMenuOpen,
   openUserMenu,
@@ -198,7 +199,14 @@ const Header: React.FC<Props> = ({
     <header className={headerClassName}>
       <div className={styles.container}>
         <div className={styles.menu}>
-          <IconButton className={styles.iconButton} aria-label={t('open_menu')} onClick={onMenuButtonClick}>
+          <IconButton
+            className={styles.iconButton}
+            aria-label={sideBarOpen ? t('close_menu') : t('open_menu')}
+            aria-controls="sidebar"
+            aria-haspopup="true"
+            aria-expanded={sideBarOpen}
+            onClick={onMenuButtonClick}
+          >
             <Icon icon={Menu} />
           </IconButton>
         </div>
@@ -210,9 +218,7 @@ const Header: React.FC<Props> = ({
             <Logo src={logoSrc} onLoad={() => setLogoLoaded(true)} />
           </div>
         )}
-        <nav className={styles.nav} aria-label="menu">
-          {logoLoaded || !logoSrc ? children : null}
-        </nav>
+        <nav className={styles.nav}>{logoLoaded || !logoSrc ? children : null}</nav>
         <div className={styles.actions}>
           {renderSearch()}
           {renderLanguageDropdown()}

--- a/packages/ui-react/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/ui-react/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -12,6 +12,9 @@ exports[`<Header /> > renders header 1`] = `
         class="_menu_f4f7a7"
       >
         <div
+          aria-controls="sidebar"
+          aria-expanded="false"
+          aria-haspopup="true"
           aria-label="open_menu"
           class="_iconButton_0fef65 _iconButton_f4f7a7"
           role="button"
@@ -40,7 +43,6 @@ exports[`<Header /> > renders header 1`] = `
         skip_to_content
       </a>
       <nav
-        aria-label="menu"
         class="_nav_f4f7a7"
       >
         a

--- a/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
+++ b/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
@@ -23,9 +23,10 @@ type Props = {
   markdownString: string;
   className?: string;
   inline?: boolean;
+  tag?: string;
 };
 
-const MarkdownComponent: React.FC<Props> = ({ markdownString, className, inline = false }) => {
+const MarkdownComponent: React.FC<Props> = ({ markdownString, className, tag = 'div', inline = false }) => {
   const sanitizedHTMLString = useMemo(() => {
     const parseDelegate = inline ? marked.parseInline : marked.parse;
     const dirtyHTMLString = parseDelegate(markdownString);
@@ -33,7 +34,7 @@ const MarkdownComponent: React.FC<Props> = ({ markdownString, className, inline 
     return DOMPurify.sanitize(dirtyHTMLString, { ADD_ATTR: ['target'] });
   }, [inline, markdownString]);
 
-  return <div className={classNames(styles.markdown, className)} dangerouslySetInnerHTML={{ __html: sanitizedHTMLString }} />;
+  return React.createElement(tag, { dangerouslySetInnerHTML: { __html: sanitizedHTMLString }, className: classNames(styles.markdown, className) });
 };
 
 export default MarkdownComponent;

--- a/packages/ui-react/src/components/MenuButton/MenuButton.tsx
+++ b/packages/ui-react/src/components/MenuButton/MenuButton.tsx
@@ -26,7 +26,6 @@ const MenuButton: React.FC<Props> = ({ label, to, onClick, onBlur, onFocus, tabI
         onBlur={onBlur}
         onFocus={onFocus}
         onClick={onClick}
-        aria-label={label}
         className={({ isActive }) => getClassName(isActive || active)}
         to={to}
         tabIndex={tabIndex}
@@ -39,7 +38,7 @@ const MenuButton: React.FC<Props> = ({ label, to, onClick, onBlur, onFocus, tabI
   }
 
   return (
-    <div onBlur={onBlur} onFocus={onFocus} aria-label={label} className={getClassName(active)} onClick={onClick} tabIndex={tabIndex}>
+    <div onBlur={onBlur} onFocus={onFocus} className={getClassName(active)} onClick={onClick} tabIndex={tabIndex}>
       {icon}
       <span className={styles.label}>{label}</span>
     </div>

--- a/packages/ui-react/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/ui-react/src/components/MenuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<MenuButton> > renders and matches snapshot 1`] = `
 <div>
   <div
-    aria-label="Label"
     class="_menuButton_91706b"
     tabindex="0"
   >

--- a/packages/ui-react/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/packages/ui-react/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`<Popover> > renders and matches snapshot 1`] = `
     >
       <a
         aria-current="page"
-        aria-label="Home"
         class="_menuButton_91706b _active_91706b"
         href="/"
         tabindex="0"

--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -43,7 +43,10 @@
 .group {
   display: flex;
   flex-direction: column;
+  max-height: 100%;
   padding: variables.$base-spacing 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 //

--- a/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
@@ -8,9 +8,19 @@ import Sidebar from './Sidebar';
 describe('<SideBar />', () => {
   const playlistMenuItems = [<Button key="key" label="Home" to="/" />];
 
-  test('renders sideBar', () => {
+  test('renders sideBar opened', () => {
     const { container } = renderWithRouter(
       <Sidebar isOpen={true} onClose={vi.fn()}>
+        {playlistMenuItems}
+      </Sidebar>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders sideBar closed', () => {
+    const { container } = renderWithRouter(
+      <Sidebar isOpen={false} onClose={vi.fn()}>
         {playlistMenuItems}
       </Sidebar>,
     );

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, type ReactNode } from 'react';
+import React, { AriaAttributes, Fragment, useEffect, useRef, type ReactNode } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import Close from '@jwp/ott-theme/assets/icons/close.svg?react';
@@ -16,22 +16,35 @@ type SidebarProps = {
 
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const { t } = useTranslation('menu');
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const sidebarRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
+  const ariaAttributes: AriaAttributes = {};
+
+  if (!isOpen) {
+    ariaAttributes['aria-hidden'] = true;
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      lastFocusedElementRef.current = document.activeElement as HTMLElement;
+      sidebarRef.current.querySelectorAll('a')[0]?.focus({ preventScroll: true });
+    } else {
+      lastFocusedElementRef.current?.focus({ preventScroll: true });
+    }
+  }, [isOpen]);
 
   return (
     <Fragment>
       <div
-        className={classNames(styles.backdrop, {
-          [styles.visible]: isOpen,
-        })}
-        onClick={onClose}
-      />
-      <div
+        ref={sidebarRef}
         className={classNames(styles.sidebar, {
           [styles.open]: isOpen,
         })}
+        id="sidebar"
+        {...ariaAttributes}
       >
         <div className={styles.heading}>
-          <IconButton onClick={onClose} aria-label={t('close_menu')} tabIndex={isOpen ? 0 : -1}>
+          <IconButton onClick={onClose} aria-label={t('close_menu')}>
             <Icon icon={Close} />
           </IconButton>
         </div>
@@ -39,6 +52,12 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
           {children}
         </nav>
       </div>
+      <div
+        className={classNames(styles.backdrop, {
+          [styles.visible]: isOpen,
+        })}
+        onClick={onClose}
+      />
     </Fragment>
   );
 };

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes, Fragment, useEffect, useRef, type ReactNode } from 'react';
+import React, { Fragment, useEffect, useRef, type ReactNode } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import Close from '@jwp/ott-theme/assets/icons/close.svg?react';
@@ -18,11 +18,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const { t } = useTranslation('menu');
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const sidebarRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
-  const ariaAttributes: AriaAttributes = {};
-
-  if (!isOpen) {
-    ariaAttributes['aria-hidden'] = true;
-  }
+  const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
 
   useEffect(() => {
     if (isOpen) {
@@ -41,7 +37,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
           [styles.open]: isOpen,
         })}
         id="sidebar"
-        {...ariaAttributes}
+        {...htmlAttributes}
       >
         <div className={styles.heading}>
           <IconButton onClick={onClose} aria-label={t('close_menu')}>

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -17,13 +17,13 @@ type SidebarProps = {
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const { t } = useTranslation('menu');
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
-  const sidebarRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
+  const sidebarRef = useRef<HTMLDivElement>(null);
   const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
 
   useEffect(() => {
     if (isOpen) {
       lastFocusedElementRef.current = document.activeElement as HTMLElement;
-      sidebarRef.current.querySelectorAll('a')[0]?.focus({ preventScroll: true });
+      sidebarRef.current?.querySelectorAll('a')[0]?.focus({ preventScroll: true });
     } else {
       lastFocusedElementRef.current?.focus({ preventScroll: true });
     }
@@ -31,6 +31,12 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
 
   return (
     <Fragment>
+      <div
+        className={classNames(styles.backdrop, {
+          [styles.visible]: isOpen,
+        })}
+        onClick={onClose}
+      />
       <div
         ref={sidebarRef}
         className={classNames(styles.sidebar, {
@@ -48,12 +54,6 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
           {children}
         </nav>
       </div>
-      <div
-        className={classNames(styles.backdrop, {
-          [styles.visible]: isOpen,
-        })}
-        onClick={onClose}
-      />
     </Fragment>
   );
 };

--- a/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -3,10 +3,8 @@
 exports[`<SideBar /> > renders sideBar 1`] = `
 <div>
   <div
-    class="_backdrop_577f70 _visible_577f70"
-  />
-  <div
     class="_sidebar_577f70 _open_577f70"
+    id="sidebar"
   >
     <div
       class="_heading_577f70"
@@ -47,5 +45,8 @@ exports[`<SideBar /> > renders sideBar 1`] = `
       </a>
     </nav>
   </div>
+  <div
+    class="_backdrop_577f70 _visible_577f70"
+  />
 </div>
 `;

--- a/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -1,6 +1,58 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<SideBar /> > renders sideBar 1`] = `
+exports[`<SideBar /> > renders sideBar closed 1`] = `
+<div>
+  <div
+    class="_sidebar_577f70"
+    id="sidebar"
+    inert=""
+  >
+    <div
+      class="_heading_577f70"
+    >
+      <div
+        aria-label="close_menu"
+        class="_iconButton_0fef65"
+        role="button"
+        tabindex="0"
+      >
+        <svg
+          aria-hidden="true"
+          class="_icon_585b29"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+      </div>
+    </div>
+    <nav
+      class="_group_577f70"
+    >
+      <a
+        aria-current="page"
+        class="_button_f8f296 _default_f8f296 _outlined_f8f296 _active_f8f296"
+        href="/"
+      >
+        <span>
+          Home
+        </span>
+      </a>
+    </nav>
+  </div>
+  <div
+    class="_backdrop_577f70"
+  />
+</div>
+`;
+
+exports[`<SideBar /> > renders sideBar opened 1`] = `
 <div>
   <div
     class="_sidebar_577f70 _open_577f70"

--- a/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`<SideBar /> > renders sideBar closed 1`] = `
 <div>
   <div
+    class="_backdrop_577f70"
+  />
+  <div
     class="_sidebar_577f70"
     id="sidebar"
     inert=""
@@ -46,14 +49,14 @@ exports[`<SideBar /> > renders sideBar closed 1`] = `
       </a>
     </nav>
   </div>
-  <div
-    class="_backdrop_577f70"
-  />
 </div>
 `;
 
 exports[`<SideBar /> > renders sideBar opened 1`] = `
 <div>
+  <div
+    class="_backdrop_577f70 _visible_577f70"
+  />
   <div
     class="_sidebar_577f70 _open_577f70"
     id="sidebar"
@@ -97,8 +100,5 @@ exports[`<SideBar /> > renders sideBar opened 1`] = `
       </a>
     </nav>
   </div>
-  <div
-    class="_backdrop_577f70 _visible_577f70"
-  />
 </div>
 `;

--- a/packages/ui-react/src/components/UserMenu/__snapshots__/UserMenu.test.tsx.snap
+++ b/packages/ui-react/src/components/UserMenu/__snapshots__/UserMenu.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`<UserMenu> > renders and matches snapshot 1`] = `
     </li>
     <li>
       <a
-        aria-label="nav.account"
         class="_menuButton_91706b"
         href="/u/my-account"
         tabindex="0"
@@ -38,7 +37,6 @@ exports[`<UserMenu> > renders and matches snapshot 1`] = `
     </li>
     <li>
       <a
-        aria-label="nav.payments"
         class="_menuButton_91706b"
         href="/u/payments"
         tabindex="0"
@@ -69,7 +67,6 @@ exports[`<UserMenu> > renders and matches snapshot 1`] = `
     </li>
     <li>
       <div
-        aria-label="nav.logout"
         class="_menuButton_91706b"
         tabindex="0"
       >

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -38,7 +38,7 @@ const VideoDetails: React.VFC<Props> = ({
 
   return (
     <div data-testid={testId('cinema-layout')}>
-      <div className={styles.video} data-testid={testId('video-details')}>
+      <header className={styles.video} data-testid={testId('video-details')}>
         <div className={classNames(styles.main, styles.mainPadding)}>
           <Image className={styles.poster} image={image} alt={title} width={1280} />
           <div className={styles.info}>
@@ -57,7 +57,7 @@ const VideoDetails: React.VFC<Props> = ({
             </div>
           </div>
         </div>
-      </div>
+      </header>
       {children}
     </div>
   );

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
   <div
     data-testid="cinema-layout"
   >
-    <div
+    <header
       class="_video_d0c133"
       data-testid="video-details"
     >
@@ -69,7 +69,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </header>
     <div>
       Related Videos
     </div>

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
 }
 
-.main {
+.container {
   flex: 1;
 }
 
@@ -47,6 +47,6 @@ div.testFixMargin {
   }
 }
 
-.content {
+.main {
   height: 100%;
 }

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -11,7 +11,7 @@
   flex: 1;
 }
 
-div.footer {
+.footer {
   padding: 20px 40px;
   line-height: 18px;
   letter-spacing: 0.15px;

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -137,6 +137,8 @@ const Layout = () => {
     );
   };
 
+  const mainProps = { inert: sideBarOpen ? '' : undefined }; // inert is not yet officially supported in react
+
   return (
     <div className={styles.layout}>
       <Helmet>
@@ -147,7 +149,7 @@ const Layout = () => {
         <meta name="twitter:title" content={siteName} />
         <meta name="twitter:description" content={metaDescription} />
       </Helmet>
-      <div className={styles.main}>
+      <div className={styles.main} {...mainProps}>
         <Header
           onMenuButtonClick={() => setSideBarOpen(true)}
           logoSrc={banner}
@@ -167,6 +169,7 @@ const Layout = () => {
           supportedLanguages={supportedLanguages}
           currentLanguage={currentLanguage}
           isLoggedIn={isLoggedIn}
+          sideBarOpen={sideBarOpen}
           userMenuOpen={userMenuOpen}
           languageMenuOpen={languageMenuOpen}
           openUserMenu={openUserMenu}
@@ -189,26 +192,27 @@ const Layout = () => {
             <Button key={item.contentId} label={item.label} to={`/p/${item.contentId}`} variant="text" />
           ))}
         </Header>
-        <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
-          <MenuButton label={t('home')} to="/" tabIndex={sideBarOpen ? 0 : -1} />
-          {menu.map((item) => (
-            <MenuButton key={item.contentId} label={item.label} to={`/p/${item.contentId}`} tabIndex={sideBarOpen ? 0 : -1} />
-          ))}
-          <hr className={styles.divider} />
-          {renderUserActions(sideBarOpen)}
-        </Sidebar>
         <div id="content" className={styles.content} tabIndex={-1}>
           <Outlet />
         </div>
+        {!!footerText && (
+          <MarkdownComponent
+            // The extra style below is just to fix the footer on mobile when the dev selector is shown
+            className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}
+            markdownString={footerText}
+            tag="footer"
+            inline
+          />
+        )}
       </div>
-      {!!footerText && (
-        <MarkdownComponent
-          // The extra style below is just to fix the footer on mobile when the dev selector is shown
-          className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}
-          markdownString={footerText}
-          inline
-        />
-      )}
+      <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
+        <MenuButton label={t('home')} to="/" />
+        {menu.map((item) => (
+          <MenuButton key={item.contentId} label={item.label} to={`/p/${item.contentId}`} />
+        ))}
+        <hr className={styles.divider} />
+        {renderUserActions(sideBarOpen)}
+      </Sidebar>
     </div>
   );
 };

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -137,7 +137,7 @@ const Layout = () => {
     );
   };
 
-  const mainProps = { inert: sideBarOpen ? '' : undefined }; // inert is not yet officially supported in react
+  const containerProps = { inert: sideBarOpen ? '' : undefined }; // inert is not yet officially supported in react
 
   return (
     <div className={styles.layout}>
@@ -149,7 +149,7 @@ const Layout = () => {
         <meta name="twitter:title" content={siteName} />
         <meta name="twitter:description" content={metaDescription} />
       </Helmet>
-      <div className={styles.main} {...mainProps}>
+      <div className={styles.container} {...containerProps}>
         <Header
           onMenuButtonClick={() => setSideBarOpen(true)}
           logoSrc={banner}
@@ -192,9 +192,9 @@ const Layout = () => {
             <Button key={item.contentId} label={item.label} to={`/p/${item.contentId}`} variant="text" />
           ))}
         </Header>
-        <div id="content" className={styles.content} tabIndex={-1}>
+        <main id="content" className={styles.main} tabIndex={-1}>
           <Outlet />
-        </div>
+        </main>
         {!!footerText && (
           <MarkdownComponent
             // The extra style below is just to fix the footer on mobile when the dev selector is shown

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -18,6 +18,9 @@ exports[`<Layout /> > renders layout 1`] = `
             class="_menu_f4f7a7"
           >
             <div
+              aria-controls="sidebar"
+              aria-expanded="false"
+              aria-haspopup="true"
               aria-label="open_menu"
               class="_iconButton_0fef65 _iconButton_f4f7a7"
               role="button"
@@ -46,7 +49,6 @@ exports[`<Layout /> > renders layout 1`] = `
             skip_to_content
           </a>
           <nav
-            aria-label="menu"
             class="_nav_f4f7a7"
           >
             <a
@@ -65,61 +67,62 @@ exports[`<Layout /> > renders layout 1`] = `
         </div>
       </header>
       <div
-        class="_backdrop_577f70"
-      />
-      <div
-        class="_sidebar_577f70"
-      >
-        <div
-          class="_heading_577f70"
-        >
-          <div
-            aria-label="close_menu"
-            class="_iconButton_0fef65"
-            role="button"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="_icon_585b29"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-              />
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-            </svg>
-          </div>
-        </div>
-        <nav
-          class="_group_577f70"
-        >
-          <a
-            aria-current="page"
-            aria-label="home"
-            class="_menuButton_91706b _active_91706b"
-            href="/"
-            tabindex="-1"
-          >
-            <span>
-              home
-            </span>
-          </a>
-          <hr
-            class="_divider_c71437"
-          />
-        </nav>
-      </div>
-      <div
         class="_content_c71437"
         id="content"
         tabindex="-1"
       />
     </div>
+    <div
+      aria-hidden="true"
+      class="_sidebar_577f70"
+      id="sidebar"
+    >
+      <div
+        class="_heading_577f70"
+      >
+        <div
+          aria-label="close_menu"
+          class="_iconButton_0fef65"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="_icon_585b29"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </div>
+      </div>
+      <nav
+        class="_group_577f70"
+      >
+        <a
+          aria-current="page"
+          class="_menuButton_91706b _active_91706b"
+          href="/"
+          tabindex="0"
+        >
+          <span>
+            home
+          </span>
+        </a>
+        <hr
+          class="_divider_c71437"
+        />
+      </nav>
+    </div>
+    <div
+      class="_backdrop_577f70"
+    />
   </div>
 </div>
 `;

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -73,6 +73,9 @@ exports[`<Layout /> > renders layout 1`] = `
       />
     </div>
     <div
+      class="_backdrop_577f70"
+    />
+    <div
       class="_sidebar_577f70"
       id="sidebar"
       inert=""
@@ -120,9 +123,6 @@ exports[`<Layout /> > renders layout 1`] = `
         />
       </nav>
     </div>
-    <div
-      class="_backdrop_577f70"
-    />
   </div>
 </div>
 `;

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -73,9 +73,9 @@ exports[`<Layout /> > renders layout 1`] = `
       />
     </div>
     <div
-      aria-hidden="true"
       class="_sidebar_577f70"
       id="sidebar"
+      inert=""
     >
       <div
         class="_heading_577f70"

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Layout /> > renders layout 1`] = `
     class="_layout_c71437"
   >
     <div
-      class="_main_c71437"
+      class="_container_c71437"
     >
       <header
         class="_header_f4f7a7 _static_f4f7a7"
@@ -66,8 +66,8 @@ exports[`<Layout /> > renders layout 1`] = `
           />
         </div>
       </header>
-      <div
-        class="_content_c71437"
+      <main
+        class="_main_c71437"
         id="content"
         tabindex="-1"
       />

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistGrid/PlaylistGrid.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistGrid/PlaylistGrid.tsx
@@ -41,7 +41,7 @@ const PlaylistGrid: ScreenComponent<Playlist> = ({ data, isLoading }) => {
         <meta property="og:title" content={pageTitle} />
         <meta name="twitter:title" content={pageTitle} />
       </Helmet>
-      <main className={styles.main}>
+      <div className={styles.main}>
         <header className={styles.header}>
           <h1>{data.title}</h1>
           {shouldShowFilter && <Filter name="genre" value={filter} defaultLabel="All" options={categories} setValue={setFilter} />}
@@ -55,7 +55,7 @@ const PlaylistGrid: ScreenComponent<Playlist> = ({ data, isLoading }) => {
           isLoading={isLoading}
           headingLevel={2}
         />
-      </main>
+      </div>
     </div>
   );
 };

--- a/packages/ui-react/src/pages/Search/Search.module.scss
+++ b/packages/ui-react/src/pages/Search/Search.module.scss
@@ -8,7 +8,7 @@
   font-family: var(--body-alt-font-family);
   text-align: center;
 
-  > main {
+  > div {
     margin-top: 6px;
   }
 
@@ -23,10 +23,6 @@
   @include responsive.desktop-small-only() {
     margin: 0 calc(#{variables.$base-spacing} * 3);
   }
-}
-
-.main {
-  margin: -8px;
 }
 
 .header {

--- a/packages/ui-react/src/pages/Search/Search.tsx
+++ b/packages/ui-react/src/pages/Search/Search.tsx
@@ -90,9 +90,7 @@ const Search = () => {
       <header className={styles.header}>
         <h2>{t('heading')}</h2>
       </header>
-      <main className={styles.main}>
-        <CardGrid getUrl={getURL} playlist={playlist} isLoading={firstRender} accessModel={accessModel} isLoggedIn={!!user} hasSubscription={!!subscription} />
-      </main>
+      <CardGrid getUrl={getURL} playlist={playlist} isLoading={firstRender} accessModel={accessModel} isLoggedIn={!!user} hasSubscription={!!subscription} />
     </div>
   );
 };

--- a/packages/ui-react/src/pages/User/User.tsx
+++ b/packages/ui-react/src/pages/User/User.tsx
@@ -85,7 +85,7 @@ const User = (): JSX.Element => {
   return (
     <div className={styles.user}>
       {isLargeScreen && (
-        <div className={styles.leftColumn}>
+        <nav className={styles.leftColumn}>
           <div className={styles.panel}>
             <ul>
               {accessModel === 'SVOD' && profilesEnabled && profileAndFavoritesPage && (
@@ -123,7 +123,7 @@ const User = (): JSX.Element => {
               )}
             </ul>
           </div>
-        </div>
+        </nav>
       )}
       <div className={styles.mainColumn}>
         <Routes>

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`User Component tests > Account Page 1`] = `
   <div
     class="_user_e9c5ca"
   >
-    <div
+    <nav
       class="_leftColumn_e9c5ca"
     >
       <div
@@ -89,7 +89,7 @@ exports[`User Component tests > Account Page 1`] = `
           </li>
         </ul>
       </div>
-    </div>
+    </nav>
     <div
       class="_mainColumn_e9c5ca"
     >
@@ -267,7 +267,7 @@ exports[`User Component tests > Favorites Page 1`] = `
   <div
     class="_user_e9c5ca"
   >
-    <div
+    <nav
       class="_leftColumn_e9c5ca"
     >
       <div
@@ -375,7 +375,7 @@ exports[`User Component tests > Favorites Page 1`] = `
           </li>
         </ul>
       </div>
-    </div>
+    </nav>
     <div
       class="_mainColumn_e9c5ca"
     >
@@ -542,7 +542,7 @@ exports[`User Component tests > Payments Page 1`] = `
   <div
     class="_user_e9c5ca"
   >
-    <div
+    <nav
       class="_leftColumn_e9c5ca"
     >
       <div
@@ -626,7 +626,7 @@ exports[`User Component tests > Payments Page 1`] = `
           </li>
         </ul>
       </div>
-    </div>
+    </nav>
     <div
       class="_mainColumn_e9c5ca"
     >

--- a/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
+++ b/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
@@ -36,14 +36,12 @@ exports[`<DemoConfigDialog> > renders and matches snapshot error dialog 1`] = `
           class="_image_d73633"
           src="/images/logo.png"
         />
-        <header>
-          <h1
-            class="_title_d73633"
-          >
-            app_config_not_found
-          </h1>
-        </header>
-        <main
+        <h1
+          class="_title_d73633"
+        >
+          app_config_not_found
+        </h1>
+        <div
           class="_main_d73633"
         >
           <p
@@ -138,7 +136,7 @@ exports[`<DemoConfigDialog> > renders and matches snapshot error dialog 1`] = `
               </a>
             </span>
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/platforms/web/test-e2e/tests/video_detail_test.ts
+++ b/platforms/web/test-e2e/tests/video_detail_test.ts
@@ -103,7 +103,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     await I.checkPlayerClosed();
     I.waitForText('Email', normalTimeout);
     I.see('Password');
-    I.click('div[aria-label=Close]');
+    I.click('div[aria-label=Close panel]');
 
     I.click('Trailer');
     await I.waitForPlayerPlaying(`${constants.elephantsDreamTitle} - Trailer`);


### PR DESCRIPTION
This change will make it possible to use the sidebar correctly using keyboard and screen reader navigation. It uses `inert` primarily to achieve this. I reordered the HTML and encapsulated all the main elements (header, main-content, footer) in one container, so I only need to apply `inert` to one element instead of multiple elements separately. 

While implementing this I also encountered some other accessibility improvements which I applied. These were relevant to the sidebar / main navigation. Allow me to argue them:
1. The DevConfigSelector can cause weird behaviour while navigating through the page. So I added `aria-hidden={true}` on the DevConfigSelector to make accessibility testing easier on screen readers by just igorning it. Since this is not used on production, let's not waste time to optimize this.
2. I gave the hamburger icon an accessibility treatment (added all the necessary aria attributes)
3. `aria-label="menu"` on the menu is not needed. Because it's applied in a `<nav>` within the `<header>` banner region, the screen reader can assume it's the main navigation.
4. Encapsulate the footer within a `<footer>` to make it more explicit
5. Menu buttons do not need a `aria-label={label}`. The contents of the element can just be used.
6. Set and restore the focussed element within and outside the sidebar

Also fixes a scrolling issue in sidebar on small viewports.

ps. On VoiceOver the sidebar can get in to weird behaviour on my iOS 15.7. Sometimes it still focuses elements in the background. This also happens on DebatDirect. There is also a known issue for that in the DebatDirect backlog. So I decided to not waste a lot of time on this.

Ticket: https://videodock.atlassian.net/browse/OTT-405