### PR TITLE
Feat / a11y apply lang attribute to custom fields

### DIFF
--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -2,6 +2,7 @@ export type Env = {
   APP_VERSION: string;
   APP_API_BASE_URL: string;
   APP_PLAYER_ID: string;
+  APP_DEFAULT_LANGUAGE: string;
 
   APP_DEFAULT_CONFIG_SOURCE?: string;
   APP_PLAYER_LICENSE_KEY?: string;
@@ -14,12 +15,14 @@ const env: Env = {
   APP_VERSION: '',
   APP_API_BASE_URL: 'https://cdn.jwplayer.com',
   APP_PLAYER_ID: 'M4qoGvUk',
+  APP_DEFAULT_LANGUAGE: 'en',
 };
 
 export const configureEnv = (options: Partial<Env>) => {
   env.APP_VERSION = options.APP_VERSION || env.APP_VERSION;
   env.APP_API_BASE_URL = options.APP_API_BASE_URL || env.APP_API_BASE_URL;
   env.APP_PLAYER_ID = options.APP_PLAYER_ID || env.APP_PLAYER_ID;
+  env.APP_DEFAULT_LANGUAGE = options.APP_DEFAULT_LANGUAGE || env.APP_DEFAULT_LANGUAGE;
 
   env.APP_DEFAULT_CONFIG_SOURCE ||= options.APP_DEFAULT_CONFIG_SOURCE;
   env.APP_PLAYER_LICENSE_KEY ||= options.APP_PLAYER_LICENSE_KEY;

--- a/packages/ui-react/src/components/Account/Account.tsx
+++ b/packages/ui-react/src/components/Account/Account.tsx
@@ -13,6 +13,7 @@ import { formatConsents, formatConsentsFromValues, formatConsentsToRegisterField
 import useToggle from '@jwp/ott-hooks-react/src/useToggle';
 import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
 import VisibilityOff from '@jwp/ott-theme/assets/icons/visibility_off.svg?react';
+import env from '@jwp/ott-common/src/env';
 
 import type { FormSectionContentArgs, FormSectionProps } from '../Form/FormSection';
 import Alert from '../Alert/Alert';
@@ -46,7 +47,7 @@ interface FormErrors {
 const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }: Props): JSX.Element => {
   const accountController = getModule(AccountController);
 
-  const { t } = useTranslation('user');
+  const { t, i18n } = useTranslation('user');
   const announce = useAriaAnnouncer();
   const navigate = useNavigate();
   const location = useLocation();
@@ -54,6 +55,7 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
   const exportData = useMutation(accountController.exportAccountData);
   const [isAlertVisible, setIsAlertVisible] = useState(false);
   const exportDataMessage = exportData.isSuccess ? t('account.export_data_success') : t('account.export_data_error');
+  const htmlLang = i18n.language !== env.APP_DEFAULT_LANGUAGE ? env.APP_DEFAULT_LANGUAGE : undefined;
 
   useEffect(() => {
     if (exportData.isSuccess || exportData.isError) {
@@ -332,6 +334,7 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
                     onChange={section.onChange}
                     label={formatConsentLabel(consent.label)}
                     disabled={consent.required || section.isBusy}
+                    lang={htmlLang}
                   />
                 ))}
               </>
@@ -366,6 +369,7 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
                       disabled={(consent.type === 'checkbox' && consent.required) || section.isBusy}
                       onChange={section.onChange}
                       required={consent.required}
+                      lang={htmlLang}
                     />
                   ))}
                 </div>

--- a/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
+++ b/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
@@ -195,6 +195,7 @@ exports[`<Account> > renders and matches snapshot 1`] = `
           />
           <label
             for="check-box_1235_consentsvalues_marketing"
+            lang="en"
           >
             Receive Marketing Emails
           </label>

--- a/packages/ui-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui-react/src/components/Checkbox/Checkbox.tsx
@@ -18,9 +18,10 @@ type Props = {
   helperText?: string;
   disabled?: boolean;
   required?: boolean;
+  lang?: string;
 };
 
-const Checkbox: React.FC<Props> = ({ label, name, onChange, header, checked, value, helperText, disabled, error, required, ...rest }: Props) => {
+const Checkbox: React.FC<Props> = ({ label, name, onChange, header, checked, value, helperText, disabled, error, required, lang, ...rest }: Props) => {
   const { t } = useTranslation('common');
   const id = useOpaqueId('check-box', name);
   const helperTextId = useOpaqueId('helper_text', name);
@@ -45,7 +46,7 @@ const Checkbox: React.FC<Props> = ({ label, name, onChange, header, checked, val
           aria-required={required}
           aria-describedby={helperTextId}
         />
-        <label htmlFor={id}>
+        <label htmlFor={id} lang={lang}>
           {required ? '* ' : ''}
           {label}
         </label>

--- a/packages/ui-react/src/components/CustomRegisterField/CustomRegisterField.tsx
+++ b/packages/ui-react/src/components/CustomRegisterField/CustomRegisterField.tsx
@@ -23,9 +23,10 @@ export type CustomRegisterFieldCommonProps = {
   disabled: boolean;
   required: boolean;
   options: RegisterFieldOptions;
+  lang?: string;
 }>;
 
-const CustomRegisterField: FC<CustomRegisterFieldCommonProps> = ({ type, value = '', options, ...props }) => {
+const CustomRegisterField: FC<CustomRegisterFieldCommonProps> = ({ type, value = '', options, lang, ...props }) => {
   const { t, i18n } = useTranslation();
 
   const optionsList = useMemo(() => {
@@ -49,15 +50,25 @@ const CustomRegisterField: FC<CustomRegisterFieldCommonProps> = ({ type, value =
     case 'input':
       return <TextField {...props} value={value as string} testId={testId(`crf-${type}`)} />;
     case 'radio':
-      return <Radio {...props} values={optionsList} value={value as string} header={props.label} data-testid={testId(`crf-${type}`)} />;
+      return <Radio {...props} values={optionsList} value={value as string} header={props.label} data-testid={testId(`crf-${type}`)} lang={lang} />;
     case 'select':
     case 'country':
     case 'us_state':
-      return <Dropdown {...props} options={optionsList} value={value as string} defaultLabel={props.placeholder} fullWidth testId={testId(`crf-${type}`)} />;
+      return (
+        <Dropdown
+          {...props}
+          options={optionsList}
+          value={value as string}
+          defaultLabel={props.placeholder}
+          fullWidth
+          testId={testId(`crf-${type}`)}
+          lang={lang}
+        />
+      );
     case 'datepicker':
       return <DateField {...props} value={value as string} testId={testId(`crf-${type}`)} />;
     default:
-      return <Checkbox {...props} checked={isTruthyCustomParamValue(value)} data-testid={testId(`crf-${type}`)} />;
+      return <Checkbox {...props} checked={isTruthyCustomParamValue(value)} data-testid={testId(`crf-${type}`)} lang={lang} />;
   }
 };
 

--- a/packages/ui-react/src/components/CustomRegisterField/__snapshots__/CustomRegisterField.test.tsx.snap
+++ b/packages/ui-react/src/components/CustomRegisterField/__snapshots__/CustomRegisterField.test.tsx.snap
@@ -250,8 +250,12 @@ exports[`<CustomRegisterField> > renders and matches snapshot <Radio> 1`] = `
       data-testid="radio-header"
       for="radio_1235_name"
     >
-      label
       <span>
+        label
+      </span>
+      <span
+        class="_note_d50e6e"
+      >
         optional
       </span>
     </label>

--- a/packages/ui-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui-react/src/components/Dropdown/Dropdown.tsx
@@ -22,6 +22,7 @@ type Props = {
   required?: boolean;
   onChange: React.ChangeEventHandler;
   testId?: string;
+  lang?: string;
 };
 
 const Dropdown: React.FC<Props & React.AriaAttributes> = ({
@@ -39,6 +40,7 @@ const Dropdown: React.FC<Props & React.AriaAttributes> = ({
   required = false,
   size = 'medium',
   testId,
+  lang,
   ...rest
 }: Props & React.AriaAttributes) => {
   const { t } = useTranslation('common');
@@ -63,6 +65,7 @@ const Dropdown: React.FC<Props & React.AriaAttributes> = ({
           aria-required={required}
           aria-invalid={error}
           aria-describedby={helperTextId}
+          lang={lang}
           {...rest}
         >
           {defaultLabel && (

--- a/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
+++ b/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
@@ -437,8 +437,12 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
         data-testid="radio-header"
         for="radio_1235_key2"
       >
-        Is this a question?
         <span>
+          Is this a question?
+        </span>
+        <span
+          class="_note_d50e6e"
+        >
           optional
         </span>
       </label>
@@ -883,8 +887,12 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
         data-testid="radio-header"
         for="radio_1235_key2"
       >
-        Is this a question?
         <span>
+          Is this a question?
+        </span>
+        <span
+          class="_note_d50e6e"
+        >
           optional
         </span>
       </label>

--- a/packages/ui-react/src/components/Radio/Radio.module.scss
+++ b/packages/ui-react/src/components/Radio/Radio.module.scss
@@ -7,7 +7,7 @@
   font-weight: var(--body-font-weight-bold);
   text-align: left;
 
-  > span {
+  > span.note {
     margin-left: auto;
     color: rgba(variables.$white, 0.7);
     font-weight: normal;

--- a/packages/ui-react/src/components/Radio/Radio.tsx
+++ b/packages/ui-react/src/components/Radio/Radio.tsx
@@ -15,9 +15,10 @@ type Props = {
   helperText?: string;
   error?: boolean;
   required?: boolean;
+  lang?: string;
 };
 
-const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperText, error, required, ...rest }: Props) => {
+const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperText, error, required, lang, ...rest }: Props) => {
   const { t } = useTranslation('common');
   const id = useOpaqueId('radio', name);
 
@@ -25,12 +26,12 @@ const Radio: React.FC<Props> = ({ name, onChange, header, value, values, helperT
     <div className={error ? styles.error : undefined} {...rest}>
       {header || !required ? (
         <label className={styles.header} htmlFor={id} data-testid="radio-header">
-          {header}
-          {!required ? <span>{t('optional')}</span> : null}
+          <span lang={lang}>{header}</span>
+          {!required ? <span className={styles.note}>{t('optional')}</span> : null}
         </label>
       ) : null}
       {values.map(({ value: optionValue, label: optionLabel }, index) => (
-        <div className={styles.radio} key={index}>
+        <div className={styles.radio} key={index} lang={lang}>
           <input value={optionValue} name={name} type="radio" id={id + index} onChange={onChange} checked={value === optionValue} required={required} />
           <label htmlFor={id + index}>{optionLabel}</label>
         </div>

--- a/packages/ui-react/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/ui-react/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -8,8 +8,12 @@ exports[`<Radio> > renders and matches snapshot 1`] = `
       data-testid="radio-header"
       for="radio_1235_radio"
     >
-      Choose a Value
       <span>
+        Choose a Value
+      </span>
+      <span
+        class="_note_d50e6e"
+      >
         optional
       </span>
     </label>

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -8,6 +8,7 @@ import { testId } from '@jwp/ott-common/src/utils/common';
 import useToggle from '@jwp/ott-hooks-react/src/useToggle';
 import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
 import VisibilityOff from '@jwp/ott-theme/assets/icons/visibility_off.svg?react';
+import env from '@jwp/ott-common/src/env';
 
 import TextField from '../TextField/TextField';
 import Button from '../Button/Button';
@@ -53,10 +54,11 @@ const RegistrationForm: React.FC<Props> = ({
 }: Props) => {
   const [viewPassword, toggleViewPassword] = useToggle();
 
-  const { t } = useTranslation('account');
+  const { t, i18n } = useTranslation('account');
   const location = useLocation();
 
   const ref = useRef<HTMLDivElement>(null);
+  const htmlLang = i18n.language !== env.APP_DEFAULT_LANGUAGE ? env.APP_DEFAULT_LANGUAGE : undefined;
 
   const formatConsentLabel = (label: string): string | JSX.Element => {
     const sanitizedLabel = DOMPurify.sanitize(label);
@@ -140,6 +142,7 @@ const RegistrationForm: React.FC<Props> = ({
                 error={!!consentError}
                 helperText={consentError ? t(`registration.field_${consent.type}_required`) : undefined}
                 onChange={onConsentChange}
+                lang={htmlLang}
               />
             );
           })}

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
         class="_main_d0c133 _mainPadding_d0c133"
       >
         <img
-          alt="Test video"
+          alt=""
           class="_poster_d0c133 _image_4c41c3"
           src="http://image.jpg?width=1280"
         />


### PR DESCRIPTION
This change adds a `lang="xyz"` attribute to custom account/registration fields. It will prevent the voiceover to read the text in the wrong language.

It will only do that when website language is set to a different language than the default otherwise the attribute will be redundant.

It is primarily targetted to the terms & agreements checkbox. But also apply to some other fields

Ticket: [OTT-395](https://videodock.atlassian.net/browse/OTT-395)

[OTT-395]: https://videodock.atlassian.net/browse/OTT-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ