### PR TITLE
Fix / roles and aria-attributes regarding modals

### DIFF
--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -19,10 +19,8 @@ const ConfirmationDialog: React.FC<Props> = ({ open, title, body, onConfirm, onC
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose} role="alertdialog" aria-describedby="confirmation-body" aria-labelledby="confirmation-heading">
-      <h2 className={styles.title} id="confirmation-heading">
-        {title}
-      </h2>
+    <Dialog open={open} onClose={onClose} role="alertdialog" aria-describedby="confirmation-body">
+      <h2 className={styles.title}>{title}</h2>
       <p id="confirmation-body" className={styles.body}>
         {body}
       </p>

--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -19,11 +19,9 @@ const ConfirmationDialog: React.FC<Props> = ({ open, title, body, onConfirm, onC
   const { t } = useTranslation('common');
 
   return (
-    <Dialog open={open} onClose={onClose} role="alertdialog" aria-describedby="confirmation-body">
+    <Dialog open={open} onClose={onClose} role="alertdialog">
       <h2 className={styles.title}>{title}</h2>
-      <p id="confirmation-body" className={styles.body}>
-        {body}
-      </p>
+      <p className={styles.body}>{body}</p>
       <Button
         className={styles.confirmButton}
         label={t('confirmation_dialog.confirm')}

--- a/packages/ui-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.test.tsx
@@ -17,4 +17,21 @@ describe('<Dialog>', () => {
 
     expect(baseElement).toMatchSnapshot();
   });
+
+  test('Should ensure Dialog is properly marked as a modal and has role "dialog"', () => {
+    const { getByTestId } = render(
+      <>
+        <span>Some content</span>
+        <Dialog onClose={vi.fn()} open={true} role="dialog" data-testid="dialog">
+          Dialog contents
+        </Dialog>
+        <span>Some other content</span>
+      </>,
+    );
+
+    const dialogElement = getByTestId('dialog');
+
+    expect(dialogElement).toHaveAttribute('aria-modal', 'true');
+    expect(dialogElement).toHaveAttribute('role', 'dialog');
+  });
 });

--- a/packages/ui-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import { testId } from '@jwp/ott-common/src/utils/common';
 
 import Modal from '../Modal/Modal';
 import Slide from '../Animation/Slide/Slide';
@@ -18,7 +19,7 @@ type Props = {
 const Dialog: React.FC<Props> = ({ open, onClose, children, size = 'small', role = 'dialog', ...ariaAttributes }: Props) => {
   return (
     <Modal open={open} onClose={onClose} AnimationComponent={Slide}>
-      <div className={classNames(styles.dialog, styles[size])} role={role} {...ariaAttributes}>
+      <div className={classNames(styles.dialog, styles[size])} aria-modal="true" role={role} data-testid={testId('dialog')} {...ariaAttributes}>
         {children}
         <ModalCloseButton onClick={onClose} />
       </div>

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
           style="transition: transform 0.2s ease, opacity 0.2s ease; transform: translate(0, -15px); opacity: 0; z-index: 15;"
         >
           <div
-            aria-describedby="test-label"
             aria-modal="true"
             class="_dialog_00d559 _small_00d559"
             data-testid="dialog"

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -23,15 +23,16 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
         data-testid="backdrop"
       />
       <div
-        aria-modal="true"
         class="_container_6c6c55"
-        data-testid="container"
       >
         <div
           style="transition: transform 0.2s ease, opacity 0.2s ease; transform: translate(0, -15px); opacity: 0; z-index: 15;"
         >
           <div
+            aria-describedby="test-label"
+            aria-modal="true"
             class="_dialog_00d559 _small_00d559"
+            data-testid="dialog"
             role="dialog"
           >
             Dialog contents

--- a/packages/ui-react/src/components/Modal/Modal.test.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.test.tsx
@@ -31,7 +31,6 @@ describe('<Modal>', () => {
       </div>,
     );
 
-    expect(getByTestId('container')).toHaveAttribute('aria-modal', 'true');
     expect(getByTestId('root')).toHaveProperty('inert', true);
 
     rerender(

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -80,7 +80,7 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
     <Fade open={open} duration={300} onCloseAnimationEnd={() => setVisible(false)}>
       <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
         <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
-        <div className={styles.container} data-testid={testId('container')} aria-modal="true" {...ariaAtributes}>
+        <div className={styles.container} {...ariaAtributes}>
           <AnimationComponent open={open} duration={200}>
             {children}
           </AnimationComponent>

--- a/packages/ui-react/src/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/packages/ui-react/src/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -14,10 +14,8 @@ type Props = {
 const ResetPasswordForm: React.FC<Props> = ({ onCancel, onReset, submitting }: Props) => {
   const { t } = useTranslation('account');
   return (
-    <div className={styles.resetPassword} role="dialog" aria-labelledby="reset_password">
-      <h1 id="reset_password" className={styles.title}>
-        {t('reset.reset_password')}
-      </h1>
+    <div>
+      <h1 className={styles.title}>{t('reset.reset_password')}</h1>
       <p className={styles.text}>{t('reset.text')}</p>
       <Button onClick={onReset} className={styles.button} fullWidth color="primary" label={t('reset.yes')} type="submit" disabled={submitting} />
       <Button onClick={onCancel} fullWidth label={t('reset.no')} />

--- a/packages/ui-react/src/components/ResetPasswordForm/__snapshots__/ResetPasswordForm.test.tsx.snap
+++ b/packages/ui-react/src/components/ResetPasswordForm/__snapshots__/ResetPasswordForm.test.tsx.snap
@@ -2,13 +2,9 @@
 
 exports[`<ResetPassword> > renders and matches snapshot 1`] = `
 <div>
-  <div
-    aria-labelledby="reset_password"
-    role="dialog"
-  >
+  <div>
     <h1
       class="_title_1976d9"
-      id="reset_password"
     >
       reset.reset_password
     </h1>

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -28,7 +28,7 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <div className={styles.container} role="dialog" aria-labelledby="trailer-modal-title">
+      <div className={styles.container} role="dialog" aria-modal="true" aria-labelledby="trailer-modal-title">
         <Player
           item={item}
           onPlay={handlePlay}


### PR DESCRIPTION
## This PR

- Applies the `aria-modal` attribute to the `.dialog` selector to group it together with the `role` attribute.
   - It removes the redundant `aria-describedby` in the ConfirmationDialog component, because this caused the heading to be read out loud twice
   - It does not apply `aria-describedby`, because the heading is read by the screenreader, users can navigate to any extra text describing the modal (such as the Edit Password modal, which has a description)
   - Tested on VoiceOver on macOS: It now currently reads the modal heading out loud and keeps everything else intact
     - The `aria-labelledby` attribute is removed in the ConfirmationDialog (which is actually only used for the 'Clear favorites' button), because this caused the heading to be read twice. 

Solves: OTT-528, OTT-909
