### PR TITLE
Fix / favorites history validation error

### DIFF
--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -34,7 +34,7 @@ export default class FavoriteService {
   }
 
   private validateFavorites(favorites: unknown) {
-    if (schema.validateSync(favorites)) {
+    if (favorites && schema.validateSync(favorites)) {
       return favorites as SerializedFavorite[];
     }
 

--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -61,7 +61,7 @@ export default class WatchHistoryService {
   };
 
   private validateWatchHistory(history: unknown) {
-    if (schema.validateSync(history)) {
+    if (history && schema.validateSync(history)) {
       return history as SerializedWatchHistoryItem[];
     }
 


### PR DESCRIPTION
## Description

When the favorites or history isn't set in the localStorage, the validation failed because it returns `null`. The schema doesn't allow this. I could either make the schema `.nullable()` or check the input before running the validation.
