### PR TITLE
Fix / broken checkbox in personal details

### DIFF
--- a/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
+++ b/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
@@ -44,7 +44,11 @@ const PersonalDetailsForm: React.FC<Props> = ({
   questionErrors,
 }: Props) => {
   const { t } = useTranslation('account');
-  const renderQuestion = ({ value, key, question, required }: CleengCaptureQuestionField) => {
+  const renderQuestion = ({ value, key, question, required, enabled }: CleengCaptureQuestionField) => {
+    if (!enabled) {
+      return null;
+    }
+
     const values = value?.split(';').map((question) => {
       const [value, label = value] = question.split(':');
 

--- a/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
+++ b/packages/ui-react/src/components/PersonalDetailsForm/PersonalDetailsForm.tsx
@@ -60,13 +60,19 @@ const PersonalDetailsForm: React.FC<Props> = ({
       key,
     };
 
-    const optionsKeys = Object.keys(values);
+    // The rendered field is determined by the given available options for each question:
+    // TextField <- when there is exactly 1 option and the value is empty (e.g. "")
+    // Checkbox  <- when there is exactly 1 option and the value is not empty (e.g. "accepted")
+    // Radio     <- when there are exactly 2 options
+    // Dropdown  <- when there are more than 2 options
 
-    if (optionsKeys.length === 1) {
+    if (values.length === 1 && values[0].value === '') {
+      return <TextField value={values[0].value} label={question} {...props} />;
+    } else if (values.length === 1) {
       return <Checkbox checked={!!questionValues[key]} value={values[0].value} header={question} label={values[0].label} {...props} />;
-    } else if (optionsKeys.length === 2) {
+    } else if (values.length === 2) {
       return <Radio values={values} value={questionValues[key]} header={question} {...props} />;
-    } else if (optionsKeys.length > 2) {
+    } else if (values.length > 2) {
       return <Dropdown options={values} value={questionValues[key]} label={question} defaultLabel={t('personal_details.select_answer')} {...props} fullWidth />;
     }
 


### PR DESCRIPTION
## Description

There was a "broken" checkbox in the personal details screen where we expected an open text field. This has been fixed, and I've added some comments on how the field is determined (although it is also visible by reading the code).

I've also fixed the issue that disabled questions are visible in the personal details screen.

Fixes OTT-553, OTT-584