### PR TITLE
Fix / a11y empty alt for image because of adjacent text alternative

### DIFF
--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.test.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.test.tsx
@@ -41,6 +41,7 @@ describe('<VideoDetails>', () => {
       </VideoDetails>,
     );
 
-    expect(getByAltText('Test video')).toHaveAttribute('src', 'http://image.jpg?width=1280');
+    const image = getByAltText(''); // Image alt is intentionally empty for a11y;
+    expect(image).toHaveAttribute('src', 'http://image.jpg?width=1280');
   });
 });

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -35,12 +35,13 @@ const VideoDetails: React.VFC<Props> = ({
 }) => {
   const breakpoint: Breakpoint = useBreakpoint();
   const isMobile = breakpoint === Breakpoint.xs;
+  const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
     <div data-testid={testId('cinema-layout')}>
       <header className={styles.video} data-testid={testId('video-details')}>
         <div className={classNames(styles.main, styles.mainPadding)}>
-          <Image className={styles.poster} image={image} alt={title} width={1280} />
+          <Image className={styles.poster} image={image} alt={alt} width={1280} />
           <div className={styles.info}>
             <h1 className={styles.title}>{title}</h1>
             <div className={styles.metaContainer}>


### PR DESCRIPTION
I made this a quickfix, instead of rewriting the `<img>` to a `backgroundImage` (css), because there is a mask applied to the poster this is an extra challenge. This way I was able to fix this in 1 min instead of +1 hour.

Ticket: https://videodock.atlassian.net/browse/OTT-385