### PR TITLE
Fix / Checkout bugs

### DIFF
--- a/packages/common/src/controllers/AccountController.ts
+++ b/packages/common/src/controllers/AccountController.ts
@@ -319,7 +319,7 @@ export default class AccountController {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer, customerConsents } = getAccountInfo();
 
-    const requiredMessage = i18next.t('common:form.field_required');
+    const requiredMessage = i18next.t('account:personal_details.this_field_is_required');
     const errors = fields.reduce((previousValue, currentValue) => {
       if (currentValue.required && !values[currentValue.name]) {
         return { ...previousValue, [currentValue.name]: requiredMessage };

--- a/packages/common/src/controllers/CheckoutController.ts
+++ b/packages/common/src/controllers/CheckoutController.ts
@@ -50,7 +50,6 @@ export default class CheckoutController {
   createOrder = async (offer: Offer): Promise<void> => {
     const { getAccountInfo } = useAccountStore.getState();
     const { customer } = getAccountInfo();
-    const customerIP = typeof customer?.lastUserIp === 'string' && customer.lastUserIp ? customer.lastUserIp : '';
 
     const paymentMethods = await this.getPaymentMethods();
     const paymentMethodId = paymentMethods[0]?.id;
@@ -59,7 +58,6 @@ export default class CheckoutController {
       offer,
       customerId: customer.id,
       country: customer?.country || '',
-      customerIP,
       paymentMethodId,
     };
 

--- a/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
@@ -64,12 +64,14 @@ export default class CleengCheckoutService extends CheckoutService {
 
     if (locales.errors.length > 0) throw new Error(locales.errors[0]);
 
+    const customerIP = locales.responseData.ipAddress;
+
     const createOrderPayload: CreateOrderPayload = {
       offerId: payload.offer.offerId,
       customerId: payload.customerId,
       country: payload.country,
       currency: locales?.responseData?.currency || 'EUR',
-      customerIP: payload.customerIP,
+      customerIP,
       paymentMethodId: payload.paymentMethodId,
     };
 

--- a/packages/common/types/checkout.ts
+++ b/packages/common/types/checkout.ts
@@ -216,7 +216,6 @@ export type CreateOrderArgs = {
   offer: Offer;
   customerId: string;
   country: string;
-  customerIP: string;
   paymentMethodId?: number;
   couponCode?: string;
 };

--- a/packages/hooks-react/src/useForm.ts
+++ b/packages/hooks-react/src/useForm.ts
@@ -144,7 +144,7 @@ export default function useForm<T extends GenericFormValues>({
       const newErrors: Record<string, string> = {};
 
       if (error instanceof FormValidationError) {
-        Object.entries(error.errors).forEach(([key, [value]]) => {
+        Object.entries(error.errors).forEach(([key, value]) => {
           if (key && value && !newErrors[key]) {
             newErrors[key] = value;
           }


### PR DESCRIPTION
## Fix / Checkout bugs
- FormValidation errors were only showing the first character (happened because an array destructure that shouldn't be there anymore, because the error can only be one string
- A translation key for personal details errors was wrongly set.
- CustomerIP is not anymore part of the user object, so cleeng orders couldn't be made, but we can safely take it from the locales call