### PR TITLE
Feat / set focus to start watching when switching item

### DIFF
--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -39,7 +39,7 @@ const VideoDetails: React.VFC<Props> = ({
 
   return (
     <div data-testid={testId('cinema-layout')}>
-      <header className={styles.video} data-testid={testId('video-details')}>
+      <header className={styles.video} data-testid={testId('video-details')} id="video-details">
         <div className={classNames(styles.main, styles.mainPadding)}>
           <Image className={styles.poster} image={image} alt={alt} width={1280} />
           <div className={styles.posterFade} />

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
     <header
       class="_video_d0c133"
       data-testid="video-details"
+      id="video-details"
     >
       <div
         class="_main_d0c133 _mainPadding_d0c133"

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -92,6 +92,7 @@ const LegacySeries = () => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -83,6 +83,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -19,6 +19,7 @@ const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [data]);
 
   return (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -73,6 +73,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -134,6 +134,7 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {


### PR DESCRIPTION
Set focus to "start watching" button when you switch to another video item from within the CardGrid.

I wanted to combine this with the scroll 0, because otherwise only the button will get in to the view and ideally you want to see the whole VideoDetails component.

It is dependent on the layout grid focus fix. Otherwise it will behave weird.

Ticket: https://videodock.atlassian.net/browse/OTT-867