### PR TITLE
Fix / improve consents required error

### DIFF
--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -70,7 +70,7 @@ const Registration = () => {
 
       if (consentsErrors.length) {
         setConsentErrors(consentsErrors);
-        throw new Error('Consents error');
+        throw new Error(t('registration.consents_error'));
       }
 
       await accountController.register(email, password, window.location.href, formatConsentsFromValues(publisherConsents, consentValues));

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -139,6 +139,7 @@
   "registration": {
     "already_account": "Already have an account?",
     "consent_required": "This field is required, please fill in {{field}} to continue.",
+    "consents_error": "Please accept all required consents to continue.",
     "continue": "Continue",
     "email": "Email",
     "email_updates": "Yes, I want to receive {{siteName}} updates by email.",

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -149,6 +149,7 @@
   "registration": {
     "already_account": "¿Ya tienes una cuenta?",
     "consent_required": "Este campo es obligatorio, por favor completa {{field}} para continuar.",
+    "consents_error": "Acepte todos los consentimientos necesarios para continuar.",
     "continue": "Continuar",
     "email": "Correo electrónico",
     "email_updates": "Sí, deseo recibir actualizaciones de {{siteName}} por correo electrónico.",


### PR DESCRIPTION
## Description

When the user doesn't check all required consents, a generic form error is shown on top of the form with the "Consents error" text. This is not user-friendly and accessible, so I've added a translation for this use case.

This error might disappear when we continue refactoring the consent validation into the AccountController. But, this extra-form error may be beneficial for screen reader users.

Fixes OTT-880