### PR TITLE
Fix / registration consents and custom fields

### DIFF
--- a/packages/common/src/controllers/AccountController.ts
+++ b/packages/common/src/controllers/AccountController.ts
@@ -201,7 +201,13 @@ export default class AccountController {
     await this.refreshEntitlements?.();
   };
 
-  register = async (email: string, password: string, referrer: string, consentsValues: ConsentsValue[]) => {
+  register = async (
+    email: string,
+    password: string,
+    referrer: string,
+    consentsValues: ConsentsValue[],
+    registrationFieldValues: Record<string, string | boolean>,
+  ) => {
     const consents = useAccountStore.getState().consents || [];
 
     const consentsErrors = Object.fromEntries(
@@ -300,10 +306,9 @@ export default class AccountController {
   };
 
   getRegistrationFields = async () => {
-    const { getAccountInfo } = useAccountStore.getState();
-    const { customer } = getAccountInfo();
+    const { user } = useAccountStore.getState();
 
-    const registrationFields = await this.accountService.getRegistrationFields({ customer });
+    const registrationFields = await this.accountService.getRegistrationFields({ customer: user });
 
     useAccountStore.setState({
       registrationFields: registrationFields.fields,

--- a/packages/common/src/controllers/AccountController.ts
+++ b/packages/common/src/controllers/AccountController.ts
@@ -214,7 +214,7 @@ export default class AccountController {
       consentsValues.reduce((previousValue, currentValue) => {
         const consent = consents.find(({ name }) => name === currentValue.name);
         if (consent?.required && currentValue.state !== 'accepted') {
-          return [...previousValue, [currentValue.name, i18next.t('common:form.field_required')]];
+          return [...previousValue, [`consents.${currentValue.name}`, i18next.t('account:registration.field_required')]];
         }
         return previousValue;
       }, [] as [string, string][]),

--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -242,7 +242,15 @@ export default class CleengAccountService extends AccountService {
   };
 
   getRegistrationFields: GetRegistrationFields = async ({ customer }) => {
-    const response = await this.cleengService.get<Response<GetCaptureStatusResponse>>(`/customers/${customer?.id}/capture/status`, {
+    if (!customer) {
+      return {
+        beforeSignUp: false,
+        enabled: false,
+        fields: [],
+      };
+    }
+
+    const response = await this.cleengService.get<Response<GetCaptureStatusResponse>>(`/customers/${customer.id}/capture/status`, {
       authenticate: true,
     });
 

--- a/packages/common/src/services/integrations/jwp/JWPAccountService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAccountService.ts
@@ -370,7 +370,7 @@ export default class JWPAccountService extends AccountService {
   getRegistrationFields: GetRegistrationFields = async ({ customer }) => {
     const { data } = await InPlayer.Account.getRegisterFields(this.clientId);
 
-    const fields = data.collection.filter((field) => field.name !== 'terms').map((field) => formatRegistrationField(field, customer.metadata[field.name]));
+    const fields = data.collection.filter((field) => field.name !== 'terms').map((field) => formatRegistrationField(field, customer?.metadata[field.name]));
 
     return {
       beforeSignUp: true,
@@ -382,7 +382,7 @@ export default class JWPAccountService extends AccountService {
           name: 'firstName',
           placeholder: 'First name',
           required: true,
-          defaultValue: customer.firstName,
+          defaultValue: customer?.firstName,
         },
         {
           type: 'input',
@@ -390,7 +390,7 @@ export default class JWPAccountService extends AccountService {
           name: 'lastName',
           placeholder: 'Last name',
           required: true,
-          defaultValue: customer.lastName,
+          defaultValue: customer?.lastName,
         },
         ...fields,
       ],

--- a/packages/common/types/account.ts
+++ b/packages/common/types/account.ts
@@ -50,6 +50,8 @@ export type LoginFormData = {
 export type RegistrationFormData = {
   email: string;
   password: string;
+  consents: Record<string, boolean>;
+  registrationFields: Record<string, string | boolean>;
 };
 
 export type ForgotPasswordFormData = {
@@ -205,7 +207,7 @@ export type RegistrationFields = {
 };
 
 export type GetRegistrationFieldsArgs = {
-  customer: Customer;
+  customer: Customer | null;
 };
 
 export type UpdateRegistrationFieldsValuesArgs = {

--- a/packages/common/types/form.d.ts
+++ b/packages/common/types/form.d.ts
@@ -2,10 +2,9 @@ export type UseFormChangeHandler = React.ChangeEventHandler<HTMLInputElement | H
 export type UseFormBlurHandler = React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 export type UseFormSubmitHandler = React.FormEventHandler<HTMLFormElement>;
 
-export type GenericFormErrors = { form: string };
+export type GenericFormErrors = { form: string | undefined };
 // @TODO: this type is recursive and not working properly
 export type GenericFormValues = Record<string, string | boolean>;
 export type GenericFormNestedValues = Record<string, string | boolean | GenericFormValues>;
-export type KeyedFormErrors<T> = { [K in keyof T]: T[K] extends Record<string, unknown> ? KeyedFormErrors<T[K]> : string };
-export type FormErrors<T> = Partial<KeyedFormErrors<T> & GenericFormErrors>;
+export type FormErrors<T> = Partial<Record<string, string | undefined> & GenericFormErrors>;
 export type FormValues<T> = Partial<T & GenericFormValues>;

--- a/packages/common/types/form.d.ts
+++ b/packages/common/types/form.d.ts
@@ -5,6 +5,7 @@ export type UseFormSubmitHandler = React.FormEventHandler<HTMLFormElement>;
 export type GenericFormErrors = { form: string };
 // @TODO: this type is recursive and not working properly
 export type GenericFormValues = Record<string, string | boolean>;
-export type GenericFormNestedValues = Record<string, GenericFormValues>;
-export type FormErrors<T> = Partial<{ [K in keyof T]: string } & GenericFormErrors>;
+export type GenericFormNestedValues = Record<string, string | boolean | GenericFormValues>;
+export type KeyedFormErrors<T> = { [K in keyof T]: T[K] extends Record<string, unknown> ? KeyedFormErrors<T[K]> : string };
+export type FormErrors<T> = Partial<KeyedFormErrors<T> & GenericFormErrors>;
 export type FormValues<T> = Partial<T & GenericFormValues>;

--- a/packages/ui-react/src/components/Form/FormSection.tsx
+++ b/packages/ui-react/src/components/Form/FormSection.tsx
@@ -68,11 +68,12 @@ export function FormSection<TData extends GenericFormNestedValues>({
 
         // This logic handles nested names like 'consents.terms'
         const [nestedKey, fieldName] = name.split('.');
+        const currentValue = newValues[nestedKey];
 
-        if (nestedKey in newValues) {
+        if (currentValue && typeof currentValue === 'object') {
           // @ts-ignore this typing is not working properly
           newValues[nestedKey as keyof TData] = {
-            ...newValues[nestedKey],
+            ...currentValue,
             [fieldName]: value,
           };
         }

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.module.scss
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.module.scss
@@ -30,5 +30,6 @@
 .customFields {
   display: flex;
   flex-direction: column;
+  margin: variables.$base-spacing 0;
   gap: 0.5em;
 }

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.test.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.test.tsx
@@ -8,7 +8,7 @@ describe('<RegistrationForm>', () => {
   test('renders and matches snapshot', () => {
     const { container } = renderWithRouter(
       <RegistrationForm
-        publisherConsents={null}
+        consents={null}
         onSubmit={vi.fn()}
         onChange={vi.fn()}
         onBlur={vi.fn()}

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -111,8 +111,8 @@ const RegistrationForm: React.FC<Props> = ({
               placeholder={consent.placeholder}
               value={values.consents[consent.name] || ''}
               required={consent.required}
-              error={!!errors.consents?.[consent.name]}
-              helperText={errors.consents?.[consent.name]}
+              error={!!errors[`consents.${consent.name}`]}
+              helperText={errors[`consents.${consent.name}`]}
               onChange={onChange}
             />
           ))}
@@ -130,8 +130,8 @@ const RegistrationForm: React.FC<Props> = ({
               placeholder={field.placeholder}
               value={values.registrationFields[field.name] || ''}
               required={field.required}
-              error={!!errors.registrationFields?.[field.name]}
-              helperText={errors.registrationFields?.[field.name]}
+              error={!!errors[`registrationFields.${field.name}`]}
+              helperText={errors[`registrationFields.${field.name}`]}
               onChange={onChange}
             />
           ))}

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -1,24 +1,19 @@
-import React, { type ChangeEventHandler, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import DOMPurify from 'dompurify';
 import type { FormErrors } from '@jwp/ott-common/types/form';
 import type { CustomFormField, RegistrationFormData } from '@jwp/ott-common/types/account';
 import { testId } from '@jwp/ott-common/src/utils/common';
-import useToggle from '@jwp/ott-hooks-react/src/useToggle';
-import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
-import VisibilityOff from '@jwp/ott-theme/assets/icons/visibility_off.svg?react';
 
 import TextField from '../TextField/TextField';
 import Button from '../Button/Button';
-import IconButton from '../IconButton/IconButton';
-import PasswordStrength from '../PasswordStrength/PasswordStrength';
 import CustomRegisterField from '../CustomRegisterField/CustomRegisterField';
 import FormFeedback from '../FormFeedback/FormFeedback';
 import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import Link from '../Link/Link';
-import Icon from '../Icon/Icon';
 import { modalURLFromLocation } from '../../utils/location';
+import PasswordField from '../PasswordField/PasswordField';
 
 import styles from './RegistrationForm.module.scss';
 
@@ -26,15 +21,13 @@ type Props = {
   onSubmit: React.FormEventHandler<HTMLFormElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-  onConsentChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   errors: FormErrors<RegistrationFormData>;
   values: RegistrationFormData;
   loading: boolean;
-  consentValues: Record<string, string | boolean>;
-  consentErrors: string[];
   submitting: boolean;
   canSubmit: boolean;
-  publisherConsents: CustomFormField[] | null;
+  consents: CustomFormField[] | null;
+  registrationFields: CustomFormField[] | null;
 };
 
 const RegistrationForm: React.FC<Props> = ({
@@ -46,13 +39,9 @@ const RegistrationForm: React.FC<Props> = ({
   submitting,
   loading,
   canSubmit,
-  publisherConsents,
-  consentValues,
-  onConsentChange,
-  consentErrors,
+  consents,
+  registrationFields,
 }: Props) => {
-  const [viewPassword, toggleViewPassword] = useToggle();
-
   const { t } = useTranslation('account');
   const location = useLocation();
 
@@ -100,43 +89,50 @@ const RegistrationForm: React.FC<Props> = ({
         type="email"
         required
       />
-      <TextField
+      <PasswordField
+        name="password"
         value={values.password}
         onChange={onChange}
         onBlur={onBlur}
         label={t('registration.password')}
         placeholder={t('registration.password')}
         error={!!errors.password || !!errors.form}
-        helperText={
-          <React.Fragment>
-            <PasswordStrength password={values.password} />
-            {t('registration.password_helper_text')}
-          </React.Fragment>
-        }
-        name="password"
-        type={viewPassword ? 'text' : 'password'}
-        rightControl={
-          <IconButton aria-label={viewPassword ? t('registration.hide_password') : t('registration.view_password')} onClick={() => toggleViewPassword()}>
-            <Icon icon={viewPassword ? Visibility : VisibilityOff} />
-          </IconButton>
-        }
         required
       />
-      {publisherConsents && (
-        <div className={styles.customFields} data-testid="custom-reg-fields">
-          {publisherConsents.map((consent) => (
+      {consents && (
+        <div className={styles.customFields} data-testid="consents">
+          {consents.map((consent) => (
             <CustomRegisterField
               key={consent.name}
               type={consent.type}
-              name={consent.name}
+              name={`consents.${consent.name}`}
               options={consent.options}
               label={formatConsentLabel(consent.label)}
               placeholder={consent.placeholder}
-              value={consentValues[consent.name] || ''}
+              value={values.consents[consent.name] || ''}
               required={consent.required}
-              error={consentErrors?.includes(consent.name)}
-              helperText={consentErrors?.includes(consent.name) ? t('registration.consent_required') : undefined}
-              onChange={onConsentChange}
+              error={!!errors.consents?.[consent.name]}
+              helperText={errors.consents?.[consent.name]}
+              onChange={onChange}
+            />
+          ))}
+        </div>
+      )}
+      {registrationFields && (
+        <div className={styles.customFields} data-testid="custom-reg-fields">
+          {registrationFields.map((field) => (
+            <CustomRegisterField
+              key={field.name}
+              type={field.type}
+              name={`registrationFields.${field.name}`}
+              options={field.options}
+              label={field.label}
+              placeholder={field.placeholder}
+              value={values.registrationFields[field.name] || ''}
+              required={field.required}
+              error={!!errors.registrationFields?.[field.name]}
+              helperText={errors.registrationFields?.[field.name]}
+              onChange={onChange}
             />
           ))}
         </div>

--- a/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/PersonalDetails.tsx
@@ -10,6 +10,7 @@ import useForm, { type UseFormOnSubmitHandler } from '@jwp/ott-hooks-react/src/u
 import useOffers from '@jwp/ott-hooks-react/src/useOffers';
 import type { GenericFormValues } from '@jwp/ott-common/types/form';
 import { FormValidationError } from '@jwp/ott-common/src/FormValidationError';
+import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 
 import PersonalDetailsForm from '../../../components/PersonalDetailsForm/PersonalDetailsForm';
 import LoadingOverlay from '../../../components/LoadingOverlay/LoadingOverlay';
@@ -20,7 +21,8 @@ const PersonalDetails = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const accessModel = useConfigStore((s) => s.accessModel);
-  const { data, isLoading } = useQuery('captureStatus', accountController.getRegistrationFields);
+  const user = useAccountStore((s) => s.user);
+  const { data, isLoading } = useQuery(['registrationFields', user?.id], accountController.getRegistrationFields);
   const { hasMediaOffers } = useOffers();
 
   const fields = useMemo(() => data?.fields || [], [data]);

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -1,14 +1,15 @@
-import React, { useEffect, useState, type ChangeEventHandler } from 'react';
+import React from 'react';
 import { object, string } from 'yup';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import type { RegistrationFormData } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import AccountController from '@jwp/ott-common/src/controllers/AccountController';
-import { extractCustomFormFieldValues, formatConsentsFromValues } from '@jwp/ott-common/src/utils/collection';
+import { formatConsentsFromValues } from '@jwp/ott-common/src/utils/collection';
 import useForm from '@jwp/ott-hooks-react/src/useForm';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
+import { useQuery } from 'react-query';
 
 import RegistrationForm from '../../../components/RegistrationForm/RegistrationForm';
 
@@ -19,46 +20,24 @@ const Registration = () => {
   const location = useLocation();
   const { t } = useTranslation('account');
 
-  const [consentValues, setConsentValues] = useState<Record<string, string | boolean>>({});
-  const [consentErrors, setConsentErrors] = useState<string[]>([]);
+  useQuery(['registrationFields'], accountController.getRegistrationFields);
+  useQuery(['consents'], accountController.getConsents);
 
-  const { consents, loading } = useAccountStore(({ consents, loading }) => ({ consents, loading }));
-
-  const handleChangeConsent: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> = ({ currentTarget }) => {
-    if (!currentTarget) return;
-
-    const { name, type } = currentTarget;
-    const value = type === 'checkbox' ? (currentTarget as HTMLInputElement).checked : currentTarget.value;
-
-    setConsentValues((current) => ({
-      ...current,
-      [name]: value,
-    }));
-
-    // Clear the errors for any checkbox that's toggled
-    setConsentErrors((errors) => errors.filter((e) => e !== name));
-  };
-
-  useEffect(() => {
-    if (!consents) {
-      accountController.getConsents();
-
-      return;
-    }
-
-    setConsentValues(extractCustomFormFieldValues(consents));
-  }, [accountController, consents]);
+  const { consents, registrationFields, loading } = useAccountStore(({ consents, registrationFields, loading }) => ({ consents, registrationFields, loading }));
 
   const { handleSubmit, handleChange, handleBlur, values, errors, submitting } = useForm<RegistrationFormData>({
-    initialValues: { email: '', password: '' },
+    initialValues: { email: '', password: '', registrationFields: {}, consents: {} },
     validationSchema: object().shape({
       email: string().email(t('registration.field_is_not_valid_email')).required(t('registration.field_required')),
       password: string()
         .matches(/^(?=.*[a-z])(?=.*[0-9]).{8,}$/, t('registration.invalid_password'))
         .required(t('registration.field_required')),
+      registrationFields: object(),
+      consents: object(),
     }),
     validateOnBlur: true,
-    onSubmit: ({ email, password }) => accountController.register(email, password, window.location.href, formatConsentsFromValues(consents, consentValues)),
+    onSubmit: ({ email, password, consents: consentsValues, registrationFields: registrationFieldValues }) =>
+      accountController.register(email, password, window.location.href, formatConsentsFromValues(consents, consentsValues), registrationFieldValues),
     onSubmitSuccess: () => navigate(modalURLFromLocation(location, 'personal-details')),
     onSubmitError: ({ resetValue }) => resetValue('password'),
   });
@@ -67,16 +46,14 @@ const Registration = () => {
     <RegistrationForm
       onSubmit={handleSubmit}
       onChange={handleChange}
-      onConsentChange={handleChangeConsent}
       onBlur={handleBlur}
       values={values}
       errors={errors}
-      consentErrors={consentErrors}
       submitting={submitting}
-      consentValues={consentValues}
-      publisherConsents={consents}
+      consents={consents}
+      registrationFields={registrationFields}
       loading={loading}
-      canSubmit={!!values.email && !!values.password}
+      canSubmit={true}
     />
   );
 };


### PR DESCRIPTION
## Description

@royschut here's my latest progress. I fixed the showing of the consents and registration fields. Error handling still needs to be done.

**TODO:**

- Consents/registration fields error handling
- Test personal details step (Cleeng only)

I do have two challenges to solve:

- Cleeng requires the customer to be defined when calling `getRegistrationFields`
- The registration fields are cached in the registration step but need to be re-fetched when navigating to the personal details step
- The loading state is not working properly when loading the required registration data
