### PR TITLE
Fix / accessibility offer arrow keys support

### DIFF
--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
@@ -31,9 +31,10 @@ type Props = {
 
 type OfferBoxProps = {
   offer: Offer;
-} & Pick<Props, 'values' | 'onChange'>;
+  selected: boolean;
+} & Pick<Props, 'onChange'>;
 
-const OfferBox: React.FC<OfferBoxProps> = ({ offer, values, onChange }: OfferBoxProps) => {
+const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferBoxProps) => {
   const { t } = useTranslation('account');
 
   const getFreeTrialText = (offer: Offer) => {
@@ -61,7 +62,7 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, values, onChange }: OfferBox
         name={'offerId'}
         value={offer.offerId}
         id={offer.offerId}
-        checked={values.offerId === offer.offerId}
+        checked={selected}
         data-testid={testId(title)}
       />
       <label className={styles.label} htmlFor={offer.offerId}>
@@ -162,7 +163,7 @@ const ChooseOfferForm: React.FC<Props> = ({
         {!offers.length ? (
           <p>{t('choose_offer.no_pricing_available')}</p>
         ) : (
-          offers.map((offer) => <OfferBox key={offer.offerId} offer={offer} values={values} onChange={onChange} />)
+          offers.map((offer) => <OfferBox key={offer.offerId} offer={offer} selected={values.offerId === offer.offerId} onChange={onChange} />)
         )}
       </div>
       {submitting && <LoadingOverlay transparentBackground inline />}


### PR DESCRIPTION
I noticed the DOM gets updated when you choose an other option. This caused the focus to be lost (and be set on the `body`-element).

Christiaan noticed this was because the JSX function is defined within the component itself. Because the state is changed, the JSX function get redefined (again) causing the unwanted DOM update.

By moving the JSX function outside the component this is fixed. Now you can control the radiobuttons with your arrow keys (not with the tab keys ;-)). This is native browser behaviour.

Based on Christiaan his suggestion, I rewrote it in to a React component instead of a JSX function. I agree this is better. I wanted to split it in to a own component, but moving the styling and rewriting the unit tests caused me too much delay. So I kept it in the same component in the end.

Ticket: https://videodock.atlassian.net/browse/OTT-480