### PR TITLE
Fix / ensure logo does not exceed width of the header

### DIFF
--- a/packages/ui-react/src/components/Logo/Logo.module.scss
+++ b/packages/ui-react/src/components/Logo/Logo.module.scss
@@ -8,6 +8,7 @@
 
 .logo {
   width: auto;
+  max-width: 100%;
   max-height: variables.$header-height - 10px;
   vertical-align: middle;
   cursor: pointer;


### PR DESCRIPTION
## This PR
 
Solves: [OTT-810](https://videodock.atlassian.net/browse/OTT-810)

   - Keep the logo `width` to automatically adjust the logo based on its intrinsic dimensions to maintain aspect ratio, while `max-width` to make sure the logo does not exceed container width 

[OTT-810]: https://videodock.atlassian.net/browse/OTT-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ