### PR TITLE
Feat / Player auto focus

### DIFF
--- a/packages/ui-react/src/components/Animation/Grow/Grow.tsx
+++ b/packages/ui-react/src/components/Animation/Grow/Grow.tsx
@@ -9,9 +9,10 @@ type Props = {
   onOpenAnimationEnd?: () => void;
   onCloseAnimationEnd?: () => void;
   children: ReactNode;
+  className?: string;
 };
 
-const Grow = ({ open = true, duration = 250, delay = 0, onOpenAnimationEnd, onCloseAnimationEnd, children }: Props): JSX.Element | null => {
+const Grow = ({ open = true, duration = 250, delay = 0, onOpenAnimationEnd, onCloseAnimationEnd, children, className }: Props): JSX.Element | null => {
   const seconds = duration / 1000;
   const transition = `transform ${seconds}s ease-out`; // todo: -webkit-transform;
   const createStyle = (status: Status): CSSProperties => ({
@@ -27,6 +28,7 @@ const Grow = ({ open = true, duration = 250, delay = 0, onOpenAnimationEnd, onCl
       delay={delay}
       onOpenAnimationEnd={onOpenAnimationEnd}
       onCloseAnimationEnd={onCloseAnimationEnd}
+      className={className}
     >
       {children}
     </Animation>

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -10,12 +10,13 @@ import styles from './Modal.module.scss';
 
 type Props = {
   children?: React.ReactNode;
-  AnimationComponent?: React.JSXElementConstructor<{ open?: boolean; duration?: number; delay?: number; children: React.ReactNode }>;
+  AnimationComponent?: React.JSXElementConstructor<{ open?: boolean; duration?: number; delay?: number; children: React.ReactNode; className?: string }>;
   open: boolean;
   onClose?: () => void;
+  animationContainerClassName?: string;
 } & React.AriaAttributes;
 
-const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, ...ariaAtributes }: Props) => {
+const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, animationContainerClassName, ...ariaAtributes }: Props) => {
   const [visible, setVisible] = useState(open);
   const lastFocus = useRef<HTMLElement>() as React.MutableRefObject<HTMLElement>;
   const modalRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
@@ -81,7 +82,7 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
       <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
         <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
         <div className={styles.container} data-testid={testId('container')} aria-modal="true" {...ariaAtributes}>
-          <AnimationComponent open={open} duration={200}>
+          <AnimationComponent open={open} duration={200} className={animationContainerClassName}>
             {children}
           </AnimationComponent>
         </div>

--- a/packages/ui-react/src/components/Player/Player.tsx
+++ b/packages/ui-react/src/components/Player/Player.tsx
@@ -74,8 +74,10 @@ const Player: React.FC<Props> = ({
   const handleUserInactive = useEventCallback(onUserInActive);
   const handleFirstFrame = useEventCallback(() => {
     // a11y: auto focus to play/pause button
-    const playPauseButton = document.querySelector('.jw-controlbar [aria-label="Play"], .jw-button-container [aria-label="Pause"]') as HTMLDivElement | null;
-
+    const playerContainer = playerRef.current?.getContainer();
+    const playPauseButton = playerContainer?.querySelector(
+      '.jw-controlbar [aria-label="Play"], .jw-button-container [aria-label="Pause"]',
+    ) as HTMLDivElement | null;
     playPauseButton?.focus();
 
     onFirstFrame?.();

--- a/packages/ui-react/src/components/Player/Player.tsx
+++ b/packages/ui-react/src/components/Player/Player.tsx
@@ -72,7 +72,14 @@ const Player: React.FC<Props> = ({
   const handleComplete = useEventCallback(onComplete);
   const handleUserActive = useEventCallback(onUserActive);
   const handleUserInactive = useEventCallback(onUserInActive);
-  const handleFirstFrame = useEventCallback(onFirstFrame);
+  const handleFirstFrame = useEventCallback(() => {
+    // a11y: auto focus to play/pause button
+    const playPauseButton = document.querySelector('.jw-controlbar [aria-label="Play"], .jw-button-container [aria-label="Pause"]') as HTMLDivElement | null;
+
+    playPauseButton?.focus();
+
+    onFirstFrame?.();
+  });
   const handleRemove = useEventCallback(onRemove);
   const handlePlaylistItem = useEventCallback(onPlaylistItem);
   const handlePlaylistItemCallback = useEventCallback(onPlaylistItemCallback);

--- a/packages/ui-react/src/containers/Cinema/Cinema.module.scss
+++ b/packages/ui-react/src/containers/Cinema/Cinema.module.scss
@@ -19,6 +19,7 @@
   position: absolute;
   top: 0;
   left: 0;
+  z-index: 1;
   width: 100%;
   min-height: 100px;
   padding: 24px 56px;

--- a/packages/ui-react/src/containers/Cinema/Cinema.module.scss
+++ b/packages/ui-react/src/containers/Cinema/Cinema.module.scss
@@ -3,9 +3,14 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 @use '@jwp/ott-ui-react/src/styles/mixins/typography';
 
+.cinemaContainer {
+  width: 100%;
+  height: 100%;
+}
+
 .cinema {
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh - calc(100vh - 100%));
   overflow: hidden;
   background-color: variables.$black;
 }

--- a/packages/ui-react/src/containers/Cinema/Cinema.module.scss
+++ b/packages/ui-react/src/containers/Cinema/Cinema.module.scss
@@ -3,18 +3,9 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 @use '@jwp/ott-ui-react/src/styles/mixins/typography';
 
-.fade {
-  position: relative;
-  // make sure the fade animation happens on top of page elements
-  z-index: variables.$player-z-index;
-}
-
 .cinema {
-  position: fixed;
-  top: 0;
-  left: 0;
   width: 100vw;
-  height: calc(100vh - calc(100vh - 100%));
+  height: 100vh;
   overflow: hidden;
   background-color: variables.$black;
 }

--- a/packages/ui-react/src/containers/Cinema/Cinema.test.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.test.tsx
@@ -19,7 +19,7 @@ describe('<Cinema>', () => {
     mockService(WatchHistoryController, {});
   });
 
-  test('renders and matches snapshot', () => {
+  test('renders and matches snapshot', async () => {
     const item = {
       description: 'Test item description',
       duration: 354,
@@ -38,10 +38,19 @@ describe('<Cinema>', () => {
       tracks: [],
     } as PlaylistItem;
 
-    const { container } = renderWithRouter(
-      <Cinema item={item} onPlay={() => null} onPause={() => null} open={true} title={item.title} primaryMetadata="Primary metadata" />,
+    const { baseElement } = renderWithRouter(
+      <Cinema
+        item={item}
+        onPlay={() => null}
+        onPause={() => null}
+        open
+        title={item.title}
+        primaryMetadata="Primary metadata"
+        onClose={vi.fn()}
+        onNext={vi.fn()}
+      />,
     );
 
-    expect(container).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 });

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -79,23 +79,8 @@ const Cinema: React.FC<Props> = ({
   }, [open]);
 
   return (
-    <Modal open={open} animationContainerClassName={styles.cinemaContainer}>
+    <Modal open={open} animationContainerClassName={styles.cinemaContainer} onClose={onClose}>
       <div className={styles.cinema}>
-        <PlayerContainer
-          item={item}
-          seriesItem={seriesItem}
-          feedId={feedId}
-          autostart={true}
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onComplete={handleComplete}
-          onUserActive={handleUserActive}
-          onUserInActive={handleUserInactive}
-          onNext={handleNext}
-          liveEndDateTime={liveEndDateTime}
-          liveFromBeginning={liveFromBeginning}
-          liveStartDateTime={liveStartDateTime}
-        />
         <Fade open={!isPlaying || userActive} keepMounted>
           <div className={styles.playerOverlay}>
             <div className={styles.playerContent}>
@@ -112,6 +97,21 @@ const Cinema: React.FC<Props> = ({
             </div>
           </div>
         </Fade>
+        <PlayerContainer
+          item={item}
+          seriesItem={seriesItem}
+          feedId={feedId}
+          autostart={true}
+          onPlay={handlePlay}
+          onPause={handlePause}
+          onComplete={handleComplete}
+          onUserActive={handleUserActive}
+          onUserInActive={handleUserInactive}
+          onNext={handleNext}
+          liveEndDateTime={liveEndDateTime}
+          liveFromBeginning={liveFromBeginning}
+          liveStartDateTime={liveStartDateTime}
+        />
       </div>
     </Modal>
   );

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -7,6 +7,7 @@ import IconButton from '../../components/IconButton/IconButton';
 import PlayerContainer from '../PlayerContainer/PlayerContainer';
 import Fade from '../../components/Animation/Fade/Fade';
 import Icon from '../../components/Icon/Icon';
+import Modal from '../../components/Modal/Modal';
 
 import styles from './Cinema.module.scss';
 
@@ -85,7 +86,7 @@ const Cinema: React.FC<Props> = ({
   }, [open]);
 
   return (
-    <Fade open={open} className={styles.fade}>
+    <Modal open={open}>
       <div className={styles.cinema}>
         <PlayerContainer
           item={item}
@@ -102,8 +103,7 @@ const Cinema: React.FC<Props> = ({
           liveFromBeginning={liveFromBeginning}
           liveStartDateTime={liveStartDateTime}
         />
-
-        <Fade open={!isPlaying || userActive}>
+        <Fade open={!isPlaying || userActive} keepMounted>
           <div className={styles.playerOverlay}>
             <div className={styles.playerContent}>
               <IconButton aria-label={t('common:back')} onClick={onClose} className={styles.backButton}>
@@ -120,7 +120,7 @@ const Cinema: React.FC<Props> = ({
           </div>
         </Fade>
       </div>
-    </Fade>
+    </Modal>
   );
 };
 

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -79,7 +79,7 @@ const Cinema: React.FC<Props> = ({
   }, [open]);
 
   return (
-    <Modal open={open}>
+    <Modal open={open} animationContainerClassName={styles.cinemaContainer}>
       <div className={styles.cinema}>
         <PlayerContainer
           item={item}

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -75,14 +75,7 @@ const Cinema: React.FC<Props> = ({
 
   // effects
   useEffect(() => {
-    if (open) {
-      setUserActive(true);
-      document.body.style.overflowY = 'hidden';
-    }
-
-    return () => {
-      document.body.style.overflowY = '';
-    };
+    if (open) setUserActive(true);
   }, [open]);
 
   return (

--- a/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
+++ b/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
@@ -1,66 +1,87 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<Cinema> > renders and matches snapshot 1`] = `
-<div>
+<body
+  style="margin-right: 0px; overflow-y: hidden;"
+>
+  <div />
   <div
-    class="_fade_555f3c"
-    style="transition: opacity 0.25s ease-in-out; opacity: 0;"
+    style="transition: opacity 0.3s ease-in-out; opacity: 0;"
   >
     <div
-      class="_cinema_555f3c"
+      class="_modal_6c6c55"
     >
       <div
-        class="_loadingOverlay_eb61cb _inline_eb61cb"
-      >
-        <div
-          class="_buffer_d122df"
-        >
-          <div />
-          <div />
-          <div />
-          <div />
-        </div>
-      </div>
+        class="_backdrop_6c6c55"
+        data-testid="backdrop"
+      />
       <div
-        style="transition: opacity 0.25s ease-in-out; opacity: 0;"
+        aria-modal="true"
+        class="_container_6c6c55"
+        data-testid="container"
       >
         <div
-          class="_playerOverlay_555f3c"
+          class="_cinemaContainer_555f3c"
+          style="transition: transform 0.2s ease-out; transform: scale(0.7);"
         >
           <div
-            class="_playerContent_555f3c"
+            class="_cinema_555f3c"
           >
             <div
-              aria-label="common:back"
-              class="_iconButton_0fef65 _backButton_555f3c"
-              role="button"
-              tabindex="0"
+              style="transition: opacity 0.25s ease-in-out; opacity: 0;"
             >
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
-                />
-              </svg>
-            </div>
-            <div>
-              <h1
-                class="_title_555f3c"
-              >
-                Test item title
-              </h1>
               <div
-                class="_metaContainer_555f3c"
+                class="_playerOverlay_555f3c"
               >
                 <div
-                  class="_primaryMetadata_555f3c"
+                  class="_playerContent_555f3c"
                 >
-                  Primary metadata
+                  <div
+                    aria-label="common:back"
+                    class="_iconButton_0fef65 _backButton_555f3c"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="_icon_585b29"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <h1
+                      class="_title_555f3c"
+                    >
+                      Test item title
+                    </h1>
+                    <div
+                      class="_metaContainer_555f3c"
+                    >
+                      <div
+                        class="_primaryMetadata_555f3c"
+                      >
+                        Primary metadata
+                      </div>
+                    </div>
+                  </div>
                 </div>
+              </div>
+            </div>
+            <div
+              class="_loadingOverlay_eb61cb _inline_eb61cb"
+            >
+              <div
+                class="_buffer_d122df"
+              >
+                <div />
+                <div />
+                <div />
+                <div />
               </div>
             </div>
           </div>
@@ -68,5 +89,5 @@ exports[`<Cinema> > renders and matches snapshot 1`] = `
       </div>
     </div>
   </div>
-</div>
+</body>
 `;

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -38,7 +38,7 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
           onUserInActive={handleUserInactive}
           autostart
         />
-        <Fade open={!isPlaying || userActive}>
+        <Fade open={!isPlaying || userActive} keepMounted>
           <div className={styles.playerOverlay}>
             <h1 id="trailer-modal-title" className={styles.title}>
               {title}


### PR DESCRIPTION
## Player auto focus (a11y)
- When the player opens, we should set its focus to the play/pause button from script, so that screen reader/keyboard users can logically keep navigating to interactive elements. I've done so from the `handleFirstFrame` callback, because from this point the buttons are available. I've used querySelectors, and I've made it more specific to the controlbar. [OTT-483]
- Moved the Cinema to a Modal, so that inert is handled. (With a nice opening Grow animation and a backdrop as a bonus.)
- Made sure the back button is always reachable for screen readers, by making the whole overlay disappear only using `opacity: 0`, instead of `display: none` or `visibility: hidden`. [OTT-830]
- Also Trailer back button remains visible using `opacity: 0`

[OTT-483]: https://videodock.atlassian.net/browse/OTT-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTT-830]: https://videodock.atlassian.net/browse/OTT-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ