### PR TITLE
Fix / apply aria-hidden to checkbox asterisk

### DIFF
--- a/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
+++ b/packages/ui-react/src/components/Account/__snapshots__/Account.test.tsx.snap
@@ -202,6 +202,9 @@ exports[`<Account> > renders and matches snapshot 1`] = `
             for="check-box_1235_consentsvalues_marketing"
             lang="en"
           >
+            <span
+              aria-hidden="true"
+            />
             Receive Marketing Emails
           </label>
         </div>

--- a/packages/ui-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui-react/src/components/Checkbox/Checkbox.tsx
@@ -47,7 +47,7 @@ const Checkbox: React.FC<Props> = ({ label, name, onChange, header, checked, val
           aria-describedby={helperTextId}
         />
         <label htmlFor={id} lang={lang}>
-          {required ? '* ' : ''}
+          <span aria-hidden="true">{required ? '* ' : ''}</span>
           {label}
         </label>
       </div>

--- a/packages/ui-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/ui-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,6 +18,9 @@ exports[`<Checkbox> > renders and matches snapshot 1`] = `
       <label
         for="check-box_1235_name"
       >
+        <span
+          aria-hidden="true"
+        />
         label
       </label>
     </div>

--- a/packages/ui-react/src/components/CustomRegisterField/__snapshots__/CustomRegisterField.test.tsx.snap
+++ b/packages/ui-react/src/components/CustomRegisterField/__snapshots__/CustomRegisterField.test.tsx.snap
@@ -19,6 +19,9 @@ exports[`<CustomRegisterField> > renders and matches snapshot <Checkbox> 1`] = `
       <label
         for="check-box_1235_name"
       >
+        <span
+          aria-hidden="true"
+        />
         label
       </label>
     </div>
@@ -156,6 +159,9 @@ exports[`<CustomRegisterField> > renders and matches snapshot <Dropdown type="ra
       <label
         for="check-box_1235_name"
       >
+        <span
+          aria-hidden="true"
+        />
         label
       </label>
     </div>

--- a/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
+++ b/packages/ui-react/src/components/PersonalDetailsForm/__snapshots__/PersonalDetailsForm.test.tsx.snap
@@ -519,7 +519,11 @@ exports[`<PersonalDetailsForm> > Renders with errors 1`] = `
         <label
           for="check-box_1235_ccc"
         >
-          * 
+          <span
+            aria-hidden="true"
+          >
+            * 
+          </span>
           CheckMe
         </label>
       </div>
@@ -973,7 +977,11 @@ exports[`<PersonalDetailsForm> > Renders without crashing 1`] = `
         <label
           for="check-box_1235_ccc"
         >
-          * 
+          <span
+            aria-hidden="true"
+          >
+            * 
+          </span>
           CheckMe
         </label>
       </div>


### PR DESCRIPTION
## This PR

- Applies `aria-hidden` to checkbox asterisk || OTT-898
   - We've opted for this due to several reasons:
        - The asterisk serves as a visual cue for a mandatory field, which we refrain from displaying as optional to maintain consistency.
        - The input includes a required attribute already and already announces "required" on screen readers.
        - Users with good vision can perceive the asterisk.
        - Those with limited or no vision rely on the screen reader, which already reads "required" based on the input field.
