### PR TITLE
Feat / accessibility epg alt text for images

### DIFF
--- a/packages/ui-react/src/components/Epg/Epg.tsx
+++ b/packages/ui-react/src/components/Epg/Epg.tsx
@@ -23,12 +23,12 @@ type Props = {
   channels: EpgChannel[];
   onChannelClick: (channelId: string) => void;
   onProgramClick: (programId: string, channelId: string) => void;
-  channel: EpgChannel | undefined;
+  selectedChannel: EpgChannel | undefined;
   program: EpgProgram | undefined;
   config: Config;
 };
 
-export default function Epg({ channels, onChannelClick, onProgramClick, channel, program, config }: Props) {
+export default function Epg({ channels, selectedChannel, onChannelClick, onProgramClick, program, config }: Props) {
   const breakpoint = useBreakpoint();
   const { t } = useTranslation('common');
 
@@ -48,6 +48,7 @@ export default function Epg({ channels, onChannelClick, onProgramClick, channel,
     backgroundColor,
   });
   const catchupHoursDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.catchupHours])), [channels]);
+  const titlesDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.title])), [channels]);
 
   return (
     <div className={styles.epg}>
@@ -74,7 +75,8 @@ export default function Epg({ channels, onChannelClick, onProgramClick, channel,
                 onChannelClick(toChannel.uuid);
                 onScrollToNow();
               }}
-              isActive={channel?.id === epgChannel.uuid}
+              title={titlesDict[epgChannel.uuid] || ''}
+              isActive={selectedChannel?.id === epgChannel.uuid}
             />
           )}
           renderProgram={({ program: programItem, isBaseTimeFormat }) => {

--- a/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
+++ b/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
@@ -13,9 +13,10 @@ type Props = {
   sidebarWidth: number;
   onClick?: (channel: Channel) => void;
   isActive: boolean;
+  title: string;
 };
 
-const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWidth, onClick, isActive }) => {
+const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWidth, onClick, isActive, title }) => {
   const { position, uuid, channelLogoImage } = channel;
   const style = { top: position.top, height: position.height, width: sidebarWidth };
 
@@ -28,7 +29,7 @@ const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWi
         data-testid={testId(uuid)}
         role="button"
       >
-        <Image className={styles.epgChannelLogo} image={channelLogoImage} alt="Logo" width={320} />
+        <Image className={styles.epgChannelLogo} image={channelLogoImage} alt={title} width={320} />
       </div>
     </div>
   );

--- a/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
+++ b/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
@@ -36,6 +36,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
 
   const showImage = !compact && isMinWidth;
   const showLiveTagInImage = !compact && isMinWidth && isLive;
+  const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
     <div className={styles.epgProgramBox} style={position} onClick={() => onClick && onClick(program)}>
@@ -48,7 +49,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
         style={{ width: styles.width }}
         data-testid={testId(program.data.id)}
       >
-        {showImage && <img className={styles.epgProgramImage} src={image} alt="Preview" />}
+        {showImage && <img className={styles.epgProgramImage} src={image} alt={alt} />}
         {showLiveTagInImage && <div className={styles.epgLiveTag}>{t('live')}</div>}
         <div className={styles.epgProgramContent}>
           {compact && isLive && <div className={styles.epgLiveTag}>{t('live')}</div>}

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -215,7 +215,7 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
             channels={channels}
             onChannelClick={handleChannelClick}
             onProgramClick={handleProgramClick}
-            channel={channel}
+            selectedChannel={channel}
             program={program}
             config={config}
           />

--- a/platforms/web/test-e2e/tests/live_channel_test.ts
+++ b/platforms/web/test-e2e/tests/live_channel_test.ts
@@ -237,12 +237,12 @@ Scenario('I can navigate through the epg', async ({ I }) => {
 
 Scenario('I can see the channel logo for Channel 1', async ({ I }) => {
   await I.openVideoCard('Channel 1');
-  await I.seeEpgChannelLogoImage('Uh7zcqVm', 'https://cdn.jwplayer.com/v2/media/Uh7zcqVm/images/channel_logo.webp?poster_fallback=1&width=320');
+  await I.seeEpgChannelLogoImage('Uh7zcqVm', 'https://cdn.jwplayer.com/v2/media/Uh7zcqVm/images/channel_logo.webp?poster_fallback=1&width=320', 'Channel 1');
 });
 
 Scenario('I can see the channel logo for Channel 2', async ({ I }) => {
   await I.openVideoCard('Channel 2');
-  await I.seeEpgChannelLogoImage('Z2evecey', 'https://cdn.jwplayer.com/v2/media/Z2evecey/images/channel_logo.webp?poster_fallback=1&width=320');
+  await I.seeEpgChannelLogoImage('Z2evecey', 'https://cdn.jwplayer.com/v2/media/Z2evecey/images/channel_logo.webp?poster_fallback=1&width=320', 'Channel 2');
 });
 
 Scenario('I can see the background image for Channel 3', async ({ I }) => {

--- a/platforms/web/test-e2e/tests/video_detail_test.ts
+++ b/platforms/web/test-e2e/tests/video_detail_test.ts
@@ -103,7 +103,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     await I.checkPlayerClosed();
     I.waitForText('Email', normalTimeout);
     I.see('Password');
-    I.click('div[aria-label=Close panel]');
+    I.click('div[aria-label="Close panel"]');
 
     I.click('Trailer');
     await I.waitForPlayerPlaying(`${constants.elephantsDreamTitle} - Trailer`);

--- a/platforms/web/test-e2e/utils/steps_file.ts
+++ b/platforms/web/test-e2e/utils/steps_file.ts
@@ -454,8 +454,8 @@ const stepsObj = {
     const imgSrc = await this.grabAttributeFrom(imageLocator, 'src');
     assert.equal(imgSrc, src, "img element src attribute doesn't match");
   },
-  seeEpgChannelLogoImage: async function (this: CodeceptJS.I, channelId: string, src: string) {
-    const imageLocator = locate({ css: `div[data-testid="${channelId}"] img[alt="Logo"]` });
+  seeEpgChannelLogoImage: async function (this: CodeceptJS.I, channelId: string, src: string, alt: string) {
+    const imageLocator = locate({ css: `div[data-testid="${channelId}"] img[alt="${alt}"]` });
     const imgSrc = await this.grabAttributeFrom(imageLocator, 'src');
     assert.equal(imgSrc, src, "img element src attribute doesn't match");
   },


### PR DESCRIPTION
Fix alt text for EPG.

ps. EPG is broken in `feat/a11y-sprint-2 branch`. This issue is fixed in `feat/restructure-sprint-2`.

Ticket: https://videodock.atlassian.net/browse/OTT-404
ps2. Yes, this is a high-prio quickwin for accessibility!