### PR TITLE
Fix / optional above non required inputs

### DIFF
--- a/packages/ui-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui-react/src/components/Dropdown/Dropdown.tsx
@@ -20,6 +20,7 @@ type Props = {
   error?: boolean;
   helperText?: string;
   required?: boolean;
+  hideOptional?: boolean;
   onChange: React.ChangeEventHandler;
   testId?: string;
   lang?: string;
@@ -40,6 +41,7 @@ const Dropdown: React.FC<Props & React.AriaAttributes> = ({
   required = false,
   size = 'medium',
   testId,
+  hideOptional,
   lang,
   ...rest
 }: Props & React.AriaAttributes) => {
@@ -49,10 +51,10 @@ const Dropdown: React.FC<Props & React.AriaAttributes> = ({
 
   return (
     <div className={classNames(styles.container, { [styles.fullWidth]: fullWidth, [styles.error]: error }, styles[size], className)} data-testid={testId}>
-      {(label || !required) && (
+      {(label || (!required && !hideOptional)) && (
         <label htmlFor={id} className={styles.label}>
           {label}
-          {!required ? <span>{t('optional')}</span> : null}
+          {!required && !hideOptional ? <span>{t('optional')}</span> : null}
         </label>
       )}
       <div className={classNames(styles.dropdown, { [styles.fullWidth]: fullWidth })}>

--- a/packages/ui-react/src/components/Filter/Filter.tsx
+++ b/packages/ui-react/src/components/Filter/Filter.tsx
@@ -57,6 +57,7 @@ const Filter: FC<Props> = ({ name, value, defaultLabel, options, setValue, force
             value={value}
             onChange={handleChange}
             aria-label={t('filter_videos_by', { name })}
+            hideOptional
           />
         </div>
       )}

--- a/packages/ui-react/src/components/VideoLayout/VideoLayout.module.scss
+++ b/packages/ui-react/src/components/VideoLayout/VideoLayout.module.scss
@@ -136,7 +136,7 @@
 }
 
 .filtersInline {
-  margin-bottom: variables.$base-spacing;
+  margin: variables.$base-spacing 24px;
   padding-bottom: variables.$base-spacing;
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
## Description

The "simple" fix for hiding the season selector in the inline video details layout. I've also fixed the spacing around the season selector.

Fixes [OTT-554](https://videodock.atlassian.net/browse/OTT-554)
Fixes [OTT-836](https://videodock.atlassian.net/browse/OTT-836) (sorry @MelissaDTH)

![image](https://github.com/Videodock/ott-web-app/assets/3996119/076fbe25-4aa9-4246-8648-d562f549142d)





[OTT-554]: https://videodock.atlassian.net/browse/OTT-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-836]: https://videodock.atlassian.net/browse/OTT-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ