### PR TITLE
Chore / add version number to footer text

### DIFF
--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -1,9 +1,9 @@
 APP_API_BASE_URL=https://cdn.jwplayer.com
 APP_PLAYER_ID=M4qoGvUk
 
-
 ### Web-only env vars (not sent to common/src/env configureEnv())
-APP_FOOTER_TEXT=\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/)
+APP_FOOTER_VERSION=$npm_package_version
+APP_FOOTER_TEXT=\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | v${APP_FOOTER_VERSION}
 
 # the default language that the app should load when the language couldn't be detected
 APP_DEFAULT_LANGUAGE=en

--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -2,7 +2,7 @@ APP_API_BASE_URL=https://cdn.jwplayer.com
 APP_PLAYER_ID=M4qoGvUk
 
 ### Web-only env vars (not sent to common/src/env configureEnv())
-APP_FOOTER_VERSION=$npm_package_version
+APP_VERSION=$npm_package_version
 APP_FOOTER_TEXT=\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | v${APP_FOOTER_VERSION}
 
 # the default language that the app should load when the language couldn't be detected

--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -3,7 +3,7 @@ APP_PLAYER_ID=M4qoGvUk
 
 ### Web-only env vars (not sent to common/src/env configureEnv())
 APP_VERSION=$npm_package_version
-APP_FOOTER_TEXT=\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | v${APP_FOOTER_VERSION}
+APP_FOOTER_TEXT=\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | v${APP_VERSION}
 
 # the default language that the app should load when the language couldn't be detected
 APP_DEFAULT_LANGUAGE=en


### PR DESCRIPTION
Add the app version to the default `.env`. If you have suggestions for another name please suggest a change.