### PR TITLE
Fix / accessible EPG

### DIFF
--- a/packages/ui-react/src/components/Epg/Epg.tsx
+++ b/packages/ui-react/src/components/Epg/Epg.tsx
@@ -50,10 +50,17 @@ export default function Epg({ channels, selectedChannel, onChannelClick, onProgr
   const catchupHoursDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.catchupHours])), [channels]);
   const titlesDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.title])), [channels]);
 
+  const onNowClick = () => {
+    onScrollToNow();
+    if (program) {
+      document.getElementById(`program-${program.id}`)?.focus();
+    }
+  };
+
   return (
     <div className={styles.epg}>
       <div className={styles.timelineControl}>
-        <Button className={styles.timelineNowButton} variant="contained" label={t('now')} color="primary" onClick={onScrollToNow} size="small" />
+        <Button className={styles.timelineNowButton} variant="contained" label={t('now')} color="primary" onClick={onNowClick} size="small" />
         <IconButton className={styles.leftControl} aria-label={t('slide_left')} onClick={() => onScrollLeft()}>
           <Icon icon={ChevronLeft} />
         </IconButton>

--- a/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
+++ b/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
@@ -28,6 +28,7 @@ const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWi
         onClick={() => onClick && onClick(channel)}
         data-testid={testId(uuid)}
         role="button"
+        tabIndex={0}
       >
         <Image className={styles.epgChannelLogo} image={channelLogoImage} alt={title} width={320} />
       </div>

--- a/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
+++ b/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
@@ -29,7 +29,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
 
   const { t } = useTranslation('common');
   const { data } = program;
-  const { image, title, since, till } = data;
+  const { id, image, title, since, till } = data;
 
   const sinceTime = formatTime(since, set12HoursTimeFormat()).toLowerCase();
   const tillTime = formatTime(till, set12HoursTimeFormat()).toLowerCase();
@@ -39,7 +39,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
-    <div className={styles.epgProgramBox} style={position} onClick={() => onClick && onClick(program)}>
+    <div className={styles.epgProgramBox} style={position}>
       <div
         className={classNames(styles.epgProgram, {
           [styles.selected]: isActive,
@@ -48,6 +48,10 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
         })}
         style={{ width: styles.width }}
         data-testid={testId(program.data.id)}
+        onClick={() => onClick && onClick(program)}
+        role="button"
+        tabIndex={0}
+        id={`program-${id}`}
       >
         {showImage && <img className={styles.epgProgramImage} src={image} alt={alt} />}
         {showLiveTagInImage && <div className={styles.epgLiveTag}>{t('live')}</div>}

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -106,6 +106,10 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
 
     // scroll to top when clicking a program
     (document.scrollingElement || document.body).scroll({ top: 0, behavior: 'smooth' });
+
+    // focus first interactive element
+    const focusableElement = document.querySelector('#content button') as HTMLElement | null;
+    focusableElement?.focus();
   };
 
   const handleChannelClick = (channelId: string) => {


### PR DESCRIPTION
I took my timebox of 4 hours literally and I was only able to fix the following:
- Make the channel and program items accessible by tab-key and screen reader
- Set focus to current program when pressing the NOW-button
- Set focus to first interactive element (= start watching button) when clicking on a program

I also did a quick test on Android Talkback.

There were a lot of things I tried to optimize too, but I was not able to within the time. I should have tried to go forward with small increments, but I challenged myself it's optimising the HTML structure (grid/list sstructure) and I failed while doing it.

I consider my time spent more as a research project, learning about the technical possibilities within the EPG then an actual optimization. 

We can do one of these two things.
A. Merge this. Now you can navigate through the EPG, but there are a lot of accessibility optimisations to be done (and some would not even be possible due to the EPG has it's technical limitations)
B. We don't merge it. But that leaves the EPG inaccessible at all. It will completely be ignored by the tab-key or screen reader.

Ticket: https://videodock.atlassian.net/browse/OTT-478