### PR TITLE
Fix / shelf margin and grid loading state

### DIFF
--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -156,10 +156,15 @@ $aspects: ((1, 1), (2, 1), (2, 3), (4, 3), (5, 3), (16, 9), (9, 16), (9, 13));
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);
 
   &.loading {
-    width: 30%;
-    height: 16px;
-    background-color: theme.$card-loading-bg-color;
-    border-radius: 5px;
+    &::before {
+      content: '';
+      position: relative;
+      display: inline-block;
+      width: 45%;
+      height: 1.2em;
+      background-color: theme.$card-loading-bg-color;
+      border-radius: 5px;
+    }
   }
 
   @include responsive.mobile-only {

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -95,7 +95,7 @@ function Card({
     }
   };
 
-  const heading = React.createElement(`h${headingLevel}`, { className: classNames(styles.title, { [styles.loading]: loading }) }, title);
+  const heading = React.createElement(`h${headingLevel}`, { className: classNames(styles.title, { [styles.loading]: loading }) }, loading ? '' : title);
 
   return (
     <Link

--- a/packages/ui-react/src/components/TileDock/TileDock.module.scss
+++ b/packages/ui-react/src/components/TileDock/TileDock.module.scss
@@ -9,6 +9,7 @@
 .tileDock li {
   display: inline-block;
   white-space: normal;
+  vertical-align: top;
   list-style-type: none;
 }
 .notInView {

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.module.scss
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.module.scss
@@ -24,7 +24,7 @@
   }
 
   @include responsive.tablet-only() {
-    padding: 0 calc(#{variables.$base-spacing} * 2);
+    padding: 24px calc(#{variables.$base-spacing} * 2);
 
     &.featured {
       padding: 24px 10%;


### PR DESCRIPTION
## Description

This PR contains ~two~ three small fixes:

- The ShelfList was missing vertical spacing between the shelves on tablets
- The Card component was causing a visual jump when the loading state changes
- The card alignment in the slider on mobile Safari

Fixes OTT-928, OTT-929
