### PR TITLE
Refactor / Underline for active header item and add lineair gradient

### DIFF
--- a/packages/ui-react/src/components/Button/Button.module.scss
+++ b/packages/ui-react/src/components/Button/Button.module.scss
@@ -80,7 +80,7 @@ $large-button-height: 40px;
 
   &.text {
     background: none;
-    opacity: 0.7;
+    opacity: 0.9;
 
     &:not(.disabled) {
       &.active,

--- a/packages/ui-react/src/components/Header/Header.module.scss
+++ b/packages/ui-react/src/components/Header/Header.module.scss
@@ -81,7 +81,7 @@
     height: 36px;
     min-height: 36px;
     margin: 0 6px;
-    padding: calc(#{variables.$header-height} / 2.5) calc(#{variables.$base-spacing} / 2);
+    padding: 0 calc(#{variables.$base-spacing} / 2);
     font-weight: var(--body-font-weight-bold);
     font-size: 18px;
   }

--- a/packages/ui-react/src/components/IconButton/IconButton.module.scss
+++ b/packages/ui-react/src/components/IconButton/IconButton.module.scss
@@ -11,7 +11,7 @@
   outline: var(--highlight-color, white) none;
 
   cursor: pointer;
-  opacity: 0.7;
+  opacity: 0.9;
   transition: transform 0.1s ease;
 
   &:hover,

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -173,6 +173,16 @@
   }
 }
 
+.posterFade {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(0deg, transparent, var(--body-background-color, variables.$white));
+}
+
 .playIcon {
   position: absolute;
   top: calc(50% - 60px);

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -42,6 +42,7 @@ const VideoDetails: React.VFC<Props> = ({
       <header className={styles.video} data-testid={testId('video-details')}>
         <div className={classNames(styles.main, styles.mainPadding)}>
           <Image className={styles.poster} image={image} alt={alt} width={1280} />
+          <div className={styles.posterFade} />
           <div className={styles.info}>
             <h1 className={styles.title}>{title}</h1>
             <div className={styles.metaContainer}>

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -18,6 +18,9 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           src="http://image.jpg?width=1280"
         />
         <div
+          class="_posterFade_d0c133"
+        />
+        <div
           class="_info_d0c133"
         >
           <h1

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -1,6 +1,5 @@
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
-@use 'sass:math';
 
 .layout {
   display: flex;

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -52,8 +52,22 @@ div.testFixMargin {
 }
 
 .headerButton {
-  &:not(:focus) {
-    border-bottom: 2px variables.$white solid;
-    border-radius: 0;
-  }
+    overflow: visible;
+
+    &::after {
+      position: absolute;
+      bottom: -#{(variables.$header-height - 36px) / 2};
+      left:0;
+      width: 100%;
+      height: 2px;
+      background-color: variables.$white;
+      content: '';
+    }
+    body:global(.is-tabbing) & {
+      &:focus {
+        &::after {
+          display: none;
+        }
+      }
+    }
 }

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -1,5 +1,6 @@
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
+@use 'sass:math';
 
 .layout {
   display: flex;
@@ -56,8 +57,8 @@ div.testFixMargin {
 
     &::after {
       position: absolute;
-      bottom: -#{(variables.$header-height - 36px) / 2};
-      left:0;
+      bottom: calc(((variables.$header-height - 36px) / 2) * -1);
+      left: 0;
       width: 100%;
       height: 2px;
       background-color: variables.$white;

--- a/packages/ui-react/src/utils/theming.ts
+++ b/packages/ui-react/src/utils/theming.ts
@@ -13,8 +13,10 @@ export const setThemingVariables = (config: Config) => {
   root.style.setProperty('--highlight-color', highlightColor || '#fff');
   root.style.setProperty('--highlight-contrast-color', highlightColor ? calculateContrastColor(highlightColor) : '#000');
 
-  root.style.setProperty('--header-background', headerBackground || 'rgba(0, 0, 0, 0.85)');
-  root.style.setProperty('--header-contrast-color', headerBackground ? calculateContrastColor(headerBackground) : '#fff');
+  if (headerBackground) {
+    root.style.setProperty('--header-background', headerBackground);
+    root.style.setProperty('--header-contrast-color', calculateContrastColor(headerBackground));
+  }
 
   if (backgroundColor) {
     root.style.setProperty('--body-background-color', backgroundColor);

--- a/packages/ui-react/stylelint.config.js
+++ b/packages/ui-react/stylelint.config.js
@@ -1,3 +1,11 @@
 module.exports = {
   extends: ['stylelint-config-jwp'],
+  rules: {
+    'selector-pseudo-class-no-unknown': [
+      true,
+      {
+        ignorePseudoClasses: ['global'],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## This PR

- Refactors the implementation of the underline for the active header item:
   - Required the usage of the global `is-tabbing` method, resulting in a `stylelint` error _"Unexpected unknown pseudo-class selector ":global"_. Therefore updated the `stylelint` configuration to ignore this specific pseudo-class.
- Introduces a linear gradient to the header in place of the previously added solid background, as discussed internally on Slack

![Screenshot 2024-02-07 at 15 36 10](https://github.com/Videodock/ott-web-app/assets/48496458/a5659a2d-8b68-4ad1-9c75-7350262187bb)
