### PR TITLE
Fix / Search field background color contrast

### DIFF
--- a/packages/ui-react/src/components/SearchBar/SearchBar.module.scss
+++ b/packages/ui-react/src/components/SearchBar/SearchBar.module.scss
@@ -22,7 +22,7 @@
   font-weight: var(--body-font-weight-bold);
   font-size: 16px;
 
-  background: rgba(variables.$black, 0.54);
+  background: variables.$black;
 
   border: 1px solid rgba(variables.$white, 0.32);
   border-radius: 4px;


### PR DESCRIPTION
Fixes search box overlaps with menu items (iPad mini - landscape, Safari)
But you can also consider it a contrast improvement for a11y.

Ticket: https://videodock.atlassian.net/browse/OTT-872