### PR TITLE
Fix /  undouble serieIds to prevent crash

### DIFF
--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -47,8 +47,9 @@ export default class WatchHistoryService {
     const seriesIds = Object.keys(mediaWithSeries || {})
       .map((key) => mediaWithSeries?.[key]?.[0]?.series_id)
       .filter(Boolean) as string[];
+    const uniqueSerieIds = [...new Set(seriesIds)];
 
-    const seriesItems = await this.apiService.getMediaByWatchlist(continueWatchingList, seriesIds);
+    const seriesItems = await this.apiService.getMediaByWatchlist(continueWatchingList, uniqueSerieIds);
     const seriesItemsDict = Object.keys(mediaWithSeries || {}).reduce((acc, key) => {
       const seriesItemId = mediaWithSeries?.[key]?.[0]?.series_id;
       if (seriesItemId) {


### PR DESCRIPTION
Because the series IDs are determined based on the episodes you watched, it could occur that a double serie ID is generated. This caused an API error, resulting in a crashing app.

Now that I understand the problem better. I consider this https://videodock.atlassian.net/browse/OTT-695 fixed.

Bug ticket: https://videodock.atlassian.net/browse/OTT-801