### PR TITLE
Fix / a11y layout grid spatial navigation bug

### DIFF
--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -145,6 +145,12 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
               aria-colindex={columnIndex}
               className={styles.cell}
               style={{ width: `${Math.round(100 / columnCount)}%` }}
+              onClick={() => {
+                setSpatialNavigation(false);
+                setFocused(false);
+                setCurrentColumnIndex(0);
+                setCurrentRowIndex(0);
+              }}
             >
               {renderCell(item, currentRowIndex === rowIndex && currentColumnIndex === columnIndex ? 0 : -1)}
             </div>

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -19,6 +19,7 @@ const scrollIntoViewThrottled = throttle(function (focusedElement: HTMLElement) 
 
 const LayoutGrid = <Item extends object>({ className, columnCount, data, renderCell }: Props<Item>) => {
   const [focused, setFocused] = useState(false);
+  const [spatialNavigation, setSpatialNavigation] = useState(false);
   const [currentRowIndex, setCurrentRowIndex] = useState(0);
   const [currentColumnIndex, setCurrentColumnIndex] = useState(0);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -39,6 +40,8 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
     const isOnLastRow = currentRowIndex === rowCount - 1;
     const maxRightLastRow = (data.length % columnCount || columnCount) - 1; // Never go beyond last item
     const maxRight = isOnLastRow ? maxRightLastRow : columnCount - 1;
+
+    setSpatialNavigation(true);
 
     switch (key) {
       case 'ArrowLeft':
@@ -112,9 +115,11 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
 
     if (!elementToFocus) return;
 
-    elementToFocus.focus();
-    scrollIntoViewThrottled(elementToFocus);
-  }, [focused, currentRowIndex, currentColumnIndex]);
+    if (spatialNavigation) {
+      elementToFocus.focus();
+      scrollIntoViewThrottled(elementToFocus);
+    }
+  }, [focused, spatialNavigation, currentRowIndex, currentColumnIndex]);
 
   // When the window size changes, correct indexes if necessary
   useEffect(() => {

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -39,7 +39,7 @@ const VideoDetails: React.VFC<Props> = ({
 
   return (
     <div data-testid={testId('cinema-layout')}>
-      <header className={styles.video} data-testid={testId('video-details')}>
+      <header className={styles.video} data-testid={testId('video-details')} id="video-details">
         <div className={classNames(styles.main, styles.mainPadding)}>
           <Image className={styles.poster} image={image} alt={alt} width={1280} />
           <div className={styles.posterFade} />

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
     <header
       class="_video_d0c133"
       data-testid="video-details"
+      id="video-details"
     >
       <div
         class="_main_d0c133 _mainPadding_d0c133"

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -92,6 +92,7 @@ const LegacySeries = () => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -83,6 +83,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -19,6 +19,7 @@ const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [data]);
 
   return (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -73,6 +73,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -134,6 +134,7 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {


### PR DESCRIPTION
This fixes a bug where you video content would not switch when clicking a item from the CardGrid. This caused a mobile e2e test to fail.

This fix should also be cherry picked and added to https://github.com/jwplayer/ott-web-app/pull/451 because the bug is still active there.

Coincidentally I also fixed this bug: https://videodock.atlassian.net/browse/OTT-853

I also applied some logic which reset the column/row back to 0,0 after you clicked (opened) an item. So you will start in the top/left corner again when tabbing to this component.