### PR TITLE
fix(a11y): shelf navigation with screen reader

### DIFF
--- a/packages/ui-react/src/components/TileDock/TileDock.tsx
+++ b/packages/ui-react/src/components/TileDock/TileDock.tsx
@@ -194,6 +194,7 @@ function TileDock<T>({
   // Run code after the slide animation to set the new index
   useLayoutEffect(() => {
     const postAnimationCleanup = (): void => {
+      const firstVisibleTileIndex = Array.from(frameRef.current?.children || []).findIndex((element) => element.getAttribute('aria-hidden') === 'false');
       let resetIndex: number = slideToIndex;
 
       resetIndex = resetIndex >= items.length ? slideToIndex - items.length : resetIndex;
@@ -201,6 +202,10 @@ function TileDock<T>({
 
       if (resetIndex !== slideToIndex) {
         setSlideToIndex(resetIndex);
+      }
+
+      if (firstVisibleTileIndex !== -1) {
+        (frameRef.current?.children[firstVisibleTileIndex] as HTMLElement).focus();
       }
 
       setIndex(resetIndex);
@@ -263,13 +268,17 @@ function TileDock<T>({
             />
           ) : null}
           {tileList.map((tile: Tile<T>, listIndex) => {
+            const posInSet = items.findIndex((item) => item === tile.item); // TODO optimize this for performances
             const isInView = !isMultiPage || (listIndex > tilesToShow - slideOffset && listIndex < tilesToShow * 2 + 1 - slideOffset);
 
             return (
               <li
                 key={tile.key}
+                aria-setsize={items.length}
+                aria-posinset={posInSet + 1}
                 aria-hidden={!isInView}
                 className={classNames({ [styles.notInView]: !isInView })}
+                tabIndex={-1}
                 style={{
                   width: `${tileWidth}%`,
                   paddingLeft: spacing / 2,


### PR DESCRIPTION
Improve navigation through shelf items for screen readers. This was a really difficult one. Still not finished.

These 6 lines of code almost took me the whole day. 

Ticket: https://videodock.atlassian.net/browse/OTT-692