### PR TITLE
Fix / Format date function-call caused an  error message on 'Cancel payment' modal

### DIFF
--- a/packages/ui-react/src/containers/AccountModal/forms/CancelSubscription.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/CancelSubscription.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { format, fromUnixTime } from 'date-fns';
 import { useLocation, useNavigate } from 'react-router';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import AccountController from '@jwp/ott-common/src/controllers/AccountController';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
+import { formatLocalizedDate } from '@jwp/ott-common/src/utils/formatting';
 
 import CancelSubscriptionForm from '../../../components/CancelSubscriptionForm/CancelSubscriptionForm';
 import LoadingOverlay from '../../../components/LoadingOverlay/LoadingOverlay';
@@ -23,7 +23,7 @@ const CancelSubscription = () => {
   const [cancelled, setCancelled] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const expirationDate = subscription?.expiresAt ? fromUnixTime(subscription.expiresAt) : null;
+  const expirationDateFormatted = subscription?.expiresAt ? formatLocalizedDate(new Date(subscription.expiresAt * 1000), i18n.language) : '';
 
   const cancelSubscriptionConfirmHandler = async () => {
     setSubmitting(true);
@@ -32,9 +32,8 @@ const CancelSubscription = () => {
     try {
       await accountController.updateSubscription('cancelled');
 
-      if (expirationDate) {
-        const formattedDate = format(expirationDate, 'P', { locale: { code: i18n.language } });
-        announce(t('subscription_cancelled.message', { date: formattedDate }), 'success');
+      if (expirationDateFormatted) {
+        announce(t('subscription_cancelled.message', { date: expirationDateFormatted }), 'success');
       }
 
       setCancelled(true);
@@ -54,7 +53,7 @@ const CancelSubscription = () => {
   return (
     <React.Fragment>
       {cancelled ? (
-        <SubscriptionCancelled expiresDate={expirationDate ? format(expirationDate, 'P', { locale: { code: i18n.language } }) : ''} onClose={closeHandler} />
+        <SubscriptionCancelled expiresDate={expirationDateFormatted} onClose={closeHandler} />
       ) : (
         <CancelSubscriptionForm onConfirm={cancelSubscriptionConfirmHandler} onCancel={closeHandler} submitting={submitting} error={error} />
       )}


### PR DESCRIPTION
An Javascript error occurred in the following call:
```
const formattedDate = format(expirationDate, 'P', { locale: { code: i18n.language } });
```
This caused an error to occur within the try/catch block, result in a "Unknown error occurred" error message in the UI.

**Explanation for the error:**
This function is called incorrectly. Instead `option.locale` should dynamically load a `Locale` from within `date-fns ` containing formatter utilities within it. That is too much work for now. This work was done based on this feedback https://github.com/Videodock/ott-web-app/pull/36#discussion_r1466164073

I think it's acceptable to leave it like this for the foreseeable future. `formatLocalizedDate` is used throughout the app. So if we want to phase out this function, let's do it for all occurrences ;-) 

Ticket: https://videodock.atlassian.net/browse/OTT-795

