### PR TITLE
Feat / slide chevron buttons hitarea increased 

### DIFF
--- a/packages/ui-react/src/components/Shelf/Shelf.module.scss
+++ b/packages/ui-react/src/components/Shelf/Shelf.module.scss
@@ -29,14 +29,19 @@
 }
 
 .chevron {
-  padding: 12px 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
+  width: 44px;
+  height: 44px;
   outline-color: var(--highlight-color, white);
   cursor: pointer;
   transition: transform 0.3s ease-out, opacity 0.3s ease-out;
 
   > svg {
-    // Use scale because width and height properties causes layout shifting issues on screen readers
-    transform: scale(1.1);
+    width: 30px;
+    height: 30px;
   }
   &.disabled {
     cursor: default;

--- a/packages/ui-react/src/components/TileDock/TileDock.module.scss
+++ b/packages/ui-react/src/components/TileDock/TileDock.module.scss
@@ -19,15 +19,15 @@
 }
 .tileDock .leftControl {
   position: absolute;
-  top: calc(50% + 25px);
-  left: 0;
+  top: calc(50% + 22px);
+  left: 1px;
   z-index: 1;
   transform: translateY(-100%);
 }
 .tileDock .rightControl {
   position: absolute;
-  top: calc(50% + 25px);
-  right: 0;
+  top: calc(50% + 22px);
+  right: 1px;
   z-index: 1;
   transform: translateY(-100%);
 }


### PR DESCRIPTION
This change gives the chevron buttons (left/right) a hitarea of 44x44, so it conforms with https://www.w3.org/WAI/WCAG21/Understanding/target-size.html

This solves: https://videodock.atlassian.net/browse/OTT-803

I reintroduced the original SVG icon size of 30x30, and fixed the screen reader layout shifting issue by applying a `left` and `right` with `1px`. I do not know why this fixes this issue, but I noticed that it does. This 1px gap is not noticeable, because of the transparent background of the button.

When testing/verifying this on a screen reader, make sure the following does not happen anymore: https://videodock.atlassian.net/browse/OTT-863