### PR TITLE
WIP: Refactor / account consents and capture fields

### DIFF
--- a/docs/backend-services.md
+++ b/docs/backend-services.md
@@ -14,12 +14,12 @@ that any backend integration needs to support broken down by role:
 - [Account](../packages/common/src/services/integrations/AccountService.ts)
   - login
   - register
-  - getPublisherConsents
-  - getCustomerConsents
+  - getConsents
+  - getConsentsValues
   - resetPassword
   - changePassword
   - updateCustomer
-  - updateCustomerConsents
+  - updateConsentsValues
   - getCustomer
   - refreshToken
   - getLocales

--- a/docs/backend-services.md
+++ b/docs/backend-services.md
@@ -23,8 +23,8 @@ that any backend integration needs to support broken down by role:
   - getCustomer
   - refreshToken
   - getLocales
-  - getCaptureStatus
-  - updateCaptureAnswers
+  - getRegistrationFields
+  - updateRegistrationFieldsValues
 - [Subscription](../packages/common/src/services/integrations/SubscriptionService.ts)
   - getSubscriptions
   - updateSubscription

--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -25,27 +25,27 @@ export default class FavoriteService {
   private readonly storageService;
   private readonly accountService;
 
-  constructor (@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
+  constructor(@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
     this.apiService = apiService;
     this.storageService = storageService;
     this.accountService = getNamedModule(AccountService, integrationType, false);
   }
 
-  private validateFavorites (favorites: unknown) {
+  private validateFavorites(favorites: unknown) {
     if (Array.isArray(favorites)) {
-      return favorites.filter(item => schema.isValidSync(item)) as SerializedFavorite[];
+      return favorites.filter((item) => schema.isValidSync(item)) as SerializedFavorite[];
     }
 
     return [];
   }
 
-  private async getFavoritesFromAccount (user: Customer) {
+  private async getFavoritesFromAccount(user: Customer) {
     const favorites = await this.accountService?.getFavorites({ user });
 
     return this.validateFavorites(favorites);
   }
 
-  private async getFavoritesFromStorage () {
+  private async getFavoritesFromStorage() {
     const favorites = await this.storageService.getItem(this.PERSIST_KEY_FAVORITES, true);
 
     return this.validateFavorites(favorites);

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -25,7 +25,7 @@ export default class WatchHistoryService {
   private readonly storageService;
   private readonly accountService;
 
-  constructor (@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
+  constructor(@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
     this.apiService = apiService;
     this.storageService = storageService;
     this.accountService = getNamedModule(AccountService, integrationType);
@@ -43,8 +43,8 @@ export default class WatchHistoryService {
   private getWatchHistorySeriesItems = async (continueWatchingList: string, ids: string[]): Promise<Record<string, PlaylistItem | undefined>> => {
     const mediaWithSeries = await this.apiService.getSeriesByMediaIds(ids);
     const seriesIds = Object.keys(mediaWithSeries || {})
-    .map((key) => mediaWithSeries?.[key]?.[0]?.series_id)
-    .filter(Boolean) as string[];
+      .map((key) => mediaWithSeries?.[key]?.[0]?.series_id)
+      .filter(Boolean) as string[];
 
     const seriesItems = await this.apiService.getMediaByWatchlist(continueWatchingList, seriesIds);
     const seriesItemsDict = Object.keys(mediaWithSeries || {}).reduce((acc, key) => {
@@ -58,21 +58,21 @@ export default class WatchHistoryService {
     return seriesItemsDict;
   };
 
-  private validateWatchHistory (history: unknown) {
+  private validateWatchHistory(history: unknown) {
     if (Array.isArray(history)) {
-      return history.filter(item => schema.isValidSync(item)) as SerializedWatchHistoryItem[];
+      return history.filter((item) => schema.isValidSync(item)) as SerializedWatchHistoryItem[];
     }
 
     return [];
   }
 
-  private async getWatchHistoryFromAccount (user: Customer) {
+  private async getWatchHistoryFromAccount(user: Customer) {
     const history = await this.accountService.getWatchHistory({ user });
 
     return this.validateWatchHistory(history);
   }
 
-  private async getWatchHistoryFromStorage () {
+  private async getWatchHistoryFromStorage() {
     const history = await this.storageService.getItem(this.PERSIST_KEY_WATCH_HISTORY, true);
 
     return this.validateWatchHistory(history);
@@ -92,15 +92,15 @@ export default class WatchHistoryService {
     const seriesItems = await this.getWatchHistorySeriesItems(continueWatchingList, ids);
 
     return savedItems
-    .map((item) => {
-      const parentSeries = seriesItems?.[item.mediaid];
-      const historyItem = watchHistoryItems[item.mediaid];
+      .map((item) => {
+        const parentSeries = seriesItems?.[item.mediaid];
+        const historyItem = watchHistoryItems[item.mediaid];
 
-      if (historyItem) {
-        return this.createWatchHistoryItem(parentSeries || historyItem, item.mediaid, parentSeries?.mediaid, item.progress);
-      }
-    })
-    .filter((item): item is WatchHistoryItem => Boolean(item));
+        if (historyItem) {
+          return this.createWatchHistoryItem(parentSeries || historyItem, item.mediaid, parentSeries?.mediaid, item.progress);
+        }
+      })
+      .filter((item): item is WatchHistoryItem => Boolean(item));
   };
 
   serializeWatchHistory = (watchHistory: WatchHistoryItem[]): SerializedWatchHistoryItem[] =>

--- a/packages/common/src/services/integrations/AccountService.ts
+++ b/packages/common/src/services/integrations/AccountService.ts
@@ -4,7 +4,7 @@ import type {
   ChangePasswordWithOldPassword,
   DeleteAccount,
   ExportAccountData,
-  GetCaptureStatus,
+  GetRegistrationFields,
   GetConsentsValues,
   GetConsents,
   Login,
@@ -12,7 +12,7 @@ import type {
   Register,
   ResetPassword,
   GetSocialURLs,
-  UpdateCaptureAnswers,
+  UpdateRegistrationFieldsValues,
   UpdateConsentsValues,
   Logout,
   GetAuthData,
@@ -66,9 +66,9 @@ export default abstract class AccountService {
 
   abstract updateConsentsValues: UpdateConsentsValues;
 
-  abstract getCaptureStatus: GetCaptureStatus;
+  abstract getRegistrationFields: GetRegistrationFields;
 
-  abstract updateCaptureAnswers: UpdateCaptureAnswers;
+  abstract updateRegistrationFieldsValues: UpdateRegistrationFieldsValues;
 
   abstract resetPassword: ResetPassword;
 

--- a/packages/common/src/services/integrations/AccountService.ts
+++ b/packages/common/src/services/integrations/AccountService.ts
@@ -5,15 +5,15 @@ import type {
   DeleteAccount,
   ExportAccountData,
   GetCaptureStatus,
-  GetCustomerConsents,
-  GetPublisherConsents,
+  GetConsentsValues,
+  GetConsents,
   Login,
   NotificationsData,
   Register,
   ResetPassword,
   GetSocialURLs,
   UpdateCaptureAnswers,
-  UpdateCustomerConsents,
+  UpdateConsentsValues,
   Logout,
   GetAuthData,
   UpdateCustomer,
@@ -60,11 +60,11 @@ export default abstract class AccountService {
 
   abstract getUser: GetUser;
 
-  abstract getPublisherConsents: GetPublisherConsents;
+  abstract getConsents: GetConsents;
 
-  abstract getCustomerConsents: GetCustomerConsents;
+  abstract getConsentsValues: GetConsentsValues;
 
-  abstract updateCustomerConsents: UpdateCustomerConsents;
+  abstract updateConsentsValues: UpdateConsentsValues;
 
   abstract getCaptureStatus: GetCaptureStatus;
 

--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -8,8 +8,8 @@ import type {
   ChangePasswordWithOldPassword,
   GetCaptureStatus,
   GetCaptureStatusResponse,
-  GetCustomerConsents,
-  GetPublisherConsents,
+  GetConsentsValues,
+  GetConsents,
   JwtDetails,
   Login,
   LoginPayload,
@@ -20,7 +20,7 @@ import type {
   UpdateCaptureAnswers,
   UpdateCaptureAnswersPayload,
   UpdateCustomer,
-  UpdateCustomerConsents,
+  UpdateConsentsValues,
   UpdateCustomerConsentsPayload,
   UpdateCustomerPayload,
   UpdateFavorites,
@@ -131,7 +131,7 @@ export default class CleengAccountService extends AccountService {
     return null;
   };
 
-  getCustomerConsents: GetCustomerConsents = async (payload) => {
+  getConsentsValues: GetConsentsValues = async (payload) => {
     const { customer } = payload;
     const response = await this.cleengService.get<GetCustomerConsentsResponse>(`/customers/${customer?.id}/consents`, {
       authenticate: true,
@@ -141,7 +141,7 @@ export default class CleengAccountService extends AccountService {
     return response?.responseData?.consents || [];
   };
 
-  updateCustomerConsents: UpdateCustomerConsents = async (payload) => {
+  updateConsentsValues: UpdateConsentsValues = async (payload) => {
     const { customer } = payload;
 
     const params: UpdateCustomerConsentsPayload = {
@@ -154,7 +154,7 @@ export default class CleengAccountService extends AccountService {
     });
     this.handleErrors(response.errors);
 
-    return await this.getCustomerConsents(payload);
+    return await this.getConsentsValues(payload);
   };
 
   login: Login = async ({ email, password }) => {
@@ -201,7 +201,7 @@ export default class CleengAccountService extends AccountService {
 
     const { user, customerConsents } = await this.getUser();
 
-    await this.updateCustomerConsents({ consents, customer: user }).catch(() => {
+    await this.updateConsentsValues({ consents, customer: user }).catch(() => {
       // error caught while updating the consents, but continue the registration process
     });
 
@@ -224,7 +224,7 @@ export default class CleengAccountService extends AccountService {
 
     const customerId = this.getCustomerIdFromAuthData(authData);
     const user = await this.getCustomer({ customerId });
-    const consents = await this.getCustomerConsents({ customer: user });
+    const consents = await this.getConsentsValues({ customer: user });
 
     return {
       user,
@@ -232,7 +232,7 @@ export default class CleengAccountService extends AccountService {
     };
   };
 
-  getPublisherConsents: GetPublisherConsents = async () => {
+  getConsents: GetConsents = async () => {
     const response = await this.cleengService.get<GetPublisherConsentsResponse>(`/publishers/${this.publisherId}/consents`);
 
     this.handleErrors(response.errors);

--- a/packages/common/src/services/integrations/cleeng/formatters/capture.ts
+++ b/packages/common/src/services/integrations/cleeng/formatters/capture.ts
@@ -1,0 +1,97 @@
+import type { CleengCaptureField, CleengCaptureQuestionField, UpdateCaptureAnswersPayload } from '../types/models';
+import type { CustomFormField, CustomRegisterFieldVariant } from '../../../../../types/account';
+
+export const formatFormField = (
+  type: CustomRegisterFieldVariant,
+  name: string,
+  label: string,
+  required: boolean = false,
+  options?: Record<string, string>,
+): CustomFormField => {
+  return {
+    type,
+    name,
+    label,
+    options,
+    required,
+    placeholder: '',
+    defaultValue: '',
+  };
+};
+
+export const getInputTypeFromCaptureValue = (value: string, questions: Record<string, string>): CustomRegisterFieldVariant => {
+  const optionsCount = Object.keys(questions).length;
+
+  if (value === '') {
+    return 'input'; // text
+  } else if (optionsCount === 1) {
+    return 'checkbox';
+  } else if (optionsCount === 2) {
+    return 'radio';
+  }
+
+  return 'select';
+};
+
+export const formatCapture = (capture: CleengCaptureField | CleengCaptureQuestionField): CustomFormField[] => {
+  switch (capture.key) {
+    case 'firstNameLastName':
+      return [formatFormField('input', 'firstName', 'First name', capture.required), formatFormField('input', 'lastName', 'Last name', capture.required)];
+    case 'address':
+      return [
+        formatFormField('input', 'address', 'Address', capture.required),
+        formatFormField('input', 'address2', 'Address line 2'),
+        formatFormField('input', 'city', 'City', capture.required),
+        formatFormField('input', 'postCode', 'Postal code', capture.required),
+        formatFormField('input', 'state', 'State', capture.required),
+      ];
+    case 'birthDate':
+      return [formatFormField('datepicker', 'birthdate', 'Birthdate')];
+    default:
+      // question field (has a data different structure)
+      if ('question' in capture) {
+        const options = capture.value.split(';').reduce((values, question) => {
+          const [value, label = value] = question.split(':');
+
+          return { ...values, [value]: label };
+        }, {} as Record<string, string>);
+
+        const type = getInputTypeFromCaptureValue(capture.value, options);
+
+        return [formatFormField(type, capture.key, capture.question, capture.required, options)];
+      }
+
+      // generic capture fields
+      return [formatFormField('input', capture.key, 'IDK')];
+  }
+};
+
+const CLEENG_CAPTURE_FIELDS = [
+  'firstName',
+  'lastName',
+  'address',
+  'address2',
+  'city',
+  'state',
+  'country',
+  'postCode',
+  'birthDate',
+  'companyName',
+  'phoneNumber',
+];
+
+export const formatUpdateCaptureAnswersPayload = (fields: CustomFormField[], values: Record<string, string>): UpdateCaptureAnswersPayload => {
+  return fields.reduce((previous, current) => {
+    const key = current.name;
+    const value = values[current.name];
+
+    if (CLEENG_CAPTURE_FIELDS.includes(key)) {
+      return { ...previous, [key as keyof UpdateCaptureAnswersPayload]: value };
+    }
+
+    return {
+      ...previous,
+      customAnswers: [...(previous.customAnswers || []), { questionId: key, question: current.label, value: value }],
+    };
+  }, {} as UpdateCaptureAnswersPayload);
+};

--- a/packages/common/src/services/integrations/cleeng/formatters/capture.ts
+++ b/packages/common/src/services/integrations/cleeng/formatters/capture.ts
@@ -1,22 +1,46 @@
 import type { CleengCaptureField, CleengCaptureQuestionField, UpdateCaptureAnswersPayload } from '../types/models';
 import type { CustomFormField, CustomRegisterFieldVariant } from '../../../../../types/account';
+import type { GenericFormValues } from '../../../../../types/form';
+import { isTruthyCustomParamValue } from '../../../../utils/common';
+
+export const getCaptureValue = (capture: CleengCaptureField | CleengCaptureQuestionField, key: string): string => {
+  if (typeof capture.answer === 'string') {
+    return capture.answer;
+  }
+
+  if (capture.answer && key in capture.answer) {
+    return capture.answer[key] || '';
+  }
+
+  return '';
+};
 
 export const formatFormField = (
   type: CustomRegisterFieldVariant,
   name: string,
   label: string,
-  required: boolean = false,
+  capture: CleengCaptureField | CleengCaptureQuestionField,
   options?: Record<string, string>,
 ): CustomFormField => {
+  const value = getCaptureValue(capture, name);
+
   return {
     type,
     name,
     label,
     options,
-    required,
     placeholder: '',
-    defaultValue: '',
+    required: capture.required,
+    ...(type === 'checkbox' ? { enabledByDefault: isTruthyCustomParamValue(capture.answer) } : { defaultValue: value }),
   };
+};
+
+export const getInputOptionsFromCaptureValue = (value: string) => {
+  return value.split(';').reduce((values, question) => {
+    const [value, label = value] = question.split(':');
+
+    return { ...values, [value]: label };
+  }, {} as Record<string, string>);
 };
 
 export const getInputTypeFromCaptureValue = (value: string, questions: Record<string, string>): CustomRegisterFieldVariant => {
@@ -36,33 +60,28 @@ export const getInputTypeFromCaptureValue = (value: string, questions: Record<st
 export const formatCapture = (capture: CleengCaptureField | CleengCaptureQuestionField): CustomFormField[] => {
   switch (capture.key) {
     case 'firstNameLastName':
-      return [formatFormField('input', 'firstName', 'First name', capture.required), formatFormField('input', 'lastName', 'Last name', capture.required)];
+      return [formatFormField('input', 'firstName', 'First name', capture), formatFormField('input', 'lastName', 'Last name', capture)];
     case 'address':
       return [
-        formatFormField('input', 'address', 'Address', capture.required),
-        formatFormField('input', 'address2', 'Address line 2'),
-        formatFormField('input', 'city', 'City', capture.required),
-        formatFormField('input', 'postCode', 'Postal code', capture.required),
-        formatFormField('input', 'state', 'State', capture.required),
+        formatFormField('input', 'address', 'Address', capture),
+        formatFormField('input', 'address2', 'Address line 2', capture),
+        formatFormField('input', 'city', 'City', capture),
+        formatFormField('input', 'postCode', 'Postal code', capture),
+        formatFormField('input', 'state', 'State', capture),
       ];
     case 'birthDate':
-      return [formatFormField('datepicker', 'birthdate', 'Birthdate')];
+      return [formatFormField('datepicker', 'birthdate', 'Birthdate', capture)];
     default:
       // question field (has a data different structure)
       if ('question' in capture) {
-        const options = capture.value.split(';').reduce((values, question) => {
-          const [value, label = value] = question.split(':');
-
-          return { ...values, [value]: label };
-        }, {} as Record<string, string>);
-
+        const options = getInputOptionsFromCaptureValue(capture.value);
         const type = getInputTypeFromCaptureValue(capture.value, options);
 
-        return [formatFormField(type, capture.key, capture.question, capture.required, options)];
+        return [formatFormField(type, capture.key, capture.question, capture, options)];
       }
 
       // generic capture fields
-      return [formatFormField('input', capture.key, 'IDK')];
+      return [formatFormField('input', capture.key, capture.key, capture)];
   }
 };
 
@@ -80,18 +99,33 @@ const CLEENG_CAPTURE_FIELDS = [
   'phoneNumber',
 ];
 
-export const formatUpdateCaptureAnswersPayload = (fields: CustomFormField[], values: Record<string, string>): UpdateCaptureAnswersPayload => {
+export const formatUpdateCaptureAnswersPayload = (fields: CustomFormField[], values: GenericFormValues): UpdateCaptureAnswersPayload => {
   return fields.reduce((previous, current) => {
     const key = current.name;
     const value = values[current.name];
 
     if (CLEENG_CAPTURE_FIELDS.includes(key)) {
+      if (typeof value !== 'string') {
+        // capture fields should only accept string values
+        throw new Error(`Wrong value for registration field ${key}: ${value}`);
+      }
+
       return { ...previous, [key as keyof UpdateCaptureAnswersPayload]: value };
     }
 
+    // checkbox value is a boolean, we turn it into a string here with 'true' or 'false'
+    const stringValue = typeof value === 'string' ? value : value ? 'true' : 'false';
+
     return {
       ...previous,
-      customAnswers: [...(previous.customAnswers || []), { questionId: key, question: current.label, value: value }],
+      customAnswers: [
+        ...(previous.customAnswers || []),
+        {
+          questionId: key,
+          question: current.label,
+          value: stringValue,
+        },
+      ],
     };
   }, {} as UpdateCaptureAnswersPayload);
 };

--- a/packages/common/src/services/integrations/cleeng/types/models.ts
+++ b/packages/common/src/services/integrations/cleeng/types/models.ts
@@ -45,3 +45,45 @@ export interface CustomerConsent {
   value: string | boolean;
   version: string;
 }
+
+export type CleengCaptureField = {
+  key: string;
+  enabled: boolean;
+  required: boolean;
+  answer: string | Record<string, string | null> | null;
+};
+
+export type CleengCaptureQuestionField = {
+  key: string;
+  enabled: boolean;
+  required: boolean;
+  value: string;
+  question: string;
+  answer: string | null;
+};
+
+export type GetCaptureStatusResponse = {
+  isCaptureEnabled: boolean;
+  shouldCaptureBeDisplayed: boolean;
+  settings: Array<CleengCaptureField | CleengCaptureQuestionField>;
+};
+
+export type CaptureCustomAnswer = {
+  questionId: string;
+  question: string;
+  value: string;
+};
+
+export type UpdateCaptureAnswersPayload = {
+  firstName?: string;
+  address?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  postCode?: string;
+  country?: string;
+  birthDate?: string;
+  companyName?: string;
+  phoneNumber?: string;
+  customAnswers?: CaptureCustomAnswer[];
+};

--- a/packages/common/src/services/integrations/jwp/formatters/fields.ts
+++ b/packages/common/src/services/integrations/jwp/formatters/fields.ts
@@ -1,0 +1,22 @@
+import type { RegisterField } from '@inplayer-org/inplayer.js';
+
+import type { CustomFormField, CustomRegisterFieldVariant } from '../../../../../types/account';
+
+export const formatRegistrationField = (field: RegisterField, value?: unknown): CustomFormField => {
+  return {
+    type: field.type as CustomRegisterFieldVariant,
+    isCustomRegisterField: true,
+    name: field.name,
+    label: field.label,
+    placeholder: field.placeholder,
+    required: field.required,
+    options: field.options,
+    ...(field.type === 'checkbox'
+      ? {
+          enabledByDefault: typeof value === 'string' ? value === 'true' : field.default_value === 'true',
+        }
+      : {
+          defaultValue: typeof value === 'string' ? value : field.default_value,
+        }),
+  };
+};

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -11,7 +11,7 @@ import type { Offer } from '../../types/checkout';
 import type {
   Capture,
   Customer,
-  CustomerConsent,
+  ConsentsValue,
   EmailConfirmPasswordInput,
   FirstLastNameInput,
   GetCaptureStatusResponse,
@@ -184,7 +184,7 @@ export default class AccountController {
     await this.refreshEntitlements?.();
   };
 
-  register = async (email: string, password: string, referrer: string, consents: CustomerConsent[]) => {
+  register = async (email: string, password: string, referrer: string, consents: ConsentsValue[]) => {
     useAccountStore.setState({ loading: true });
     const response = await this.accountService.register({ email, password, consents, referrer });
 
@@ -198,14 +198,14 @@ export default class AccountController {
     await this.watchHistoryController.persistWatchHistory();
   };
 
-  updateConsents = async (customerConsents: CustomerConsent[]): Promise<ServiceResponse<CustomerConsent[]>> => {
+  updateConsents = async (customerConsents: ConsentsValue[]): Promise<ServiceResponse<ConsentsValue[]>> => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
     useAccountStore.setState({ loading: true });
 
     try {
-      const updatedConsents = await this.accountService?.updateCustomerConsents({
+      const updatedConsents = await this.accountService?.updateConsentsValues({
         customer,
         consents: customerConsents,
       });
@@ -232,7 +232,7 @@ export default class AccountController {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
-    const consents = await this.accountService.getCustomerConsents({ customer });
+    const consents = await this.accountService.getConsentsValues({ customer });
 
     if (consents) {
       useAccountStore.setState({ customerConsents: consents });
@@ -244,7 +244,7 @@ export default class AccountController {
   getPublisherConsents = async () => {
     const { config } = useConfigStore.getState();
 
-    const consents = await this.accountService.getPublisherConsents(config);
+    const consents = await this.accountService.getConsents(config);
 
     useAccountStore.setState({ publisherConsents: consents });
 
@@ -468,7 +468,7 @@ export default class AccountController {
     return this.features;
   }
 
-  private async afterLogin(user: Customer, customerConsents: CustomerConsent[] | null, shouldReloadSubscription = true) {
+  private async afterLogin(user: Customer, customerConsents: ConsentsValue[] | null, shouldReloadSubscription = true) {
     useAccountStore.setState({
       user,
       customerConsents,

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -19,6 +19,7 @@ import type {
 import { assertFeature, assertModuleMethod, getNamedModule } from '../modules/container';
 import { INTEGRATION_TYPE } from '../modules/types';
 import type { ServiceResponse } from '../../types/service';
+import type { GenericFormValues } from '../../types/form';
 
 import { useAccountStore } from './AccountStore';
 import { useConfigStore } from './ConfigStore';
@@ -257,7 +258,7 @@ export default class AccountController {
     return this.accountService.getRegistrationFields({ customer });
   };
 
-  updateRegistrationFieldsValues = async (fields: CustomFormField[], values: Record<string, string>) => {
+  updateRegistrationFieldsValues = async (fields: CustomFormField[], values: GenericFormValues) => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer, customerConsents } = getAccountInfo();
 

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -9,13 +9,12 @@ import AccountService, { type AccountServiceFeatures } from '../services/integra
 import SubscriptionService from '../services/integrations/SubscriptionService';
 import type { Offer } from '../../types/checkout';
 import type {
-  Capture,
   Customer,
   ConsentsValue,
   EmailConfirmPasswordInput,
   FirstLastNameInput,
-  GetCaptureStatusResponse,
   SubscribeToNotificationsPayload,
+  CustomFormField,
 } from '../../types/account';
 import { assertFeature, assertModuleMethod, getNamedModule } from '../modules/container';
 import { INTEGRATION_TYPE } from '../modules/types';
@@ -251,18 +250,18 @@ export default class AccountController {
     return consents;
   };
 
-  getCaptureStatus = async (): Promise<GetCaptureStatusResponse> => {
+  getRegistrationFields = async () => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
-    return this.accountService.getCaptureStatus({ customer });
+    return this.accountService.getRegistrationFields({ customer });
   };
 
-  updateCaptureAnswers = async (capture: Capture): Promise<Capture> => {
+  updateRegistrationFieldsValues = async (fields: CustomFormField[], values: Record<string, string>) => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer, customerConsents } = getAccountInfo();
 
-    const updatedCustomer = await this.accountService.updateCaptureAnswers({ customer, ...capture });
+    const updatedCustomer = await this.accountService.updateRegistrationFieldsValues({ customer, fields, values });
 
     await this.afterLogin(updatedCustomer, customerConsents, false);
 

--- a/packages/common/src/stores/AccountController.ts
+++ b/packages/common/src/stores/AccountController.ts
@@ -228,7 +228,7 @@ export default class AccountController {
 
   // TODO: Decide if it's worth keeping this or just leave combined with getUser
   // noinspection JSUnusedGlobalSymbols
-  getCustomerConsents = async () => {
+  getConsentsValues = async () => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
 
@@ -241,7 +241,7 @@ export default class AccountController {
     return consents;
   };
 
-  getPublisherConsents = async () => {
+  getConsents = async () => {
     const { config } = useConfigStore.getState();
 
     const consents = await this.accountService.getConsents(config);
@@ -474,7 +474,7 @@ export default class AccountController {
       customerConsents,
     });
 
-    await Promise.allSettled([shouldReloadSubscription ? this.reloadSubscriptions() : Promise.resolve(), this.getPublisherConsents()]);
+    await Promise.allSettled([shouldReloadSubscription ? this.reloadSubscriptions() : Promise.resolve(), this.getConsents()]);
     useAccountStore.setState({ loading: false });
   }
 

--- a/packages/common/src/stores/AccountStore.ts
+++ b/packages/common/src/stores/AccountStore.ts
@@ -1,4 +1,4 @@
-import type { CustomFormField, Customer, CustomerConsent } from '../../types/account';
+import type { CustomFormField, Customer, ConsentsValue } from '../../types/account';
 import type { Offer } from '../../types/checkout';
 import type { PaymentDetail, Subscription, Transaction } from '../../types/subscription';
 
@@ -10,11 +10,11 @@ type AccountStore = {
   subscription: Subscription | null;
   transactions: Transaction[] | null;
   activePayment: PaymentDetail | null;
-  customerConsents: CustomerConsent[] | null;
+  customerConsents: ConsentsValue[] | null;
   publisherConsents: CustomFormField[] | null;
   pendingOffer: Offer | null;
   setLoading: (loading: boolean) => void;
-  getAccountInfo: () => { customerId: string; customer: Customer; customerConsents: CustomerConsent[] | null };
+  getAccountInfo: () => { customerId: string; customer: Customer; customerConsents: ConsentsValue[] | null };
 };
 
 export const useAccountStore = createStore<AccountStore>('AccountStore', (set, get) => ({

--- a/packages/common/src/utils/collection.ts
+++ b/packages/common/src/utils/collection.ts
@@ -109,7 +109,7 @@ const formatConsentsFromValues = (publisherConsents: CustomFormField[] | null, v
   publisherConsents.forEach((consent) => {
     consents.push({
       name: consent.name,
-      version: consent.version,
+      version: consent.version || '1',
       state: values[consent.name] ? 'accepted' : 'declined',
     });
   });
@@ -130,7 +130,7 @@ const checkConsentsFromValues = (publisherConsents: CustomFormField[], consents:
 
     customerConsents.push({
       name: consent.name,
-      version: consent.version,
+      version: consent.version || '1',
       state: consents[consent.name] ? 'accepted' : 'declined',
     });
   });

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -25,13 +25,13 @@ export type LoginArgs = {
 };
 
 export type RegistrationArgs = LoginArgs & {
-  consents: CustomerConsent[];
+  consents: ConsentsValue[];
 };
 
 export type AuthResponse = {
   auth: AuthData;
   user: Customer;
-  customerConsents: CustomerConsent[];
+  customerConsents: ConsentsValue[];
 };
 
 export type LoginPayload = PayloadWithIPOverride & {
@@ -79,7 +79,7 @@ export type GetUserArgs = {
 
 export type GetUserPayload = {
   user: Customer;
-  customerConsents: CustomerConsent[];
+  customerConsents: ConsentsValue[];
 };
 
 export type RegisterPayload = PayloadWithIPOverride & {
@@ -127,7 +127,7 @@ export type PersonalDetailsFormData = {
 };
 
 export type GetCustomerConsentsResponse = {
-  consents: CustomerConsent[];
+  consents: ConsentsValue[];
 };
 
 export type ResetPasswordPayload = {
@@ -159,7 +159,7 @@ export type UpdateCustomerPayload = {
 
 export type UpdateCustomerConsentsPayload = {
   id?: string;
-  consents: CustomerConsent[];
+  consents: ConsentsValue[];
 };
 
 export type Customer = {
@@ -198,16 +198,9 @@ export interface CustomFormField {
   version: string;
 }
 
-export type CustomerConsent = {
-  customerId?: string;
-  date?: number;
-  label?: string;
+export type ConsentsValue = {
   name: string;
-  needsUpdate?: boolean;
-  newestVersion?: string;
-  required?: boolean;
   state: 'accepted' | 'declined';
-  value?: string | boolean;
   version: string;
 };
 
@@ -217,7 +210,7 @@ export type CustomerConsentArgs = {
 
 export type UpdateCustomerConsentsArgs = {
   customer: Customer;
-  consents: CustomerConsent[];
+  consents: ConsentsValue[];
 };
 
 export type GetCaptureStatusResponse = {
@@ -323,9 +316,9 @@ export type Register = PromiseRequest<RegistrationArgs, AuthResponse>;
 export type GetUser = PromiseRequest<GetUserArgs, GetUserPayload>;
 export type Logout = () => Promise<void>;
 export type UpdateCustomer = PromiseRequest<UpdateCustomerArgs, Customer>;
-export type GetPublisherConsents = PromiseRequest<Config, CustomFormField[]>;
-export type GetCustomerConsents = PromiseRequest<CustomerConsentArgs, CustomerConsent[]>;
-export type UpdateCustomerConsents = PromiseRequest<UpdateCustomerConsentsArgs, CustomerConsent[]>;
+export type GetConsents = PromiseRequest<Config, CustomFormField[]>;
+export type GetConsentsValues = PromiseRequest<CustomerConsentArgs, ConsentsValue[]>;
+export type UpdateConsentsValues = PromiseRequest<UpdateCustomerConsentsArgs, ConsentsValue[]>;
 export type GetCaptureStatus = PromiseRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
 export type UpdateCaptureAnswers = PromiseRequest<UpdateCaptureStatusArgs, Customer>;
 export type ResetPassword = PromiseRequest<ResetPasswordPayload, void>;

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -2,6 +2,7 @@ import type { Config } from './config';
 import type { PromiseRequest } from './service';
 import type { SerializedWatchHistoryItem } from './watchHistory';
 import type { SerializedFavorite } from './favorite';
+import type { GenericFormValues } from './form';
 
 export type AuthData = {
   jwt: string;
@@ -216,7 +217,7 @@ export type GetRegistrationFieldsArgs = {
 export type UpdateRegistrationFieldsValuesArgs = {
   customer: Customer;
   fields: CustomFormField[];
-  values: Record<string, string>;
+  values: GenericFormValues;
 };
 
 export type FirstLastNameInput = {

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -96,22 +96,6 @@ export type RegisterPayload = PayloadWithIPOverride & {
   externalData?: string;
 };
 
-export type CleengCaptureField = {
-  key: string;
-  enabled: boolean;
-  required: boolean;
-  answer: string | Record<string, string | null> | null;
-};
-
-export type CleengCaptureQuestionField = {
-  key: string;
-  enabled: boolean;
-  required: boolean;
-  value: string;
-  question: string;
-  answer: string | null;
-};
-
 export type PersonalDetailsFormData = {
   firstName: string;
   lastName: string;
@@ -194,8 +178,8 @@ export interface CustomFormField {
   label: string;
   placeholder: string;
   required: boolean;
-  options: Record<string, string>;
-  version: string;
+  options?: Record<string, string>;
+  version?: string;
 }
 
 export type ConsentsValue = {
@@ -213,43 +197,27 @@ export type UpdateCustomerConsentsArgs = {
   consents: ConsentsValue[];
 };
 
-export type GetCaptureStatusResponse = {
-  isCaptureEnabled: boolean;
-  shouldCaptureBeDisplayed: boolean;
-  settings: Array<CleengCaptureField | CleengCaptureQuestionField>;
-};
-
 export type CaptureCustomAnswer = {
   questionId: string;
   question: string;
   value: string;
 };
 
-export type Capture = {
-  firstName?: string;
-  address?: string;
-  address2?: string;
-  city?: string;
-  state?: string;
-  postCode?: string;
-  country?: string;
-  birthDate?: string;
-  companyName?: string;
-  phoneNumber?: string;
-  customAnswers?: CaptureCustomAnswer[];
+export type RegistrationFields = {
+  beforeSignUp: boolean; // true when the registration fields need to be filled in while signing up
+  enabled: boolean; // true when the registration fields are enabled and should be shown to the user
+  fields: CustomFormField[];
 };
 
-export type GetCaptureStatusArgs = {
+export type GetRegistrationFieldsArgs = {
   customer: Customer;
 };
 
-export type UpdateCaptureStatusArgs = {
+export type UpdateRegistrationFieldsValuesArgs = {
   customer: Customer;
-} & Capture;
-
-export type UpdateCaptureAnswersPayload = {
-  customerId: string;
-} & Capture;
+  fields: CustomFormField[];
+  values: Record<string, string>;
+};
 
 export type FirstLastNameInput = {
   firstName: string;
@@ -319,8 +287,8 @@ export type UpdateCustomer = PromiseRequest<UpdateCustomerArgs, Customer>;
 export type GetConsents = PromiseRequest<Config, CustomFormField[]>;
 export type GetConsentsValues = PromiseRequest<CustomerConsentArgs, ConsentsValue[]>;
 export type UpdateConsentsValues = PromiseRequest<UpdateCustomerConsentsArgs, ConsentsValue[]>;
-export type GetCaptureStatus = PromiseRequest<GetCaptureStatusArgs, GetCaptureStatusResponse>;
-export type UpdateCaptureAnswers = PromiseRequest<UpdateCaptureStatusArgs, Customer>;
+export type GetRegistrationFields = PromiseRequest<GetRegistrationFieldsArgs, RegistrationFields>;
+export type UpdateRegistrationFieldsValues = PromiseRequest<UpdateRegistrationFieldsValuesArgs, Customer>;
 export type ResetPassword = PromiseRequest<ResetPasswordPayload, void>;
 export type ChangePassword = PromiseRequest<ChangePasswordWithTokenPayload, void>;
 export type ChangePasswordWithOldPassword = PromiseRequest<ChangePasswordWithOldPasswordPayload, void>;

--- a/packages/common/types/form.d.ts
+++ b/packages/common/types/form.d.ts
@@ -3,6 +3,6 @@ export type UseFormBlurHandler = React.FocusEventHandler<HTMLInputElement | HTML
 export type UseFormSubmitHandler = React.FormEventHandler<HTMLFormElement>;
 
 export type GenericFormErrors = { form: string };
-export type GenericFormValues = Record<string, string | boolean>;
+export type GenericFormValues = Record<string, string | boolean | GenericFormValues>;
 export type FormErrors<T> = Partial<{ [K in keyof T]: string } & GenericFormErrors>;
 export type FormValues<T> = Partial<T & GenericFormValues>;

--- a/packages/common/types/form.d.ts
+++ b/packages/common/types/form.d.ts
@@ -3,6 +3,6 @@ export type UseFormBlurHandler = React.FocusEventHandler<HTMLInputElement | HTML
 export type UseFormSubmitHandler = React.FormEventHandler<HTMLFormElement>;
 
 export type GenericFormErrors = { form: string };
-export type GenericFormValues = Record<string, string | boolean | GenericFormValues>;
-export type FormErrors<T> = Partial<T & GenericFormErrors>;
+export type GenericFormValues = Record<string, string | boolean>;
+export type FormErrors<T> = Partial<{ [K in keyof T]: string } & GenericFormErrors>;
 export type FormValues<T> = Partial<T & GenericFormValues>;

--- a/packages/hooks-react/src/useForm.ts
+++ b/packages/hooks-react/src/useForm.ts
@@ -9,7 +9,7 @@ export type UseFormReturnValue<T> = {
   handleChange: UseFormChangeHandler;
   handleBlur: UseFormBlurHandler;
   handleSubmit: UseFormSubmitHandler;
-  setValue: (key: keyof T, value: string) => void;
+  setValue: (key: keyof T, value: string | boolean) => void;
   setErrors: (errors: FormErrors<T>) => void;
   setSubmitting: (submitting: boolean) => void;
   reset: () => void;

--- a/packages/hooks-react/src/useProfiles.ts
+++ b/packages/hooks-react/src/useProfiles.ts
@@ -1,7 +1,7 @@
 import type { ProfilesData } from '@inplayer-org/inplayer.js';
 import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions } from 'react-query';
 import { useTranslation } from 'react-i18next';
-import type { GenericFormErrors } from '@jwp/ott-common/types/form';
+import type { FormErrors } from '@jwp/ott-common/types/form';
 import type { CommonAccountResponse } from '@jwp/ott-common/types/account';
 import type { ListProfilesResponse, ProfileDetailsPayload, ProfileFormSubmitError, ProfileFormValues, ProfilePayload } from '@jwp/ott-common/types/profiles';
 import { getModule } from '@jwp/ott-common/src/modules/container';
@@ -84,7 +84,7 @@ export const isProfileFormSubmitError = (e: unknown): e is ProfileFormSubmitErro
 export const useProfileErrorHandler = () => {
   const { t } = useTranslation('user');
 
-  return (e: unknown, setErrors: (errors: Partial<ProfileFormValues & GenericFormErrors>) => void) => {
+  return (e: unknown, setErrors: (errors: FormErrors<ProfileFormValues>) => void) => {
     if (isProfileFormSubmitError(e) && e.message.includes('409')) {
       setErrors({ name: t('profile.validation.name.already_exists') });
       return;

--- a/packages/ui-react/src/components/Account/Account.tsx
+++ b/packages/ui-react/src/components/Account/Account.tsx
@@ -9,7 +9,7 @@ import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
 import { isTruthy, isTruthyCustomParamValue, logDev, testId } from '@jwp/ott-common/src/utils/common';
-import { formatConsents, formatConsentsFromValues, formatConsentsToRegisterFields, formatConsentValues } from '@jwp/ott-common/src/utils/collection';
+import { formatConsents, formatConsentsFromValues, formatConsentValues } from '@jwp/ott-common/src/utils/collection';
 import useToggle from '@jwp/ott-hooks-react/src/useToggle';
 import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
 import VisibilityOff from '@jwp/ott-theme/assets/icons/visibility_off.svg?react';
@@ -200,16 +200,9 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
             label: t('account.about_you'),
             editButton: t('account.edit_information'),
             onSubmit: (values) => {
-              const consents = formatConsentsFromValues(publisherConsents, { ...values.metadata, ...values.consentsValues });
-
               return accountController.updateUser({
                 firstName: values.firstName || '',
                 lastName: values.lastName || '',
-                metadata: {
-                  ...values.metadata,
-                  ...formatConsentsToRegisterFields(consents),
-                  consents: JSON.stringify(consents),
-                },
               });
             },
             content: (section) => (

--- a/packages/ui-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/ui-react/src/components/Checkbox/Checkbox.module.scss
@@ -21,6 +21,9 @@
       &:not(:checked) {
         border: 2px solid theme.$input-field-error-color;
       }
+      &:checked {
+        background-color: theme.$input-field-error-color;
+      }
     }
   }
 

--- a/packages/ui-react/src/components/CustomRegisterField/CustomRegisterField.tsx
+++ b/packages/ui-react/src/components/CustomRegisterField/CustomRegisterField.tsx
@@ -23,9 +23,10 @@ export type CustomRegisterFieldCommonProps = {
   disabled: boolean;
   required: boolean;
   options: RegisterFieldOptions;
+  editing: boolean;
 }>;
 
-const CustomRegisterField: FC<CustomRegisterFieldCommonProps> = ({ type, value = '', options, ...props }) => {
+const CustomRegisterField: FC<CustomRegisterFieldCommonProps> = ({ type, value = '', options, editing, ...props }) => {
   const { t, i18n } = useTranslation();
 
   const optionsList = useMemo(() => {

--- a/packages/ui-react/src/components/Form/FormSection.tsx
+++ b/packages/ui-react/src/components/Form/FormSection.tsx
@@ -24,7 +24,7 @@ export interface FormSectionProps<TData extends GenericFormValues, TErrors> {
   saveButton?: string;
   cancelButton?: string;
   canSave?: (values: TData) => boolean;
-  onSubmit?: (values: TData) => Promise<{ errors?: string[] }>;
+  onSubmit?: (values: TData) => Promise<void>;
   content?: (args: FormSectionContentArgs<TData, TErrors>) => ReactNode;
   children?: never;
   readOnly?: boolean;
@@ -93,23 +93,23 @@ export function FormSection<TData extends GenericFormValues>({
       event && event.preventDefault();
 
       if (onSubmit) {
-        let response: { errors?: string[] };
+        let errors: string[] = [];
 
         try {
           setFormState((s) => {
             return { ...s, isBusy: true };
           });
-          response = await onSubmit(values);
+          await onSubmit(values);
         } catch (error: unknown) {
-          response = { errors: Array.of(error instanceof Error ? error.message : (error as string)) };
+          errors = Array.of(error instanceof Error ? error.message : (error as string));
         }
 
         // Don't leave edit mode if there are errors
-        if (response?.errors?.length) {
+        if (errors.length) {
           setFormState((s) => {
             return {
               ...s,
-              errors: response?.errors,
+              errors,
               isBusy: false,
             };
           });

--- a/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.test.tsx
+++ b/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import type { CustomFormField } from '@jwp/ott-common/types/account';
 
 import PersonalDetailsForm from './PersonalDetailsForm';
 
@@ -11,94 +12,88 @@ const values = {
   birthDate: '27-Feb-1985',
   companyName: 'JW Player',
   phoneNumber: '+1 555 555 5555',
-  address: '123 Nowhere St.',
-  address2: 'Apt 1W',
-  city: 'Chicago',
-  state: 'IL',
-  postCode: '60601',
-  country: 'United States',
 };
-const fields = {
-  firstNameLastName: {
-    key: 'fnln',
-    enabled: true,
+const fields: CustomFormField[] = [
+  {
+    type: 'input',
+    name: 'firstName',
+    label: 'First name',
+    placeholder: '',
     required: true,
-    answer: '',
+    defaultValue: '',
   },
-  companyName: {
-    key: 'c',
-    enabled: true,
+  {
+    type: 'input',
+    name: 'lastName',
+    label: 'Last name',
+    placeholder: '',
+    required: true,
+    defaultValue: '',
+  },
+  {
+    type: 'input',
+    name: 'companyName',
+    label: 'Company name',
+    placeholder: '',
     required: false,
-    answer: '',
-  },
-  address: {
-    key: 'a',
-    enabled: true,
-    required: true,
-    answer: '',
-  },
-  phoneNumber: {
-    key: 'pn',
-    enabled: true,
-    required: true,
-    answer: '',
-  },
-  birthDate: {
-    key: 'dob',
-    enabled: true,
-    required: true,
-    answer: '',
-  },
-};
-const questions = [
-  {
-    key: 'key1',
-    question: 'Which number is 2?',
-    value: '1;2;3',
-    answer: '',
-    required: true,
-    enabled: true,
+    defaultValue: '',
   },
   {
-    key: 'key2',
-    question: 'Is this a question?',
-    value: 'Yes;No',
-    answer: '',
+    type: 'datepicker',
+    name: 'birthDate',
+    label: 'Birth date',
+    placeholder: '',
     required: false,
-    enabled: true,
+    defaultValue: '',
   },
   {
-    key: 'ccc',
-    question: 'Check this off.',
-    value: 'CheckMe',
-    answer: '',
+    type: 'input',
+    name: 'phoneNumber',
+    label: 'Phone Number',
+    placeholder: '',
+    required: false,
+    defaultValue: '',
+  },
+  {
+    type: 'input',
+    name: 'custom_1',
+    label: 'This is a text field',
+    placeholder: '',
+    required: false,
+    defaultValue: '',
+  },
+  {
+    type: 'checkbox',
+    name: 'custom_2',
+    label: 'This is a checkbox field',
+    options: { accept: 'accept' },
+    placeholder: '',
+    required: false,
+    enabledByDefault: false,
+  },
+  {
+    type: 'radio',
+    name: 'custom_3',
+    label: 'This is a radio field',
+    options: { option1: 'Option 1', option2: 'Option 2' },
+    placeholder: '',
     required: true,
-    enabled: true,
+    defaultValue: '',
+  },
+  {
+    type: 'select',
+    name: 'custom_4',
+    label: 'This is a select field',
+    options: { option1: 'Option 1', option2: 'Option 2', option3: 'Option 3' },
+    placeholder: '',
+    required: true,
+    defaultValue: '',
   },
 ];
-const questionValues = {
-  key1: '3',
-  key2: 'No',
-  ccc: 'true',
-};
 
 describe('<PersonalDetailsForm>', () => {
   test('Renders without crashing', () => {
-    const { container } = render(
-      <PersonalDetailsForm
-        onSubmit={noop}
-        onChange={noop}
-        setValue={noop}
-        errors={{}}
-        values={values}
-        submitting={false}
-        fields={fields}
-        questions={questions}
-        onQuestionChange={noop}
-        questionValues={questionValues}
-        questionErrors={{}}
-      />,
-    );
+    const { container } = render(<PersonalDetailsForm onSubmit={noop} onChange={noop} errors={{}} values={values} submitting={false} fields={fields} />);
 
     expect(container).toMatchSnapshot();
   });
@@ -108,32 +103,20 @@ describe('<PersonalDetailsForm>', () => {
       <PersonalDetailsForm
         onSubmit={noop}
         onChange={noop}
-        setValue={noop}
         errors={{
           firstName: 'this is wrong',
           lastName: 'also this',
-          address: 'Do you know where you live',
-          address2: 'Come on',
-          city: 'stop it',
-          companyName: 'So much errors',
-          country: 'usa is an error',
           birthDate: 'February 30th? Really?',
           phoneNumber: 'Invalid',
-          state: 'Confusion',
-          postCode: 'Post Code should be 5 centimeters',
+          custom_1: 'Please enter some text',
+          custom_2: 'Check this box please!',
+          custom_3: "It's only two choices",
+          custom_4: 'Select something...',
           form: 'This is a form error',
         }}
         values={values}
         submitting={false}
         fields={fields}
-        questions={questions}
-        onQuestionChange={noop}
-        questionValues={questionValues}
-        questionErrors={{
-          key1: 'question 1 is invalid',
-          key2: 'Invalid answer',
-          ccc: 'No way Jose',
-        }}
       />,
     );
 

--- a/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
+++ b/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import type { FormErrors } from '@jwp/ott-common/types/form';
+import type { FormErrors, GenericFormValues } from '@jwp/ott-common/types/form';
 import type { CustomFormField } from '@jwp/ott-common/types/account';
 import { testId } from '@jwp/ott-common/src/utils/common';
 
@@ -14,10 +14,8 @@ import styles from './PersonalDetailsForm.module.scss';
 type Props = {
   onSubmit: React.FormEventHandler<HTMLFormElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-  setValue: (key: string, value: string) => void;
-  error?: string;
   errors: FormErrors<Record<string, string>>;
-  values: Record<string, string>;
+  values: GenericFormValues;
   submitting: boolean;
   fields: CustomFormField[];
 };
@@ -25,13 +23,10 @@ type Props = {
 const PersonalDetailsForm: React.FC<Props> = ({ onSubmit, onChange, values, errors, submitting, fields }: Props) => {
   const { t } = useTranslation('account');
 
-  console.log(values);
-
   return (
     <form onSubmit={onSubmit} data-testid={testId('personal_details-form')} noValidate>
       <h2 className={styles.title}>{t('personal_details.title')}</h2>
       {errors.form ? <FormFeedback variant="error">{errors.form}</FormFeedback> : null}
-
       {fields.map((field) => (
         <CustomRegisterField
           key={field.name}
@@ -45,119 +40,6 @@ const PersonalDetailsForm: React.FC<Props> = ({ onSubmit, onChange, values, erro
           options={field.options}
         />
       ))}
-
-      {/*{fields.firstNameLastName?.enabled ? (*/}
-      {/*  <React.Fragment>*/}
-      {/*    <TextField*/}
-      {/*      value={values.firstName}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.fist_name')}*/}
-      {/*      placeholder={t('personal_details.fist_name')}*/}
-      {/*      error={!!errors.firstName || !!errors.form}*/}
-      {/*      helperText={errors.firstName}*/}
-      {/*      required={fields.firstNameLastName.required}*/}
-      {/*      name="firstName"*/}
-      {/*    />*/}
-      {/*    <TextField*/}
-      {/*      value={values.lastName}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.last_name')}*/}
-      {/*      placeholder={t('personal_details.last_name')}*/}
-      {/*      error={!!errors.lastName || !!errors.form}*/}
-      {/*      helperText={errors.lastName}*/}
-      {/*      required={fields.firstNameLastName.required}*/}
-      {/*      name="lastName"*/}
-      {/*    />*/}
-      {/*  </React.Fragment>*/}
-      {/*) : null}*/}
-      {/*{fields.companyName?.enabled ? (*/}
-      {/*  <TextField*/}
-      {/*    value={values.companyName}*/}
-      {/*    onChange={onChange}*/}
-      {/*    label={t('personal_details.company_name')}*/}
-      {/*    placeholder={t('personal_details.company_name')}*/}
-      {/*    error={!!errors.companyName || !!errors.form}*/}
-      {/*    helperText={errors.companyName}*/}
-      {/*    required={fields.companyName.required}*/}
-      {/*    name="companyName"*/}
-      {/*  />*/}
-      {/*) : null}*/}
-      {/*{fields.address?.enabled ? (*/}
-      {/*  <React.Fragment>*/}
-      {/*    <TextField*/}
-      {/*      value={values.address}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.address')}*/}
-      {/*      placeholder={t('personal_details.address')}*/}
-      {/*      error={!!errors.address || !!errors.form}*/}
-      {/*      helperText={errors.address}*/}
-      {/*      required={fields.address.required}*/}
-      {/*      name="address"*/}
-      {/*    />*/}
-      {/*    <TextField*/}
-      {/*      value={values.address2}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.address2')}*/}
-      {/*      placeholder={t('personal_details.address2')}*/}
-      {/*      error={!!errors.address2 || !!errors.form}*/}
-      {/*      helperText={errors.address2}*/}
-      {/*      name="address2"*/}
-      {/*    />*/}
-      {/*    <TextField*/}
-      {/*      value={values.city}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.city')}*/}
-      {/*      placeholder={t('personal_details.city')}*/}
-      {/*      error={!!errors.city || !!errors.form}*/}
-      {/*      helperText={errors.city}*/}
-      {/*      required={fields.address.required}*/}
-      {/*      name="city"*/}
-      {/*    />*/}
-      {/*    <TextField*/}
-      {/*      value={values.state}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.state')}*/}
-      {/*      placeholder={t('personal_details.state')}*/}
-      {/*      error={!!errors.state || !!errors.form}*/}
-      {/*      helperText={errors.state}*/}
-      {/*      required={fields.address.required}*/}
-      {/*      name="state"*/}
-      {/*    />*/}
-      {/*    <TextField*/}
-      {/*      value={values.postCode}*/}
-      {/*      onChange={onChange}*/}
-      {/*      label={t('personal_details.post_code')}*/}
-      {/*      placeholder={t('personal_details.post_code')}*/}
-      {/*      error={!!errors.postCode || !!errors.form}*/}
-      {/*      helperText={errors.postCode}*/}
-      {/*      required={fields.address.required}*/}
-      {/*      name="postCode"*/}
-      {/*    />*/}
-      {/*  </React.Fragment>*/}
-      {/*) : null}*/}
-      {/*{fields.phoneNumber?.enabled ? (*/}
-      {/*  <TextField*/}
-      {/*    value={values.phoneNumber}*/}
-      {/*    onChange={onChange}*/}
-      {/*    label={t('personal_details.phone_number')}*/}
-      {/*    placeholder={t('personal_details.phone_number')}*/}
-      {/*    error={!!errors.phoneNumber || !!errors.form}*/}
-      {/*    helperText={errors.phoneNumber}*/}
-      {/*    required={fields.phoneNumber.required}*/}
-      {/*    name="phoneNumber"*/}
-      {/*  />*/}
-      {/*) : null}*/}
-      {/*{fields.birthDate?.enabled ? (*/}
-      {/*  <DateField*/}
-      {/*    value={values.birthDate}*/}
-      {/*    onChange={(event) => setValue('birthDate', event.currentTarget.value)}*/}
-      {/*    label={t('personal_details.birth_date')}*/}
-      {/*    error={!!errors.birthDate || !!errors.form}*/}
-      {/*    helperText={errors.birthDate}*/}
-      {/*    required={fields.birthDate.required}*/}
-      {/*    name="birthDate"*/}
-      {/*  />*/}
-      {/*) : null}*/}
       <Button
         className={styles.continue}
         type="submit"

--- a/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
+++ b/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
@@ -1,195 +1,163 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { FormErrors } from '@jwp/ott-common/types/form';
-import type { CleengCaptureField, CleengCaptureQuestionField, PersonalDetailsFormData } from '@jwp/ott-common/types/account';
+import type { CustomFormField } from '@jwp/ott-common/types/account';
 import { testId } from '@jwp/ott-common/src/utils/common';
 
-import TextField from '../TextField/TextField';
 import Button from '../Button/Button';
-import Dropdown from '../Dropdown/Dropdown';
-import Checkbox from '../Checkbox/Checkbox';
-import Radio from '../Radio/Radio';
-import DateField from '../DateField/DateField';
 import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import FormFeedback from '../FormFeedback/FormFeedback';
+import CustomRegisterField from '../CustomRegisterField/CustomRegisterField';
 
 import styles from './PersonalDetailsForm.module.scss';
 
 type Props = {
   onSubmit: React.FormEventHandler<HTMLFormElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-  setValue: (key: keyof PersonalDetailsFormData, value: string) => void;
+  setValue: (key: string, value: string) => void;
   error?: string;
-  errors: FormErrors<PersonalDetailsFormData>;
-  values: PersonalDetailsFormData;
+  errors: FormErrors<Record<string, string>>;
+  values: Record<string, string>;
   submitting: boolean;
-  fields: Record<string, CleengCaptureField>;
-  questions: CleengCaptureQuestionField[];
-  onQuestionChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-  questionValues: Record<string, string>;
-  questionErrors: Record<string, string>;
+  fields: CustomFormField[];
 };
 
-const PersonalDetailsForm: React.FC<Props> = ({
-  onSubmit,
-  onChange,
-  setValue,
-  values,
-  errors,
-  submitting,
-  fields,
-  questions,
-  onQuestionChange,
-  questionValues,
-  questionErrors,
-}: Props) => {
+const PersonalDetailsForm: React.FC<Props> = ({ onSubmit, onChange, values, errors, submitting, fields }: Props) => {
   const { t } = useTranslation('account');
-  const renderQuestion = ({ value, key, question, required }: CleengCaptureQuestionField) => {
-    const values = value?.split(';').map((question) => {
-      const [value, label = value] = question.split(':');
 
-      return { value, label };
-    });
-
-    const props = {
-      name: key,
-      onChange: onQuestionChange,
-      error: !!questionErrors[key],
-      helperText: questionErrors[key],
-      required,
-      key,
-    };
-
-    const optionsKeys = Object.keys(values);
-
-    if (optionsKeys.length === 1) {
-      return <Checkbox checked={!!questionValues[key]} value={values[0].value} header={question} label={values[0].label} {...props} />;
-    } else if (optionsKeys.length === 2) {
-      return <Radio values={values} value={questionValues[key]} header={question} {...props} />;
-    } else if (optionsKeys.length > 2) {
-      return <Dropdown options={values} value={questionValues[key]} label={question} defaultLabel={t('personal_details.select_answer')} {...props} fullWidth />;
-    }
-
-    return null;
-  };
+  console.log(values);
 
   return (
     <form onSubmit={onSubmit} data-testid={testId('personal_details-form')} noValidate>
       <h2 className={styles.title}>{t('personal_details.title')}</h2>
       {errors.form ? <FormFeedback variant="error">{errors.form}</FormFeedback> : null}
-      {fields.firstNameLastName?.enabled ? (
-        <React.Fragment>
-          <TextField
-            value={values.firstName}
-            onChange={onChange}
-            label={t('personal_details.fist_name')}
-            placeholder={t('personal_details.fist_name')}
-            error={!!errors.firstName || !!errors.form}
-            helperText={errors.firstName}
-            required={fields.firstNameLastName.required}
-            name="firstName"
-          />
-          <TextField
-            value={values.lastName}
-            onChange={onChange}
-            label={t('personal_details.last_name')}
-            placeholder={t('personal_details.last_name')}
-            error={!!errors.lastName || !!errors.form}
-            helperText={errors.lastName}
-            required={fields.firstNameLastName.required}
-            name="lastName"
-          />
-        </React.Fragment>
-      ) : null}
-      {fields.companyName?.enabled ? (
-        <TextField
-          value={values.companyName}
+
+      {fields.map((field) => (
+        <CustomRegisterField
+          key={field.name}
+          type={field.type}
+          name={field.name}
+          value={values[field.name] || ''}
           onChange={onChange}
-          label={t('personal_details.company_name')}
-          placeholder={t('personal_details.company_name')}
-          error={!!errors.companyName || !!errors.form}
-          helperText={errors.companyName}
-          required={fields.companyName.required}
-          name="companyName"
+          placeholder={field.placeholder}
+          label={field.label}
+          required={field.required}
+          options={field.options}
         />
-      ) : null}
-      {fields.address?.enabled ? (
-        <React.Fragment>
-          <TextField
-            value={values.address}
-            onChange={onChange}
-            label={t('personal_details.address')}
-            placeholder={t('personal_details.address')}
-            error={!!errors.address || !!errors.form}
-            helperText={errors.address}
-            required={fields.address.required}
-            name="address"
-          />
-          <TextField
-            value={values.address2}
-            onChange={onChange}
-            label={t('personal_details.address2')}
-            placeholder={t('personal_details.address2')}
-            error={!!errors.address2 || !!errors.form}
-            helperText={errors.address2}
-            name="address2"
-          />
-          <TextField
-            value={values.city}
-            onChange={onChange}
-            label={t('personal_details.city')}
-            placeholder={t('personal_details.city')}
-            error={!!errors.city || !!errors.form}
-            helperText={errors.city}
-            required={fields.address.required}
-            name="city"
-          />
-          <TextField
-            value={values.state}
-            onChange={onChange}
-            label={t('personal_details.state')}
-            placeholder={t('personal_details.state')}
-            error={!!errors.state || !!errors.form}
-            helperText={errors.state}
-            required={fields.address.required}
-            name="state"
-          />
-          <TextField
-            value={values.postCode}
-            onChange={onChange}
-            label={t('personal_details.post_code')}
-            placeholder={t('personal_details.post_code')}
-            error={!!errors.postCode || !!errors.form}
-            helperText={errors.postCode}
-            required={fields.address.required}
-            name="postCode"
-          />
-        </React.Fragment>
-      ) : null}
-      {fields.phoneNumber?.enabled ? (
-        <TextField
-          value={values.phoneNumber}
-          onChange={onChange}
-          label={t('personal_details.phone_number')}
-          placeholder={t('personal_details.phone_number')}
-          error={!!errors.phoneNumber || !!errors.form}
-          helperText={errors.phoneNumber}
-          required={fields.phoneNumber.required}
-          name="phoneNumber"
-        />
-      ) : null}
-      {fields.birthDate?.enabled ? (
-        <DateField
-          value={values.birthDate}
-          onChange={(event) => setValue('birthDate', event.currentTarget.value)}
-          label={t('personal_details.birth_date')}
-          error={!!errors.birthDate || !!errors.form}
-          helperText={errors.birthDate}
-          required={fields.birthDate.required}
-          name="birthDate"
-        />
-      ) : null}
-      {questions.map((question) => renderQuestion(question))}
+      ))}
+
+      {/*{fields.firstNameLastName?.enabled ? (*/}
+      {/*  <React.Fragment>*/}
+      {/*    <TextField*/}
+      {/*      value={values.firstName}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.fist_name')}*/}
+      {/*      placeholder={t('personal_details.fist_name')}*/}
+      {/*      error={!!errors.firstName || !!errors.form}*/}
+      {/*      helperText={errors.firstName}*/}
+      {/*      required={fields.firstNameLastName.required}*/}
+      {/*      name="firstName"*/}
+      {/*    />*/}
+      {/*    <TextField*/}
+      {/*      value={values.lastName}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.last_name')}*/}
+      {/*      placeholder={t('personal_details.last_name')}*/}
+      {/*      error={!!errors.lastName || !!errors.form}*/}
+      {/*      helperText={errors.lastName}*/}
+      {/*      required={fields.firstNameLastName.required}*/}
+      {/*      name="lastName"*/}
+      {/*    />*/}
+      {/*  </React.Fragment>*/}
+      {/*) : null}*/}
+      {/*{fields.companyName?.enabled ? (*/}
+      {/*  <TextField*/}
+      {/*    value={values.companyName}*/}
+      {/*    onChange={onChange}*/}
+      {/*    label={t('personal_details.company_name')}*/}
+      {/*    placeholder={t('personal_details.company_name')}*/}
+      {/*    error={!!errors.companyName || !!errors.form}*/}
+      {/*    helperText={errors.companyName}*/}
+      {/*    required={fields.companyName.required}*/}
+      {/*    name="companyName"*/}
+      {/*  />*/}
+      {/*) : null}*/}
+      {/*{fields.address?.enabled ? (*/}
+      {/*  <React.Fragment>*/}
+      {/*    <TextField*/}
+      {/*      value={values.address}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.address')}*/}
+      {/*      placeholder={t('personal_details.address')}*/}
+      {/*      error={!!errors.address || !!errors.form}*/}
+      {/*      helperText={errors.address}*/}
+      {/*      required={fields.address.required}*/}
+      {/*      name="address"*/}
+      {/*    />*/}
+      {/*    <TextField*/}
+      {/*      value={values.address2}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.address2')}*/}
+      {/*      placeholder={t('personal_details.address2')}*/}
+      {/*      error={!!errors.address2 || !!errors.form}*/}
+      {/*      helperText={errors.address2}*/}
+      {/*      name="address2"*/}
+      {/*    />*/}
+      {/*    <TextField*/}
+      {/*      value={values.city}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.city')}*/}
+      {/*      placeholder={t('personal_details.city')}*/}
+      {/*      error={!!errors.city || !!errors.form}*/}
+      {/*      helperText={errors.city}*/}
+      {/*      required={fields.address.required}*/}
+      {/*      name="city"*/}
+      {/*    />*/}
+      {/*    <TextField*/}
+      {/*      value={values.state}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.state')}*/}
+      {/*      placeholder={t('personal_details.state')}*/}
+      {/*      error={!!errors.state || !!errors.form}*/}
+      {/*      helperText={errors.state}*/}
+      {/*      required={fields.address.required}*/}
+      {/*      name="state"*/}
+      {/*    />*/}
+      {/*    <TextField*/}
+      {/*      value={values.postCode}*/}
+      {/*      onChange={onChange}*/}
+      {/*      label={t('personal_details.post_code')}*/}
+      {/*      placeholder={t('personal_details.post_code')}*/}
+      {/*      error={!!errors.postCode || !!errors.form}*/}
+      {/*      helperText={errors.postCode}*/}
+      {/*      required={fields.address.required}*/}
+      {/*      name="postCode"*/}
+      {/*    />*/}
+      {/*  </React.Fragment>*/}
+      {/*) : null}*/}
+      {/*{fields.phoneNumber?.enabled ? (*/}
+      {/*  <TextField*/}
+      {/*    value={values.phoneNumber}*/}
+      {/*    onChange={onChange}*/}
+      {/*    label={t('personal_details.phone_number')}*/}
+      {/*    placeholder={t('personal_details.phone_number')}*/}
+      {/*    error={!!errors.phoneNumber || !!errors.form}*/}
+      {/*    helperText={errors.phoneNumber}*/}
+      {/*    required={fields.phoneNumber.required}*/}
+      {/*    name="phoneNumber"*/}
+      {/*  />*/}
+      {/*) : null}*/}
+      {/*{fields.birthDate?.enabled ? (*/}
+      {/*  <DateField*/}
+      {/*    value={values.birthDate}*/}
+      {/*    onChange={(event) => setValue('birthDate', event.currentTarget.value)}*/}
+      {/*    label={t('personal_details.birth_date')}*/}
+      {/*    error={!!errors.birthDate || !!errors.form}*/}
+      {/*    helperText={errors.birthDate}*/}
+      {/*    required={fields.birthDate.required}*/}
+      {/*    name="birthDate"*/}
+      {/*  />*/}
+      {/*) : null}*/}
       <Button
         className={styles.continue}
         type="submit"

--- a/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
+++ b/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
@@ -17,13 +17,14 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
       This is a form error
     </div>
     <div
-      class="_textField_e16c1b _error_e16c1b"
+      class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_firstname"
       >
-        personal_details.fist_name
+        First name
       </label>
       <div
         class="_container_e16c1b"
@@ -32,26 +33,22 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_firstname"
           name="firstName"
-          placeholder="personal_details.fist_name"
+          placeholder=""
           required=""
           type="text"
           value="Vince"
         />
       </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        this is wrong
-      </div>
     </div>
     <div
-      class="_textField_e16c1b _error_e16c1b"
+      class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_lastname"
       >
-        personal_details.last_name
+        Last name
       </label>
       <div
         class="_container_e16c1b"
@@ -60,26 +57,22 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_lastname"
           name="lastName"
-          placeholder="personal_details.last_name"
+          placeholder=""
           required=""
           type="text"
           value="Guy"
         />
       </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        also this
-      </div>
     </div>
     <div
-      class="_textField_e16c1b _error_e16c1b"
+      class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_companyname"
       >
-        personal_details.company_name
+        Company name
         <span>
           optional
         </span>
@@ -91,196 +84,26 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_companyname"
           name="companyName"
-          placeholder="personal_details.company_name"
+          placeholder=""
           type="text"
           value="JW Player"
         />
       </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        So much errors
-      </div>
     </div>
     <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_address"
-      >
-        personal_details.address
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_address"
-          name="address"
-          placeholder="personal_details.address"
-          required=""
-          type="text"
-          value="123 Nowhere St."
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Do you know where you live
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_address2"
-      >
-        personal_details.address2
-        <span>
-          optional
-        </span>
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_address2"
-          name="address2"
-          placeholder="personal_details.address2"
-          type="text"
-          value="Apt 1W"
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Come on
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_city"
-      >
-        personal_details.city
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_city"
-          name="city"
-          placeholder="personal_details.city"
-          required=""
-          type="text"
-          value="Chicago"
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        stop it
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_state"
-      >
-        personal_details.state
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_state"
-          name="state"
-          placeholder="personal_details.state"
-          required=""
-          type="text"
-          value="IL"
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Confusion
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_postcode"
-      >
-        personal_details.post_code
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_postcode"
-          name="postCode"
-          placeholder="personal_details.post_code"
-          required=""
-          type="text"
-          value="60601"
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Post Code should be 5 centimeters
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b _error_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_phonenumber"
-      >
-        personal_details.phone_number
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_phonenumber"
-          name="phoneNumber"
-          placeholder="personal_details.phone_number"
-          required=""
-          type="text"
-          value="+1 555 555 5555"
-        />
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Invalid
-      </div>
-    </div>
-    <div
-      class="_dateField_eb6974 _error_eb6974"
+      class="_dateField_eb6974"
+      data-testid="crf-datepicker"
       id="text-field_1235_birthdate"
+      placeholder=""
     >
       <label
         class="_label_eb6974"
         for="text-field_1235_birthdate"
       >
-        personal_details.birth_date
+        Birth date
+        <span>
+          optional
+        </span>
       </label>
       <div
         class="_container_eb6974"
@@ -320,20 +143,134 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
           value="1985"
         />
       </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
+    </div>
+    <div
+      class="_textField_e16c1b"
+      data-testid="crf-input"
+    >
+      <label
+        class="_label_e16c1b"
+        for="text-field_1235_phonenumber"
       >
-        February 30th? Really?
+        Phone Number
+        <span>
+          optional
+        </span>
+      </label>
+      <div
+        class="_container_e16c1b"
+      >
+        <input
+          class="_input_e16c1b"
+          id="text-field_1235_phonenumber"
+          name="phoneNumber"
+          placeholder=""
+          type="text"
+          value="+1 555 555 5555"
+        />
       </div>
     </div>
     <div
-      class="_container_bb73c6 _fullWidth_bb73c6 _error_bb73c6 _medium_bb73c6"
+      class="_textField_e16c1b"
+      data-testid="crf-input"
+    >
+      <label
+        class="_label_e16c1b"
+        for="text-field_1235_custom_1"
+      >
+        This is a text field
+        <span>
+          optional
+        </span>
+      </label>
+      <div
+        class="_container_e16c1b"
+      >
+        <input
+          class="_input_e16c1b"
+          id="text-field_1235_custom_1"
+          name="custom_1"
+          placeholder=""
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="_checkbox_531f07"
+      data-testid="crf-checkbox"
+      placeholder=""
+    >
+      <div
+        class="_row_531f07"
+      >
+        <input
+          aria-required="false"
+          id="check-box_1235_custom_2"
+          name="custom_2"
+          type="checkbox"
+          value=""
+        />
+        <label
+          for="check-box_1235_custom_2"
+        >
+          This is a checkbox field
+        </label>
+      </div>
+    </div>
+    <div
+      data-testid="crf-radio"
+      label="This is a radio field"
+      placeholder=""
+    >
+      <div
+        class="_header_d50e6e"
+        data-testid="radio-header"
+      >
+        This is a radio field
+      </div>
+      <div
+        class="_radio_d50e6e"
+      >
+        <input
+          id="radio_1235_custom_30"
+          name="custom_3"
+          required=""
+          type="radio"
+          value="option1"
+        />
+        <label
+          for="radio_1235_custom_30"
+        >
+          Option 1
+        </label>
+      </div>
+      <div
+        class="_radio_d50e6e"
+      >
+        <input
+          id="radio_1235_custom_31"
+          name="custom_3"
+          required=""
+          type="radio"
+          value="option2"
+        />
+        <label
+          for="radio_1235_custom_31"
+        >
+          Option 2
+        </label>
+      </div>
+    </div>
+    <div
+      class="_container_bb73c6 _fullWidth_bb73c6 _medium_bb73c6"
+      data-testid="crf-select"
     >
       <label
         class="_label_bb73c6"
         for="1235"
       >
-        Which number is 2?
+        This is a select field
       </label>
       <div
         class="_dropdown_bb73c6 _fullWidth_bb73c6"
@@ -342,118 +279,28 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
           aria-required="true"
           class="_select_bb73c6"
           id="1235"
-          name="key1"
+          name="custom_4"
+          placeholder=""
         >
           <option
             class="_option_bb73c6"
-            disabled=""
-            value=""
+            value="option1"
           >
-            personal_details.select_answer
+            Option 1
           </option>
           <option
             class="_option_bb73c6"
-            value="1"
+            value="option2"
           >
-            1
+            Option 2
           </option>
           <option
             class="_option_bb73c6"
-            value="2"
+            value="option3"
           >
-            2
-          </option>
-          <option
-            class="_option_bb73c6"
-            value="3"
-          >
-            3
+            Option 3
           </option>
         </select>
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        question 1 is invalid
-      </div>
-    </div>
-    <div>
-      <div
-        class="_header_d50e6e"
-        data-testid="radio-header"
-      >
-        Is this a question?
-        <span>
-          optional
-        </span>
-      </div>
-      <div
-        class="_radio_d50e6e"
-      >
-        <input
-          id="radio_1235_key20"
-          name="key2"
-          type="radio"
-          value="Yes"
-        />
-        <label
-          for="radio_1235_key20"
-        >
-          Yes
-        </label>
-      </div>
-      <div
-        class="_radio_d50e6e"
-      >
-        <input
-          checked=""
-          id="radio_1235_key21"
-          name="key2"
-          type="radio"
-          value="No"
-        />
-        <label
-          for="radio_1235_key21"
-        >
-          No
-        </label>
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0"
-      >
-        Invalid answer
-      </div>
-    </div>
-    <div
-      class="_checkbox_531f07 _error_531f07"
-    >
-      <div
-        class="_header_531f07"
-      >
-        Check this off.
-      </div>
-      <div
-        class="_row_531f07"
-      >
-        <input
-          aria-required="true"
-          checked=""
-          id="check-box_1235_ccc"
-          name="ccc"
-          type="checkbox"
-          value="CheckMe"
-        />
-        <label
-          for="check-box_1235_ccc"
-        >
-          * 
-          CheckMe
-        </label>
-      </div>
-      <div
-        class="_helperText_da58e0 _error_da58e0 _helperTextError_531f07"
-      >
-        No way Jose
       </div>
     </div>
     <button
@@ -482,12 +329,13 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     </h2>
     <div
       class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_firstname"
       >
-        personal_details.fist_name
+        First name
       </label>
       <div
         class="_container_e16c1b"
@@ -496,7 +344,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_firstname"
           name="firstName"
-          placeholder="personal_details.fist_name"
+          placeholder=""
           required=""
           type="text"
           value="Vince"
@@ -505,12 +353,13 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     </div>
     <div
       class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_lastname"
       >
-        personal_details.last_name
+        Last name
       </label>
       <div
         class="_container_e16c1b"
@@ -519,7 +368,7 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_lastname"
           name="lastName"
-          placeholder="personal_details.last_name"
+          placeholder=""
           required=""
           type="text"
           value="Guy"
@@ -528,12 +377,13 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
     </div>
     <div
       class="_textField_e16c1b"
+      data-testid="crf-input"
     >
       <label
         class="_label_e16c1b"
         for="text-field_1235_companyname"
       >
-        personal_details.company_name
+        Company name
         <span>
           optional
         </span>
@@ -545,161 +395,26 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
           class="_input_e16c1b"
           id="text-field_1235_companyname"
           name="companyName"
-          placeholder="personal_details.company_name"
+          placeholder=""
           type="text"
           value="JW Player"
         />
       </div>
     </div>
     <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_address"
-      >
-        personal_details.address
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_address"
-          name="address"
-          placeholder="personal_details.address"
-          required=""
-          type="text"
-          value="123 Nowhere St."
-        />
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_address2"
-      >
-        personal_details.address2
-        <span>
-          optional
-        </span>
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_address2"
-          name="address2"
-          placeholder="personal_details.address2"
-          type="text"
-          value="Apt 1W"
-        />
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_city"
-      >
-        personal_details.city
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_city"
-          name="city"
-          placeholder="personal_details.city"
-          required=""
-          type="text"
-          value="Chicago"
-        />
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_state"
-      >
-        personal_details.state
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_state"
-          name="state"
-          placeholder="personal_details.state"
-          required=""
-          type="text"
-          value="IL"
-        />
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_postcode"
-      >
-        personal_details.post_code
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_postcode"
-          name="postCode"
-          placeholder="personal_details.post_code"
-          required=""
-          type="text"
-          value="60601"
-        />
-      </div>
-    </div>
-    <div
-      class="_textField_e16c1b"
-    >
-      <label
-        class="_label_e16c1b"
-        for="text-field_1235_phonenumber"
-      >
-        personal_details.phone_number
-      </label>
-      <div
-        class="_container_e16c1b"
-      >
-        <input
-          class="_input_e16c1b"
-          id="text-field_1235_phonenumber"
-          name="phoneNumber"
-          placeholder="personal_details.phone_number"
-          required=""
-          type="text"
-          value="+1 555 555 5555"
-        />
-      </div>
-    </div>
-    <div
       class="_dateField_eb6974"
+      data-testid="crf-datepicker"
       id="text-field_1235_birthdate"
+      placeholder=""
     >
       <label
         class="_label_eb6974"
         for="text-field_1235_birthdate"
       >
-        personal_details.birth_date
+        Birth date
+        <span>
+          optional
+        </span>
       </label>
       <div
         class="_container_eb6974"
@@ -741,13 +456,132 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
       </div>
     </div>
     <div
+      class="_textField_e16c1b"
+      data-testid="crf-input"
+    >
+      <label
+        class="_label_e16c1b"
+        for="text-field_1235_phonenumber"
+      >
+        Phone Number
+        <span>
+          optional
+        </span>
+      </label>
+      <div
+        class="_container_e16c1b"
+      >
+        <input
+          class="_input_e16c1b"
+          id="text-field_1235_phonenumber"
+          name="phoneNumber"
+          placeholder=""
+          type="text"
+          value="+1 555 555 5555"
+        />
+      </div>
+    </div>
+    <div
+      class="_textField_e16c1b"
+      data-testid="crf-input"
+    >
+      <label
+        class="_label_e16c1b"
+        for="text-field_1235_custom_1"
+      >
+        This is a text field
+        <span>
+          optional
+        </span>
+      </label>
+      <div
+        class="_container_e16c1b"
+      >
+        <input
+          class="_input_e16c1b"
+          id="text-field_1235_custom_1"
+          name="custom_1"
+          placeholder=""
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="_checkbox_531f07"
+      data-testid="crf-checkbox"
+      placeholder=""
+    >
+      <div
+        class="_row_531f07"
+      >
+        <input
+          aria-required="false"
+          id="check-box_1235_custom_2"
+          name="custom_2"
+          type="checkbox"
+          value=""
+        />
+        <label
+          for="check-box_1235_custom_2"
+        >
+          This is a checkbox field
+        </label>
+      </div>
+    </div>
+    <div
+      data-testid="crf-radio"
+      label="This is a radio field"
+      placeholder=""
+    >
+      <div
+        class="_header_d50e6e"
+        data-testid="radio-header"
+      >
+        This is a radio field
+      </div>
+      <div
+        class="_radio_d50e6e"
+      >
+        <input
+          id="radio_1235_custom_30"
+          name="custom_3"
+          required=""
+          type="radio"
+          value="option1"
+        />
+        <label
+          for="radio_1235_custom_30"
+        >
+          Option 1
+        </label>
+      </div>
+      <div
+        class="_radio_d50e6e"
+      >
+        <input
+          id="radio_1235_custom_31"
+          name="custom_3"
+          required=""
+          type="radio"
+          value="option2"
+        />
+        <label
+          for="radio_1235_custom_31"
+        >
+          Option 2
+        </label>
+      </div>
+    </div>
+    <div
       class="_container_bb73c6 _fullWidth_bb73c6 _medium_bb73c6"
+      data-testid="crf-select"
     >
       <label
         class="_label_bb73c6"
         for="1235"
       >
-        Which number is 2?
+        This is a select field
       </label>
       <div
         class="_dropdown_bb73c6 _fullWidth_bb73c6"
@@ -756,103 +590,28 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
           aria-required="true"
           class="_select_bb73c6"
           id="1235"
-          name="key1"
+          name="custom_4"
+          placeholder=""
         >
           <option
             class="_option_bb73c6"
-            disabled=""
-            value=""
+            value="option1"
           >
-            personal_details.select_answer
+            Option 1
           </option>
           <option
             class="_option_bb73c6"
-            value="1"
+            value="option2"
           >
-            1
+            Option 2
           </option>
           <option
             class="_option_bb73c6"
-            value="2"
+            value="option3"
           >
-            2
-          </option>
-          <option
-            class="_option_bb73c6"
-            value="3"
-          >
-            3
+            Option 3
           </option>
         </select>
-      </div>
-    </div>
-    <div>
-      <div
-        class="_header_d50e6e"
-        data-testid="radio-header"
-      >
-        Is this a question?
-        <span>
-          optional
-        </span>
-      </div>
-      <div
-        class="_radio_d50e6e"
-      >
-        <input
-          id="radio_1235_key20"
-          name="key2"
-          type="radio"
-          value="Yes"
-        />
-        <label
-          for="radio_1235_key20"
-        >
-          Yes
-        </label>
-      </div>
-      <div
-        class="_radio_d50e6e"
-      >
-        <input
-          checked=""
-          id="radio_1235_key21"
-          name="key2"
-          type="radio"
-          value="No"
-        />
-        <label
-          for="radio_1235_key21"
-        >
-          No
-        </label>
-      </div>
-    </div>
-    <div
-      class="_checkbox_531f07"
-    >
-      <div
-        class="_header_531f07"
-      >
-        Check this off.
-      </div>
-      <div
-        class="_row_531f07"
-      >
-        <input
-          aria-required="true"
-          checked=""
-          id="check-box_1235_ccc"
-          name="ccc"
-          type="checkbox"
-          value="CheckMe"
-        />
-        <label
-          for="check-box_1235_ccc"
-        >
-          * 
-          CheckMe
-        </label>
       </div>
     </div>
     <button

--- a/packages/ui-react/src/components/Radio/Radio.module.scss
+++ b/packages/ui-react/src/components/Radio/Radio.module.scss
@@ -30,12 +30,14 @@
     height: 20px;
     margin: 0;
     border-radius: 15px;
+    cursor: pointer;
     transition: all 0.1s;
     appearance: none;
 
     &:not(:checked) {
       border: 2px solid theme.$input-resting-border-color;
-      &:hover {
+
+      &:hover:not(:disabled) {
         border-color: theme.$input-hover-border-color;
       }
     }
@@ -44,6 +46,7 @@
       width: 20px;
       height: 20px;
       border: 2px solid var(--primary-color);
+
       &::after {
         position: absolute;
         top: 50%;
@@ -55,6 +58,28 @@
         border-radius: 15px;
         transform: translateX(-50%) translateY(-50%);
         content: '';
+      }
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.6;
+      pointer-events: none;
+
+      & + label {
+        cursor: default;
+      }
+    }
+  }
+}
+
+.error {
+  .radio {
+    input {
+      border-color: theme.$input-field-error-color;
+
+      &::after {
+        background-color: theme.$input-field-error-color;
       }
     }
   }

--- a/packages/ui-react/src/components/Radio/Radio.tsx
+++ b/packages/ui-react/src/components/Radio/Radio.tsx
@@ -15,9 +15,10 @@ type Props = {
   helperText?: string;
   error?: boolean;
   required?: boolean;
+  disabled?: boolean;
 };
 
-const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperText, error, required, ...rest }: Props) => {
+const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperText, error, required, disabled, ...rest }: Props) => {
   const { t } = useTranslation('common');
   const id = useOpaqueId('radio', name);
 
@@ -31,7 +32,16 @@ const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperT
       ) : null}
       {values.map(({ value: optionValue, label: optionLabel }, index) => (
         <div className={styles.radio} key={index}>
-          <input value={optionValue} name={name} type="radio" id={id + index} onChange={onChange} checked={value === optionValue} required={required} />
+          <input
+            value={optionValue}
+            name={name}
+            type="radio"
+            id={id + index}
+            onChange={onChange}
+            checked={value === optionValue}
+            required={required}
+            disabled={disabled}
+          />
           <label htmlFor={id + index}>{optionLabel}</label>
         </div>
       ))}

--- a/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
-import { mixed, object, string } from 'yup';
 import { useQuery } from 'react-query';
-import type { PersonalDetailsFormData } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
@@ -11,27 +8,21 @@ import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/useForm';
 import useOffers from '@jwp/ott-hooks-react/src/useOffers';
+import type { GenericFormValues } from '@jwp/ott-common/types/form';
 
 import PersonalDetailsForm from '../../../components/PersonalDetailsForm/PersonalDetailsForm';
 import LoadingOverlay from '../../../components/LoadingOverlay/LoadingOverlay';
-
-const yupConditional = (required: boolean, message: string) => {
-  return required ? string().required(message) : mixed().notRequired();
-};
 
 const PersonalDetails = () => {
   const accountController = getModule(AccountController);
 
   const navigate = useNavigate();
   const location = useLocation();
-  const { t } = useTranslation('account');
   const accessModel = useConfigStore((s) => s.accessModel);
   const { data, isLoading } = useQuery('captureStatus', accountController.getRegistrationFields);
   const { hasMediaOffers } = useOffers();
-  // const [questionValues, setQuestionValues] = useState<Record<string, string>>({});
-  // const [questionErrors, setQuestionErrors] = useState<Record<string, string>>({});
 
-  const fields = data?.fields || [];
+  const fields = useMemo(() => data?.fields || [], [data]);
 
   const nextStep = useCallback(() => {
     const hasOffers = accessModel === ACCESS_MODEL.SVOD || (accessModel === ACCESS_MODEL.AUTHVOD && hasMediaOffers);
@@ -45,63 +36,12 @@ const PersonalDetails = () => {
 
   const initialValues: Record<string, string> = {};
 
-  // const questionChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   const value = event.target.type === 'checkbox' && !event.target.checked ? '' : event.target.value;
-  //
-  //   setQuestionValues((current) => ({ ...current, [event.target.name]: value }));
-  // };
-
-  console.log(fields);
-
-  const PersonalDetailSubmitHandler: UseFormOnSubmitHandler<Record<string, string>> = async (formData, { setErrors, setSubmitting, validate }) => {
-    // const requiredMessage = t('personal_details.this_field_is_required');
-    const schema = object().shape({
-      // firstName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
-      // lastName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
-      // address1: yupConditional(!!fields.address?.required, requiredMessage),
-      // address2: yupConditional(!!fields.address?.required, requiredMessage),
-      // postCode: yupConditional(!!fields.address?.required, requiredMessage),
-      // state: yupConditional(!!fields.address?.required, requiredMessage),
-      // city: yupConditional(!!fields.address?.required, requiredMessage),
-      // companyName: yupConditional(!!fields.companyName?.required, requiredMessage),
-      // birthDate: fields.birthDate?.required
-      //   ? string()
-      //   .required(requiredMessage)
-      //   .matches(/\d{4}-\d{2}-\d{2}/, t('personal_details.birth_date_not_valid'))
-      //   : mixed().notRequired(),
-      // phoneNumber: yupConditional(!!fields.phoneNumber?.required, requiredMessage),
-    });
-
-    const errors: Record<string, string> = {};
-
-    // questions.forEach((question) => {
-    //   if (question.enabled && question.required && !questionValues[question.key]) {
-    //     errors[question.key] = t('personal_details.this_field_is_required');
-    //   }
-    // });
-    //
-    // setQuestionErrors(errors);
-
-    // we have validation errors
-    if (!validate(schema) || Object.keys(errors).length) {
-      setSubmitting(false);
-      return;
-    }
-
+  const PersonalDetailSubmitHandler: UseFormOnSubmitHandler<GenericFormValues> = async (formData, { setErrors, setSubmitting }) => {
     try {
-      const removeEmpty = (obj: Record<string, string>) =>
-        Object.fromEntries(
-          Object.keys(obj)
-            .filter((key) => obj[key] !== '')
-            .map((key) => [key, obj[key]]),
-        );
-
-      await accountController.updateRegistrationFieldsValues(fields, removeEmpty({ ...formData }));
-
-      if ('notthere' in window) {
-        nextStep();
-      }
+      await accountController.updateRegistrationFieldsValues(fields, formData);
+      nextStep();
     } catch (error: unknown) {
+      // TODO: handle form errors from thrown by controller
       if (error instanceof Error) {
         setErrors({ form: error.message });
       }
@@ -110,7 +50,13 @@ const PersonalDetails = () => {
     setSubmitting(false);
   };
 
-  const { setValue, handleSubmit, handleChange, values, errors, submitting } = useForm<Record<string, string>>(initialValues, PersonalDetailSubmitHandler);
+  const { setValue, handleSubmit, handleChange, values, errors, submitting } = useForm<GenericFormValues>(initialValues, PersonalDetailSubmitHandler);
+
+  useEffect(() => {
+    fields.forEach((field) => {
+      setValue(field.name, field.type === 'checkbox' ? !!field.enabledByDefault : field.defaultValue || '');
+    });
+  }, [fields, setValue]);
 
   if (isLoading) {
     return (
@@ -120,17 +66,7 @@ const PersonalDetails = () => {
     );
   }
 
-  return (
-    <PersonalDetailsForm
-      fields={fields}
-      onSubmit={handleSubmit}
-      onChange={handleChange}
-      setValue={setValue}
-      values={values}
-      errors={errors}
-      submitting={submitting}
-    />
-  );
+  return <PersonalDetailsForm fields={fields} onSubmit={handleSubmit} onChange={handleChange} values={values} errors={errors} submitting={submitting} />;
 };
 
 export default PersonalDetails;

--- a/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { mixed, object, string } from 'yup';
 import { useQuery } from 'react-query';
-import type { CaptureCustomAnswer, CleengCaptureQuestionField, PersonalDetailsFormData } from '@jwp/ott-common/types/account';
+import type { PersonalDetailsFormData } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import AccountController from '@jwp/ott-common/src/stores/AccountController';
@@ -26,16 +26,12 @@ const PersonalDetails = () => {
   const location = useLocation();
   const { t } = useTranslation('account');
   const accessModel = useConfigStore((s) => s.accessModel);
-  const { data, isLoading } = useQuery('captureStatus', accountController.getCaptureStatus);
+  const { data, isLoading } = useQuery('captureStatus', accountController.getRegistrationFields);
   const { hasMediaOffers } = useOffers();
-  const [questionValues, setQuestionValues] = useState<Record<string, string>>({});
-  const [questionErrors, setQuestionErrors] = useState<Record<string, string>>({});
+  // const [questionValues, setQuestionValues] = useState<Record<string, string>>({});
+  // const [questionErrors, setQuestionErrors] = useState<Record<string, string>>({});
 
-  const fields = useMemo(() => Object.fromEntries(data?.settings.map((item) => [item.key, item]) || []), [data]);
-  const questions = useMemo(
-    () => (data?.settings.filter((item) => !!(item as CleengCaptureQuestionField).question) as CleengCaptureQuestionField[]) || [],
-    [data],
-  );
+  const fields = data?.fields || [];
 
   const nextStep = useCallback(() => {
     const hasOffers = accessModel === ACCESS_MODEL.SVOD || (accessModel === ACCESS_MODEL.AUTHVOD && hasMediaOffers);
@@ -44,61 +40,47 @@ const PersonalDetails = () => {
   }, [navigate, location, accessModel, hasMediaOffers]);
 
   useEffect(() => {
-    if (data && (!data.isCaptureEnabled || !data.shouldCaptureBeDisplayed)) nextStep();
+    if (data && (!data.enabled || data.beforeSignUp)) nextStep();
+  }, [data, nextStep]);
 
-    if (data && questions) {
-      setQuestionValues(Object.fromEntries(questions.map((question) => [question.key, ''])));
-    }
-  }, [data, nextStep, questions]);
+  const initialValues: Record<string, string> = {};
 
-  const initialValues: PersonalDetailsFormData = {
-    firstName: '',
-    lastName: '',
-    birthDate: '',
-    companyName: '',
-    phoneNumber: '',
-    address: '',
-    address2: '',
-    city: '',
-    state: '',
-    postCode: '',
-    country: '',
-  };
+  // const questionChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   const value = event.target.type === 'checkbox' && !event.target.checked ? '' : event.target.value;
+  //
+  //   setQuestionValues((current) => ({ ...current, [event.target.name]: value }));
+  // };
 
-  const questionChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.type === 'checkbox' && !event.target.checked ? '' : event.target.value;
+  console.log(fields);
 
-    setQuestionValues((current) => ({ ...current, [event.target.name]: value }));
-  };
-
-  const PersonalDetailSubmitHandler: UseFormOnSubmitHandler<PersonalDetailsFormData> = async (formData, { setErrors, setSubmitting, validate }) => {
-    const requiredMessage = t('personal_details.this_field_is_required');
+  const PersonalDetailSubmitHandler: UseFormOnSubmitHandler<Record<string, string>> = async (formData, { setErrors, setSubmitting, validate }) => {
+    // const requiredMessage = t('personal_details.this_field_is_required');
     const schema = object().shape({
-      firstName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
-      lastName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
-      address1: yupConditional(!!fields.address?.required, requiredMessage),
-      address2: yupConditional(!!fields.address?.required, requiredMessage),
-      postCode: yupConditional(!!fields.address?.required, requiredMessage),
-      state: yupConditional(!!fields.address?.required, requiredMessage),
-      city: yupConditional(!!fields.address?.required, requiredMessage),
-      companyName: yupConditional(!!fields.companyName?.required, requiredMessage),
-      birthDate: fields.birthDate?.required
-        ? string()
-            .required(requiredMessage)
-            .matches(/\d{4}-\d{2}-\d{2}/, t('personal_details.birth_date_not_valid'))
-        : mixed().notRequired(),
-      phoneNumber: yupConditional(!!fields.phoneNumber?.required, requiredMessage),
+      // firstName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
+      // lastName: yupConditional(!!fields.firstNameLastName?.required, requiredMessage),
+      // address1: yupConditional(!!fields.address?.required, requiredMessage),
+      // address2: yupConditional(!!fields.address?.required, requiredMessage),
+      // postCode: yupConditional(!!fields.address?.required, requiredMessage),
+      // state: yupConditional(!!fields.address?.required, requiredMessage),
+      // city: yupConditional(!!fields.address?.required, requiredMessage),
+      // companyName: yupConditional(!!fields.companyName?.required, requiredMessage),
+      // birthDate: fields.birthDate?.required
+      //   ? string()
+      //   .required(requiredMessage)
+      //   .matches(/\d{4}-\d{2}-\d{2}/, t('personal_details.birth_date_not_valid'))
+      //   : mixed().notRequired(),
+      // phoneNumber: yupConditional(!!fields.phoneNumber?.required, requiredMessage),
     });
 
     const errors: Record<string, string> = {};
 
-    questions.forEach((question) => {
-      if (question.enabled && question.required && !questionValues[question.key]) {
-        errors[question.key] = t('personal_details.this_field_is_required');
-      }
-    });
-
-    setQuestionErrors(errors);
+    // questions.forEach((question) => {
+    //   if (question.enabled && question.required && !questionValues[question.key]) {
+    //     errors[question.key] = t('personal_details.this_field_is_required');
+    //   }
+    // });
+    //
+    // setQuestionErrors(errors);
 
     // we have validation errors
     if (!validate(schema) || Object.keys(errors).length) {
@@ -107,24 +89,18 @@ const PersonalDetails = () => {
     }
 
     try {
-      const removeEmpty = (obj: Record<string, unknown>) =>
+      const removeEmpty = (obj: Record<string, string>) =>
         Object.fromEntries(
           Object.keys(obj)
             .filter((key) => obj[key] !== '')
             .map((key) => [key, obj[key]]),
         );
-      const customAnswers = questions.map(
-        (question) =>
-          ({
-            question: question.question,
-            questionId: question.key,
-            value: questionValues[question.key],
-          } as CaptureCustomAnswer),
-      );
 
-      await accountController.updateCaptureAnswers(removeEmpty({ ...formData, customAnswers }));
+      await accountController.updateRegistrationFieldsValues(fields, removeEmpty({ ...formData }));
 
-      nextStep();
+      if ('notthere' in window) {
+        nextStep();
+      }
     } catch (error: unknown) {
       if (error instanceof Error) {
         setErrors({ form: error.message });
@@ -134,7 +110,7 @@ const PersonalDetails = () => {
     setSubmitting(false);
   };
 
-  const { setValue, handleSubmit, handleChange, values, errors, submitting } = useForm<PersonalDetailsFormData>(initialValues, PersonalDetailSubmitHandler);
+  const { setValue, handleSubmit, handleChange, values, errors, submitting } = useForm<Record<string, string>>(initialValues, PersonalDetailSubmitHandler);
 
   if (isLoading) {
     return (
@@ -147,10 +123,6 @@ const PersonalDetails = () => {
   return (
     <PersonalDetailsForm
       fields={fields}
-      questions={questions}
-      onQuestionChange={questionChangeHandler}
-      questionValues={questionValues}
-      questionErrors={questionErrors}
       onSubmit={handleSubmit}
       onChange={handleChange}
       setValue={setValue}

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -23,7 +23,7 @@ const Registration = () => {
   const [consentErrors, setConsentErrors] = useState<string[]>([]);
 
   const appConfigId = useConfigStore(({ config }) => config.id);
-  const { data, isLoading: publisherConsentsLoading } = useQuery(['consents', appConfigId], accountController.getPublisherConsents);
+  const { data, isLoading: publisherConsentsLoading } = useQuery(['consents', appConfigId], accountController.getConsents);
 
   const publisherConsents = useMemo(() => data || [], [data]);
 


### PR DESCRIPTION
## Description

This PR is the result of refactoring the consent and capture methods. Here are the changes:

## Common

**DONE:**

- Rename service consents methods
  - `AccountService#getPublisherConsents ` -> `AccountService#getConsents`
  - `AccountService#getCustomerConsents ` -> `AccountService#getConsentsValues`
  - `AccountService#updateCustomerConsents ` -> `AccountService#updateConsentsValues`
- Update and cleaned consents typings
- Remove JWP registration fields from consents (will be refactored to getRegistrationFields)
- Rename service capture methods
  - `AccountService#getCaptureStatus` -> `AccountService#getRegistrationFields`
  - `AccountService#updateCaptureAnswers` -> `AccountService#updateRegistrationFieldsValues`
- Change the return type of `getRegistrationFields` method to `CustomFormField[]`
  - The integration can decide and build the form fields dynamically now
- Change the signature of the `updateRegistrationFieldsValues` method to customer, fields and values
- Generate Cleeng-specific update payload in the Cleeng integration with the help of formatters (small and testable)
- Move more Cleeng typings to the Cleeng integration folder

**TODO:**

- Update JWP integration with new methods

## Account page

**DONE:**

- Use `getRegistrationFields` for the "About you" section (no more mixing of customer/capture/consents data)
- Use updateRegistrationFieldsValues` for updating the "About you" section
- Remove the "Other registration data" section because these fields will now show in the "About you" section
- Clean up consent fields and values
- Add disabled and error state to Radio component 

**TODO:**

- Form errors need to be handled. @royschut is in the process of refactoring this

## Registration

**TODO:**

- Implement updated consent and registration field data

I still have to finish this PR and update the JWP integration, but I hope to get some early feedback.