### PR TITLE
Fix / usermenu item count & correct html structure

### DIFF
--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -36,8 +36,9 @@
 
   ul {
     margin: 0;
-    padding: 0;
+    padding: 0 0 calc(#{variables.$base-spacing} / 2) 0;
     list-style-type: none;
+    border-bottom: 1px solid rgba(variables.$white, 0.12);
   }
 }
 

--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -33,6 +33,12 @@
   background-color: var(--body-background-color);
   transform: translateX(-100%);
   transition: transform 0.3s cubic-bezier(0.52, 0.51, 0.2, 1);
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
 }
 
 .heading {

--- a/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
@@ -42,7 +42,7 @@
 
 .sectionHeader {
   width: 100%;
-  padding: 0 0 12px 24px;
+  padding: 12px 0 12px 24px;
   color: variables.$white;
   font-weight: 700;
   font-size: 12px;

--- a/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
@@ -1,6 +1,21 @@
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
 
+@mixin divider-before($marginY, $marginX, $background-opacity) {
+  position: relative;
+  margin-top: $marginY;
+
+  &::before {
+    position: absolute;
+    top: calc(#{$marginY} * -0.5);
+    right: $marginX;
+    left: $marginX;
+    height: 1px;
+    background-color: rgba(variables.$white, $background-opacity);
+    content: '';
+  }
+}
+
 .menuItems {
   width: auto;
   margin: 0;
@@ -18,14 +33,10 @@
 }
 
 .divider {
-  vertical-align: baseline;
-  background: transparent;
-  border: 0;
-  border-top: 1px solid rgba(variables.$white, 0.12);
+  @include divider-before(variables.$base-spacing, 0, 0.12);
 
   &.small {
-    margin: variables.$base-spacing;
-    border-top: 1px solid rgba(255, 255, 255, 0.32);
+    @include divider-before(variables.$base-spacing, variables.$base-spacing, 0.32);
   }
 }
 

--- a/packages/ui-react/src/components/UserMenu/UserMenu.tsx
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.tsx
@@ -128,10 +128,7 @@ const UserMenu = ({
             />
           </li>
         )}
-        <li role="presentation">
-          <hr className={classNames(styles.divider, { [styles.small]: small })} />
-        </li>
-        <li>
+        <li className={classNames(styles.divider, { [styles.small]: small })}>
           <MenuButton small={small} onClick={onLogout} label={t('nav.logout')} startIcon={<Icon icon={Exit} />} tabIndex={tabIndex} />
         </li>
       </ul>

--- a/packages/ui-react/src/components/UserMenu/UserMenu.tsx
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.tsx
@@ -26,6 +26,7 @@ type Props = {
   onClick?: () => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  titleId?: string;
   currentProfile?: Profile | null;
   profilesEnabled?: boolean;
   profiles?: Profile[];
@@ -47,6 +48,7 @@ const UserMenu = ({
   selectProfile,
   favoritesEnabled,
   focusable,
+  titleId,
 }: Props) => {
   const { t } = useTranslation('user');
   const navigate = useNavigate();
@@ -63,74 +65,77 @@ const UserMenu = ({
   }, [onClick, navigate, accountController]);
 
   return (
-    <ul onFocus={onFocus} onBlur={onBlur} className={styles.menuItems}>
-      {profilesEnabled && selectProfile && (
-        <ProfilesMenu
-          profiles={profiles ?? []}
-          currentProfile={currentProfile}
-          small={small}
-          selectingProfile={!!isSelectingProfile}
-          selectProfile={selectProfile}
-          createButtonLabel={t('nav.add_profile')}
-          switchProfilesLabel={t('nav.switch_profiles')}
-          onCreateButtonClick={() => navigate(PATH_USER_PROFILES_CREATE)}
-        />
-      )}
-      <li className={styles.sectionHeader}>{t('nav.settings')}</li>
-      {profilesEnabled && currentProfile && (
+    <>
+      <h2 className={styles.sectionHeader} id={titleId}>
+        {t('nav.settings')}
+      </h2>
+      <ul onFocus={onFocus} onBlur={onBlur} className={styles.menuItems}>
+        {profilesEnabled && selectProfile && (
+          <ProfilesMenu
+            profiles={profiles ?? []}
+            currentProfile={currentProfile}
+            small={small}
+            selectingProfile={!!isSelectingProfile}
+            selectProfile={selectProfile}
+            createButtonLabel={t('nav.add_profile')}
+            switchProfilesLabel={t('nav.switch_profiles')}
+            onCreateButtonClick={() => navigate(PATH_USER_PROFILES_CREATE)}
+          />
+        )}
+        {profilesEnabled && currentProfile && (
+          <li>
+            <MenuButton
+              small={small}
+              onClick={onClick}
+              to={userProfileURL(currentProfile.id ?? '')}
+              label={t('nav.profile')}
+              tabIndex={tabIndex}
+              startIcon={<ProfileCircle src={currentProfile?.avatar_url} alt={currentProfile?.name ?? ''} />}
+            />
+          </li>
+        )}
         <li>
           <MenuButton
             small={small}
             onClick={onClick}
-            to={userProfileURL(currentProfile.id ?? '')}
-            label={t('nav.profile')}
+            to={PATH_USER_ACCOUNT}
+            label={t('nav.account')}
+            startIcon={<Icon icon={AccountCircle} />}
             tabIndex={tabIndex}
-            startIcon={<ProfileCircle src={currentProfile?.avatar_url} alt={currentProfile?.name ?? ''} />}
           />
         </li>
-      )}
-      <li>
-        <MenuButton
-          small={small}
-          onClick={onClick}
-          to={PATH_USER_ACCOUNT}
-          label={t('nav.account')}
-          startIcon={<Icon icon={AccountCircle} />}
-          tabIndex={tabIndex}
-        />
-      </li>
-
-      {favoritesEnabled && (
+        {favoritesEnabled && (
+          <li>
+            <MenuButton
+              small={small}
+              onClick={onClick}
+              to={PATH_USER_FAVORITES}
+              label={t('nav.favorites')}
+              startIcon={<Icon icon={Favorite} />}
+              tabIndex={tabIndex}
+            />
+          </li>
+        )}
+        {showPaymentsItem && (
+          <li>
+            <MenuButton
+              small={small}
+              onClick={onClick}
+              to={PATH_USER_PAYMENTS}
+              label={t('nav.payments')}
+              startIcon={<Icon icon={BalanceWallet} />}
+              tabIndex={tabIndex}
+            />
+          </li>
+        )}
+        <li role="presentation">
+          <hr className={classNames(styles.divider, { [styles.small]: small })} />
+        </li>
         <li>
-          <MenuButton
-            small={small}
-            onClick={onClick}
-            to={PATH_USER_FAVORITES}
-            label={t('nav.favorites')}
-            startIcon={<Icon icon={Favorite} />}
-            tabIndex={tabIndex}
-          />
+          <MenuButton small={small} onClick={onLogout} label={t('nav.logout')} startIcon={<Icon icon={Exit} />} tabIndex={tabIndex} />
         </li>
-      )}
-      {showPaymentsItem && (
-        <li>
-          <MenuButton
-            small={small}
-            onClick={onClick}
-            to={PATH_USER_PAYMENTS}
-            label={t('nav.payments')}
-            startIcon={<Icon icon={BalanceWallet} />}
-            tabIndex={tabIndex}
-          />
-        </li>
-      )}
-      <li>
-        <hr className={classNames(styles.divider, { [styles.small]: small })} />
-      </li>
-      <li>
-        <MenuButton small={small} onClick={onLogout} label={t('nav.logout')} startIcon={<Icon icon={Exit} />} tabIndex={tabIndex} />
-      </li>
-    </ul>
+      </ul>
+    </>
   );
 };
 

--- a/packages/ui-react/src/components/UserMenu/__snapshots__/UserMenu.test.tsx.snap
+++ b/packages/ui-react/src/components/UserMenu/__snapshots__/UserMenu.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`<UserMenu> > renders and matches snapshot 1`] = `
 <div>
+  <h2
+    class="_sectionHeader_457528"
+  >
+    nav.settings
+  </h2>
   <ul
     class="_menuItems_457528"
   >
-    <li
-      class="_sectionHeader_457528"
-    >
-      nav.settings
-    </li>
     <li>
       <a
         class="_menuButton_91706b"
@@ -60,12 +60,9 @@ exports[`<UserMenu> > renders and matches snapshot 1`] = `
         </span>
       </a>
     </li>
-    <li>
-      <hr
-        class="_divider_457528"
-      />
-    </li>
-    <li>
+    <li
+      class="_divider_457528"
+    >
       <div
         class="_menuButton_91706b"
         tabindex="0"

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -31,12 +31,6 @@ div.testFixMargin {
   margin-bottom: 50px;
 }
 
-.divider {
-  width: 100%;
-  border: none;
-  border-top: 1px solid rgba(variables.$white, 0.12);
-}
-
 .buttonContainer {
   display: flex;
   flex-direction: column;

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -224,7 +224,6 @@ const Layout = () => {
             </li>
           ))}
         </ul>
-        <hr className={styles.divider} />
         {renderUserActions(sideBarOpen)}
       </Sidebar>
     </div>

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -216,11 +216,11 @@ const Layout = () => {
       <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
         <ul>
           <li>
-            <MenuButton label={t('home')} to="/" tabIndex={sideBarOpen ? 0 : -1} />
+            <MenuButton label={t('home')} to="/" />
           </li>
           {menu.map((item) => (
             <li key={item.contentId}>
-              <MenuButton label={item.label} to={playlistURL(item.contentId)} tabIndex={sideBarOpen ? 0 : -1} />
+              <MenuButton label={item.label} to={playlistURL(item.contentId)} />
             </li>
           ))}
         </ul>

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -15,6 +15,7 @@ import { IS_DEVELOPMENT_BUILD, unicodeToChar } from '@jwp/ott-common/src/utils/c
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useSearchQueryUpdater from '@jwp/ott-ui-react/src/hooks/useSearchQueryUpdater';
 import { useProfiles, useSelectProfile } from '@jwp/ott-hooks-react/src/useProfiles';
+import useOpaqueId from '@jwp/ott-hooks-react/src/useOpaqueId';
 import { PATH_HOME, PATH_USER_PROFILES } from '@jwp/ott-common/src/paths';
 import { playlistURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import env from '@jwp/ott-common/src/env';
@@ -37,6 +38,7 @@ const Layout = () => {
     ({ config, accessModel, supportedLanguages }) => ({ config, accessModel, supportedLanguages }),
     shallow,
   );
+  const userMenuTitleId = useOpaqueId('usermenu-title');
   const isLoggedIn = !!useAccountStore(({ user }) => user);
   const favoritesEnabled = !!config.features?.favoritesList;
   const { menu, assets, siteName, description, features, styling } = config;
@@ -132,7 +134,9 @@ const Layout = () => {
     if (!canLogin) return null;
 
     return isLoggedIn ? (
-      <UserMenu focusable={sideBarOpen} favoritesEnabled={favoritesEnabled} showPaymentsItem />
+      <section aria-labelledby={userMenuTitleId}>
+        <UserMenu focusable={sideBarOpen} favoritesEnabled={favoritesEnabled} titleId={userMenuTitleId} showPaymentsItem />
+      </section>
     ) : (
       <div className={styles.buttonContainer}>
         <Button tabIndex={sideBarOpen ? 0 : -1} onClick={loginButtonClickHandler} label={t('sign_in')} fullWidth />
@@ -210,10 +214,16 @@ const Layout = () => {
         )}
       </div>
       <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
-        <MenuButton label={t('home')} to="/" tabIndex={sideBarOpen ? 0 : -1} />
-        {menu.map((item) => (
-          <MenuButton key={item.contentId} label={item.label} to={playlistURL(item.contentId)} tabIndex={sideBarOpen ? 0 : -1} />
-        ))}
+        <ul>
+          <li>
+            <MenuButton label={t('home')} to="/" tabIndex={sideBarOpen ? 0 : -1} />
+          </li>
+          {menu.map((item) => (
+            <li key={item.contentId}>
+              <MenuButton label={item.label} to={playlistURL(item.contentId)} tabIndex={sideBarOpen ? 0 : -1} />
+            </li>
+          ))}
+        </ul>
         <hr className={styles.divider} />
         {renderUserActions(sideBarOpen)}
       </Sidebar>

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -108,19 +108,20 @@ exports[`<Layout /> > renders layout 1`] = `
       <nav
         class="_group_577f70"
       >
-        <a
-          aria-current="page"
-          class="_menuButton_91706b _active_91706b"
-          href="/"
-          tabindex="-1"
-        >
-          <span>
-            home
-          </span>
-        </a>
-        <hr
-          class="_divider_c71437"
-        />
+        <ul>
+          <li>
+            <a
+              aria-current="page"
+              class="_menuButton_91706b _active_91706b"
+              href="/"
+              tabindex="0"
+            >
+              <span>
+                home
+              </span>
+            </a>
+          </li>
+        </ul>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
This change announced the correct amount of list items in the user menu. I also improved wrapped the sidebar menu items in a list, so a screen reader user knows how may items there are in the menu.

Originally I wanted to go for a border-bottom styling instead of the suggested `<li role="presentation"><hr/></li>`, but it took too much time to get the styling identical.

I chosen a `h2` for the heading because, we should limit the `h1` to one. And using a `h3` is illogical (because it is missing the `h2`). I could not find an better solution within the time. I'm open for ideas, if you disagree with the approach.

Ticket: https://videodock.atlassian.net/browse/OTT-842