### PR TITLE
fix(a11y): update dialog and modals to enhance accessibility

### DIFF
--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -19,11 +19,13 @@ const ConfirmationDialog: React.FC<Props> = ({ open, title, body, onConfirm, onC
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose} role="dialog" aria-labbeledby="confirmation-heading">
+    <Dialog open={open} onClose={onClose} role="alertdialog" aria-describedby="confirmation-body" aria-labelledby="confirmation-heading">
       <h2 className={styles.title} id="confirmation-heading">
         {title}
       </h2>
-      <p className={styles.body}>{body}</p>
+      <p id="confirmation-body" className={styles.body}>
+        {body}
+      </p>
       <Button
         className={styles.confirmButton}
         label={t('confirmation_dialog.confirm')}

--- a/packages/ui-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 import Modal from '../Modal/Modal';
@@ -7,21 +7,20 @@ import ModalCloseButton from '../ModalCloseButton/ModalCloseButton';
 
 import styles from './Dialog.module.scss';
 
-type Props = Pick<AriaAttributes, 'aria-labelledby' | 'aria-label'> & {
+type Props = {
   open: boolean;
   onClose: () => void;
   size?: 'small' | 'large';
   children: React.ReactNode;
   role: React.AriaRole;
-  'aria-labelledby'?: string; // non-optional
-};
+} & React.AriaAttributes;
 
-const Dialog: React.FC<Props> = ({ open, onClose, size = 'small', children, role, ...rest }: Props) => {
+const Dialog: React.FC<Props> = ({ open, onClose, children, size = 'small', role = 'dialog', ...ariaAttributes }: Props) => {
   return (
-    <Modal open={open} onClose={onClose} AnimationComponent={Slide} role={role} {...rest}>
-      <div className={classNames(styles.dialog, styles[size])}>
-        <ModalCloseButton onClick={onClose} />
+    <Modal open={open} onClose={onClose} AnimationComponent={Slide}>
+      <div className={classNames(styles.dialog, styles[size])} role={role} {...ariaAttributes}>
         {children}
+        <ModalCloseButton onClick={onClose} />
       </div>
     </Modal>
   );

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -26,14 +26,15 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
         aria-modal="true"
         class="_container_6c6c55"
         data-testid="container"
-        role="dialog"
       >
         <div
           style="transition: transform 0.2s ease, opacity 0.2s ease; transform: translate(0, -15px); opacity: 0; z-index: 15;"
         >
           <div
             class="_dialog_00d559 _small_00d559"
+            role="dialog"
           >
+            Dialog contents
             <div
               aria-label="close_modal"
               class="_iconButton_0fef65 _modalCloseButton_b92d69"
@@ -55,7 +56,6 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
                 />
               </svg>
             </div>
-            Dialog contents
           </div>
         </div>
       </div>

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -13,10 +13,9 @@ type Props = {
   AnimationComponent?: React.JSXElementConstructor<{ open?: boolean; duration?: number; delay?: number; children: React.ReactNode }>;
   open: boolean;
   onClose?: () => void;
-  role?: string;
-};
+} & React.AriaAttributes;
 
-const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, role }: Props) => {
+const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, ...ariaAtributes }: Props) => {
   const [visible, setVisible] = useState(open);
   const lastFocus = useRef<HTMLElement>() as React.MutableRefObject<HTMLElement>;
   const modalRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
@@ -77,7 +76,7 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
     <Fade open={open} duration={300} onCloseAnimationEnd={() => setVisible(false)}>
       <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
         <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
-        <div className={styles.container} data-testid={testId('container')} role={role} aria-modal="true">
+        <div className={styles.container} data-testid={testId('container')} aria-modal="true" {...ariaAtributes}>
           <AnimationComponent open={open} duration={200}>
             {children}
           </AnimationComponent>

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -27,8 +27,8 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
   if (!item) return null;
 
   return (
-    <Modal open={open} onClose={onClose} role="dialog">
-      <div className={styles.container}>
+    <Modal open={open} onClose={onClose}>
+      <div className={styles.container} role="dialog" aria-labelledby="trailer-modal-title">
         <Player
           item={item}
           onPlay={handlePlay}
@@ -40,7 +40,9 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
         />
         <Fade open={!isPlaying || userActive}>
           <div className={styles.playerOverlay}>
-            <div className={styles.title}>{title}</div>
+            <h1 id="trailer-modal-title" className={styles.title}>
+              {title}
+            </h1>
           </div>
           <ModalCloseButton onClick={onClose} />
         </Fade>


### PR DESCRIPTION
## Pull Request Overview

This pull request addresses a accessibility issue where the content within dialogs was not being properly announced by screen readers. To resolve this, I've implemented some enhancements in the Modal and Dialog components, as well as in other components that utilize these building blocks.

The goal is to enable screen readers to accurately announce the title and, when available, the description of the modals. This is achieved by incorporating `aria-describedby`, and `aria-labelledby` attributes within the Dialog component. These attributes are then linked to the specific elements responsible for the modal's title and description, ensuring that screen readers can recognize and verbalize this content effectively.

### Todo
- [ ] Test the implementation on mobile devices to ensure compatibility with mobile screen readers.