### PR TITLE
Fix / a11y shelf item navigation with screen reader

### DIFF
--- a/packages/ui-react/src/components/Shelf/Shelf.module.scss
+++ b/packages/ui-react/src/components/Shelf/Shelf.module.scss
@@ -32,12 +32,11 @@
   padding: 12px 0;
   outline-color: var(--highlight-color, white);
   cursor: pointer;
-  opacity: 0;
   transition: transform 0.3s ease-out, opacity 0.3s ease-out;
 
   > svg {
-    width: 30px;
-    height: 30px;
+    // Use scale because width and height properties causes layout shifting issues on screen readers
+    transform: scale(1.1);
   }
   &.disabled {
     cursor: default;

--- a/packages/ui-react/src/components/Shelf/Shelf.tsx
+++ b/packages/ui-react/src/components/Shelf/Shelf.tsx
@@ -146,7 +146,7 @@ const Shelf = ({
         tilesToShow={tilesToShow}
         wrapWithEmptyTiles={featured && playlist.playlist.length === 1}
         cycleMode={'restart'}
-        showControls={!matchMedia('(hover: none)').matches && !loading}
+        showControls={!loading}
         showDots={featured}
         transitionTime={'0.3s'}
         spacing={8}

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -66,7 +65,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -94,7 +92,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           aria-setsize="4"
           class=""
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732"
@@ -133,7 +130,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -161,7 +157,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
           aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -249,7 +244,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -292,7 +286,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -335,7 +328,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -378,7 +370,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
           aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-          tabindex="-1"
         >
           <a
             class="_card_d75732"

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -34,8 +34,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
       >
         <li
           aria-hidden="true"
+          aria-posinset="3"
+          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -59,8 +62,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
+          aria-posinset="4"
+          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -84,8 +90,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
+          aria-posinset="1"
+          aria-setsize="4"
           class=""
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732"
@@ -120,8 +129,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
+          aria-posinset="2"
+          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -145,8 +157,11 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
+          aria-posinset="3"
+          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732 _featured_d75732 _disabled_d75732"
@@ -230,8 +245,11 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
       >
         <li
           aria-hidden="false"
+          aria-posinset="1"
+          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -270,8 +288,11 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
+          aria-posinset="2"
+          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -310,8 +331,11 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
+          aria-posinset="3"
+          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732"
@@ -350,8 +374,11 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
+          aria-posinset="4"
+          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+          tabindex="-1"
         >
           <a
             class="_card_d75732"

--- a/packages/ui-react/src/components/TileDock/TileDock.tsx
+++ b/packages/ui-react/src/components/TileDock/TileDock.tsx
@@ -194,7 +194,6 @@ function TileDock<T>({
   // Run code after the slide animation to set the new index
   useLayoutEffect(() => {
     const postAnimationCleanup = (): void => {
-      const firstVisibleTileIndex = Array.from(frameRef.current?.children || []).findIndex((element) => element.getAttribute('aria-hidden') === 'false');
       let resetIndex: number = slideToIndex;
 
       resetIndex = resetIndex >= items.length ? slideToIndex - items.length : resetIndex;
@@ -202,10 +201,6 @@ function TileDock<T>({
 
       if (resetIndex !== slideToIndex) {
         setSlideToIndex(resetIndex);
-      }
-
-      if (firstVisibleTileIndex !== -1) {
-        (frameRef.current?.children[firstVisibleTileIndex] as HTMLElement).focus();
       }
 
       setIndex(resetIndex);
@@ -278,7 +273,6 @@ function TileDock<T>({
                 aria-posinset={posInSet + 1}
                 aria-hidden={!isInView}
                 className={classNames({ [styles.notInView]: !isInView })}
-                tabIndex={-1}
                 style={{
                   width: `${tileWidth}%`,
                   paddingLeft: spacing / 2,

--- a/packages/ui-react/src/components/TileDock/TileDock.tsx
+++ b/packages/ui-react/src/components/TileDock/TileDock.tsx
@@ -194,6 +194,7 @@ function TileDock<T>({
   // Run code after the slide animation to set the new index
   useLayoutEffect(() => {
     const postAnimationCleanup = (): void => {
+      const firstVisibleTileIndex = Array.from(frameRef.current?.children || []).findIndex((element) => element.getAttribute('aria-hidden') === 'false');
       let resetIndex: number = slideToIndex;
 
       resetIndex = resetIndex >= items.length ? slideToIndex - items.length : resetIndex;
@@ -201,6 +202,10 @@ function TileDock<T>({
 
       if (resetIndex !== slideToIndex) {
         setSlideToIndex(resetIndex);
+      }
+
+      if (firstVisibleTileIndex !== -1) {
+        (frameRef.current?.children[firstVisibleTileIndex] as HTMLElement).focus();
       }
 
       setIndex(resetIndex);
@@ -263,13 +268,17 @@ function TileDock<T>({
             />
           ) : null}
           {tileList.map((tile: Tile<T>, listIndex) => {
+            const posInSet = items.findIndex((item) => item === tile.item); // TODO optimize this for performances
             const isInView = !isMultiPage || (listIndex > tilesToShow - slideOffset && listIndex < tilesToShow * 2 + 1 - slideOffset);
 
             return (
               <li
                 key={tile.key}
+                aria-setsize={items.length}
+                aria-posinset={posInSet + 1}
                 aria-hidden={!isInView}
                 className={classNames({ [styles.notInView]: !isInView })}
+                tabIndex={-1}
                 style={{
                   width: `${tileWidth}%`,
                   paddingLeft: spacing / 2,

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -58,7 +58,6 @@ const ShelfList = ({ rows }: Props) => {
         style={{ overflow: 'hidden' }}
         loadMore={() => setRowsToLoad((current) => current + ROWS_TO_LOAD_STEP)}
         hasMore={rowsToLoad < rows.length}
-        role="grid"
         loader={<InfiniteScrollLoader key="loader" />}
       >
         {rows.slice(0, rowsToLoad).map(({ type, featured, title }, index) => {
@@ -70,29 +69,27 @@ const ShelfList = ({ rows }: Props) => {
           const visibleTilesDelta = parseTilesDelta(posterAspect);
 
           return (
-            <div
+            <section
               key={`${index}_${playlist.id}`}
-              role="row"
               className={classNames(styles.shelfContainer, { [styles.featured]: featured })}
               data-testid={testId(`shelf-${featured ? 'featured' : type === 'playlist' ? slugify(title || playlist?.title) : type}`)}
+              aria-label={title || playlist?.title}
             >
-              <div role="cell">
-                <Shelf
-                  loading={isLoading}
-                  error={error}
-                  type={type}
-                  playlist={playlist}
-                  watchHistory={type === PersonalShelf.ContinueWatching ? watchHistoryDictionary : undefined}
-                  title={title || playlist?.title}
-                  featured={featured}
-                  accessModel={accessModel}
-                  isLoggedIn={!!user}
-                  hasSubscription={!!subscription}
-                  posterAspect={posterAspect}
-                  visibleTilesDelta={visibleTilesDelta}
-                />
-              </div>
-            </div>
+              <Shelf
+                loading={isLoading}
+                error={error}
+                type={type}
+                playlist={playlist}
+                watchHistory={type === PersonalShelf.ContinueWatching ? watchHistoryDictionary : undefined}
+                title={title || playlist?.title}
+                featured={featured}
+                accessModel={accessModel}
+                isLoggedIn={!!user}
+                hasSubscription={!!subscription}
+                posterAspect={posterAspect}
+                visibleTilesDelta={visibleTilesDelta}
+              />
+            </section>
           );
         })}
       </InfiniteScroll>

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -11,223 +11,226 @@ exports[`Home Component tests > Home test 1`] = `
     class="_shelfList_a0651b"
   >
     <div
-      role="grid"
       style="overflow: hidden;"
     >
-      <div
+      <section
+        aria-label="This is a playlist"
         class="_shelfContainer_a0651b"
         data-testid="shelf-this-is-a-playlist"
-        role="row"
       >
         <div
-          role="cell"
+          class="_shelf_81910b"
         >
-          <div
-            class="_shelf_81910b"
+          <h2
+            class="_title_81910b"
           >
-            <h2
-              class="_title_81910b"
+            This is a playlist
+          </h2>
+          <div
+            class="_tileDock_22abb0"
+          >
+            <ul
+              style="transform: translate3d(0%, 0, 0); margin-left: -4px; margin-right: -4px;"
             >
-              This is a playlist
-            </h2>
-            <div
-              class="_tileDock_22abb0"
-            >
-              <ul
-                style="transform: translate3d(0%, 0, 0); margin-left: -4px; margin-right: -4px;"
+              <li
+                aria-hidden="false"
+                aria-posinset="1"
+                aria-setsize="2"
+                class=""
+                style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                tabindex="-1"
               >
-                <li
-                  aria-hidden="false"
-                  class=""
-                  style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                <a
+                  class="_card_d75732"
+                  data-testid="My video"
+                  href="/m/abcddabc/my-video"
+                  role="button"
+                  tabindex="0"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="My video"
-                    href="/m/abcddabc/my-video"
-                    role="button"
-                    tabindex="0"
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      My video
+                    </h3>
+                  </div>
+                  <div
+                    class="_poster_d75732 _aspect169_d75732"
                   >
                     <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        My video
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                      class="_meta_d75732"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_tags_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_tag_d75732"
                         >
-                          <div
-                            class="_tag_d75732"
-                          >
-                            6 min
-                          </div>
+                          6 min
                         </div>
                       </div>
                     </div>
-                  </a>
-                </li>
-                <li
-                  aria-hidden="false"
-                  class=""
-                  style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                  </div>
+                </a>
+              </li>
+              <li
+                aria-hidden="false"
+                aria-posinset="2"
+                aria-setsize="2"
+                class=""
+                style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                tabindex="-1"
+              >
+                <a
+                  class="_card_d75732"
+                  data-testid="Other Vids"
+                  href="/m/zzzaaazz/other-vids"
+                  role="button"
+                  tabindex="0"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="Other Vids"
-                    href="/m/zzzaaazz/other-vids"
-                    role="button"
-                    tabindex="0"
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      Other Vids
+                    </h3>
+                  </div>
+                  <div
+                    class="_poster_d75732 _aspect169_d75732"
                   >
                     <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        Other Vids
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                      class="_meta_d75732"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_tags_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_tag_d75732"
                         >
-                          <div
-                            class="_tag_d75732"
-                          >
-                            6 min
-                          </div>
+                          6 min
                         </div>
                       </div>
                     </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
+                  </div>
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
-      </div>
-      <div
+      </section>
+      <section
+        aria-label="Second Playlist"
         class="_shelfContainer_a0651b"
         data-testid="shelf-second-playlist"
-        role="row"
       >
         <div
-          role="cell"
+          class="_shelf_81910b"
         >
-          <div
-            class="_shelf_81910b"
+          <h2
+            class="_title_81910b"
           >
-            <h2
-              class="_title_81910b"
+            Second Playlist
+          </h2>
+          <div
+            class="_tileDock_22abb0"
+          >
+            <ul
+              style="transform: translate3d(0%, 0, 0); margin-left: -4px; margin-right: -4px;"
             >
-              Second Playlist
-            </h2>
-            <div
-              class="_tileDock_22abb0"
-            >
-              <ul
-                style="transform: translate3d(0%, 0, 0); margin-left: -4px; margin-right: -4px;"
+              <li
+                aria-hidden="false"
+                aria-posinset="1"
+                aria-setsize="2"
+                class=""
+                style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                tabindex="-1"
               >
-                <li
-                  aria-hidden="false"
-                  class=""
-                  style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                <a
+                  class="_card_d75732"
+                  data-testid="My video"
+                  href="/m/abcddabc/my-video"
+                  role="button"
+                  tabindex="0"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="My video"
-                    href="/m/abcddabc/my-video"
-                    role="button"
-                    tabindex="0"
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      My video
+                    </h3>
+                  </div>
+                  <div
+                    class="_poster_d75732 _aspect169_d75732"
                   >
                     <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        My video
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                      class="_meta_d75732"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_tags_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_tag_d75732"
                         >
-                          <div
-                            class="_tag_d75732"
-                          >
-                            6 min
-                          </div>
+                          6 min
                         </div>
                       </div>
                     </div>
-                  </a>
-                </li>
-                <li
-                  aria-hidden="false"
-                  class=""
-                  style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                  </div>
+                </a>
+              </li>
+              <li
+                aria-hidden="false"
+                aria-posinset="2"
+                aria-setsize="2"
+                class=""
+                style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+                tabindex="-1"
+              >
+                <a
+                  class="_card_d75732"
+                  data-testid="Other Vids"
+                  href="/m/zzzaaazz/other-vids"
+                  role="button"
+                  tabindex="0"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="Other Vids"
-                    href="/m/zzzaaazz/other-vids"
-                    role="button"
-                    tabindex="0"
+                  <div
+                    class="_titleContainer_d75732"
+                  >
+                    <h3
+                      class="_title_d75732"
+                    >
+                      Other Vids
+                    </h3>
+                  </div>
+                  <div
+                    class="_poster_d75732 _aspect169_d75732"
                   >
                     <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        Other Vids
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                      class="_meta_d75732"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_tags_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_tag_d75732"
                         >
-                          <div
-                            class="_tag_d75732"
-                          >
-                            6 min
-                          </div>
+                          6 min
                         </div>
                       </div>
                     </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
+                  </div>
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   </div>
 </div>

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`Home Component tests > Home test 1`] = `
                 aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-                tabindex="-1"
               >
                 <a
                   class="_card_d75732"
@@ -81,7 +80,6 @@ exports[`Home Component tests > Home test 1`] = `
                 aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-                tabindex="-1"
               >
                 <a
                   class="_card_d75732"
@@ -147,7 +145,6 @@ exports[`Home Component tests > Home test 1`] = `
                 aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-                tabindex="-1"
               >
                 <a
                   class="_card_d75732"
@@ -190,7 +187,6 @@ exports[`Home Component tests > Home test 1`] = `
                 aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
-                tabindex="-1"
               >
                 <a
                   class="_card_d75732"


### PR DESCRIPTION
This change make the shelf items navigatable with the screen reader and remove the grid/row/cell aria attributes from the homepage and replaces them with `<section>`. FYI: The grid is still used for the `CardGrid` component because that is a 1-on-1 visual representation of an actual grid, while the `ShelfList` isn't.

## Removed grid/row/cell aria attributes
The grid on the homepage causes the screen reader to read every every shelf as "row x, column y".  On top of that, every row only contains one column (cell).This doesn't add any value and makes navigating through the homepage really cluttered because "row x, column y" will get read on every item you focus within the grid.

I believe it's better to remove it and treat every shelf as a section. This should make it easier to navigate through the shelfs.

Ticket: [OTT-691](https://videodock.atlassian.net/browse/OTT-691)

## Navigatable shelf items
It was impossible to navigate through the shelf items previously. There where two main issues:
- The layout shifted while focussing the chevron (slide right) button
- The 'active' slide item got pronounced on the screen reader while not being inside the viewport (visible area). So it was impossible to see what is going on.

The goal that needed to be achieved had a lot of challenges, resulting in opinionated code. I will clarify my changes inline. 

There is only one problem on Android (Talkback): After you use the chevron button, the slide item will be read twice when you navigate through the shelf. I was unable to fix this. I already created a bug ticket for it: [OTT-791](https://videodock.atlassian.net/browse/OTT-791)

### Example videos
iOS:
https://github.com/Videodock/ott-web-app/assets/1019129/dd7082c7-9dc8-46ad-bb6a-1552339c38a8

Android:
https://github.com/Videodock/ott-web-app/assets/1019129/62f98b2f-6e66-410a-b392-5812ccef5b70

Ticket: [OTT-692](https://videodock.atlassian.net/browse/OTT-692)

[OTT-691]: https://videodock.atlassian.net/browse/OTT-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-692]: https://videodock.atlassian.net/browse/OTT-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OTT-791]: https://videodock.atlassian.net/browse/OTT-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ