### PR TITLE
Fix / e2e cardgrid card navigation

### DIFF
--- a/platforms/web/test-e2e/utils/steps_file.ts
+++ b/platforms/web/test-e2e/utils/steps_file.ts
@@ -468,6 +468,7 @@ const stepsObj = {
   ) {
     const cardLocator = `//a[@data-testid="${name}"]`;
     const shelfLocator = shelf ? makeShelfXpath(shelf) : undefined;
+    const gridCellLocator = locate(cardLocator).inside('//div[@role="gridcell"]');
 
     this.scrollPageToTop();
     this.wait(1);
@@ -487,16 +488,22 @@ const stepsObj = {
     const isMobile = await this.isMobile();
     // Easy way to limit to 10 swipes
     for (let i = 0; i < 10; i++) {
-      const [isElementVisible, tabindex] = await within(shelfLocator || 'body', async () => {
+      const [isWithinGridCell, isElementVisible, tabindex] = await within(shelfLocator || 'body', async () => {
+        const isWithinGridCell = (await this.grabNumberOfVisibleElements(gridCellLocator)) >= 1;
         const isElementVisible = (await this.grabNumberOfVisibleElements(cardLocator)) >= 1;
         const tabindex = isElementVisible ? Number(await this.grabAttributeFrom(cardLocator, 'tabindex')) : -1;
 
-        return [isElementVisible, tabindex];
+        return [isWithinGridCell, isElementVisible, tabindex];
       });
 
       // If the item isn't virtualized yet, throw an error (we need more information)
       if (!shelfLocator && !isElementVisible) {
         throw `Can't find item with locator: "${cardLocator}". Try specifying which shelf to look in.`;
+      }
+
+      // CardGrid component uses keyboard or regular mouse (click) navigation
+      if (isWithinGridCell) {
+        break;
       }
 
       if (tabindex >= 0) {


### PR DESCRIPTION
I noticed a failed e2e test since PR #33. See first failure here: https://github.com/Videodock/ott-web-app/actions/runs/7713395725/job/21023185240

```

video_detail - JW Player
       I can play other media from the related shelf - JW Player:
     Clickable element "{"css":"div[aria-label=\"Slide right\"]"}" was not found by text|CSS|XPath
      at new ElementNotFound (/home/runner/work/ott-web-app/ott-web-app/node_modules/codeceptjs/lib/helper/errors/ElementNotFound.js:15:11)
      at assertElementExists (/home/runner/work/ott-web-app/ott-web-app/node_modules/codeceptjs/lib/helper/Playwright.js:3530:11)
      at Playwright.proceedClick (/home/runner/work/ott-web-app/ott-web-app/node_modules/codeceptjs/lib/helper/Playwright.js:3290:5)
error Command failed with exit code 1.
```

It is caused because the tabindexes of the cards within the `CardGrid` are changed. Previously the `break;` will activate, causing the e2e test to run successfully.

I think the `openVideoCard` function has too much responsibility which makes it hard to maintain. It is used throughout the e2e tests. Rewriting or splitting of the function will be the most appropriate, but I need to understand the full context. That takes too much time. So I resorted to another escape hatch (another `break`) when the card is contained in a `gridcell`.

Let me know what you think.


