### PR TITLE
Fix / some a11y and layout fixes

### DIFF
--- a/packages/ui-react/src/components/Header/Header.module.scss
+++ b/packages/ui-react/src/components/Header/Header.module.scss
@@ -226,11 +226,14 @@
   }
 
   .brand {
+    margin-right: 0;
+    margin-left: 0;
     text-align: center;
   }
 
   .menu,
   .actions {
+    justify-content: flex-end;
     width: 80px;
   }
 }

--- a/packages/ui-react/src/components/Header/Header.tsx
+++ b/packages/ui-react/src/components/Header/Header.tsx
@@ -103,16 +103,8 @@ const Header: React.FC<Props> = ({
 
     return searchActive ? (
       <div className={styles.searchContainer}>
-        <SearchBar {...searchBarProps} />
-        <IconButton
-          className={styles.iconButton}
-          aria-label="Close search"
-          onClick={() => {
-            if (onCloseSearchButtonClick) {
-              onCloseSearchButtonClick();
-            }
-          }}
-        >
+        <SearchBar {...searchBarProps} onClose={onCloseSearchButtonClick} />
+        <IconButton className={styles.iconButton} aria-label="Close search" onClick={onCloseSearchButtonClick}>
           <Icon icon={CloseIcon} />
         </IconButton>
       </div>

--- a/packages/ui-react/src/components/IconButton/IconButton.tsx
+++ b/packages/ui-react/src/components/IconButton/IconButton.tsx
@@ -18,7 +18,12 @@ const IconButton: React.FC<Props> = ({ children, onClick, tabIndex = 0, classNam
       onClick={onClick}
       role="button"
       tabIndex={tabIndex}
-      onKeyDown={(event: React.KeyboardEvent) => (event.key === 'Enter' || event.key === ' ') && tabIndex >= 0 && onClick && onClick()}
+      onKeyDown={(event: React.KeyboardEvent) => {
+        if ((event.key === 'Enter' || event.key === ' ') && tabIndex >= 0 && onClick) {
+          onClick();
+          event.preventDefault(); // prevent click being called when this component unmounts
+        }
+      }}
       {...ariaProps}
     >
       {children}

--- a/packages/ui-react/src/components/Logo/Logo.module.scss
+++ b/packages/ui-react/src/components/Logo/Logo.module.scss
@@ -9,7 +9,8 @@
 .logo {
   width: auto;
   max-width: 100%;
-  max-height: variables.$header-height - 10px;
+  height: auto;
+  max-height: variables.$header-height - 20px;
   vertical-align: middle;
   cursor: pointer;
 }

--- a/packages/ui-react/src/components/SearchBar/SearchBar.tsx
+++ b/packages/ui-react/src/components/SearchBar/SearchBar.tsx
@@ -12,10 +12,11 @@ export type Props = {
   query?: string;
   onQueryChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onClearButtonClick?: () => void;
+  onClose?: () => void;
   inputRef?: React.MutableRefObject<HTMLInputElement>;
 };
 
-const SearchBar: React.FC<Props> = ({ query, onQueryChange, onClearButtonClick, inputRef }: Props) => {
+const SearchBar: React.FC<Props> = ({ query, onQueryChange, onClearButtonClick, onClose, inputRef }: Props) => {
   const { t } = useTranslation('search');
 
   return (
@@ -26,6 +27,7 @@ const SearchBar: React.FC<Props> = ({ query, onQueryChange, onClearButtonClick, 
         type="text"
         value={query}
         onChange={onQueryChange}
+        onKeyDown={(event) => event.key === 'Escape' && onClose?.()}
         aria-label={t('search_bar.search_label')}
         placeholder={t('search_bar.search_placeholder')}
         ref={inputRef}


### PR DESCRIPTION
## Description

- The logo was squashed on mobile
- Decreased the logo max-height
- Give the logo more space on mobile by removing the horizontal margin
- Fix header actions aligned to the left on mobile (when only 1 icon was rendered)
- Fix modal not closing when pressing the enter key on the close icon
- Close search bar when pressing the escape key

**Before logo changes**

![image](https://github.com/Videodock/ott-web-app/assets/3996119/5e0f8f36-7d62-44a4-83a3-2788baf57d5d)

![image](https://github.com/Videodock/ott-web-app/assets/3996119/3035d5b0-ee9f-4c93-bcdb-012118d28c1e)


**After logo changes**

![image](https://github.com/Videodock/ott-web-app/assets/3996119/ac3ed21f-1b0e-4be1-9b0a-a69137065233)

![image](https://github.com/Videodock/ott-web-app/assets/3996119/30ec2e22-26a5-4800-935b-f226fa92aa58)

![image](https://github.com/Videodock/ott-web-app/assets/3996119/c1744700-6ab3-438e-99e1-69fa2df6e473)

