### PR TITLE
Feat / a11y slider

### DIFF
--- a/packages/ui-react/src/components/Shelf/Shelf.tsx
+++ b/packages/ui-react/src/components/Shelf/Shelf.tsx
@@ -99,7 +99,7 @@ const Shelf = ({
         className={styles.chevron}
         role="button"
         tabIndex={0}
-        aria-label={t('slide_right')}
+        aria-label={t('slide_next')}
         onKeyDown={(event: React.KeyboardEvent) => (event.key === 'Enter' || event.key === ' ') && handleSlide(doSlide)}
         onClick={() => handleSlide(doSlide)}
       >
@@ -117,7 +117,7 @@ const Shelf = ({
         })}
         role="button"
         tabIndex={didSlideBefore ? 0 : -1}
-        aria-label={t('slide_left')}
+        aria-label={t('slide_previous')}
         onKeyDown={(event: React.KeyboardEvent) => (event.key === 'Enter' || event.key === ' ') && handleSlide(doSlide)}
         onClick={() => handleSlide(doSlide)}
       >
@@ -129,6 +129,12 @@ const Shelf = ({
 
   const renderPaginationDots = (index: number, pageIndex: number) => (
     <span key={pageIndex} className={classNames(styles.dot, { [styles.active]: index === pageIndex })} />
+  );
+
+  const renderPageIndicator = (pageIndex: number, pages: number) => (
+    <div aria-live="polite" className="hidden">
+      {t('slide_indicator', { page: pageIndex + 1, pages })}
+    </div>
   );
 
   const handleSlide = (doSlide: () => void): void => {
@@ -153,6 +159,7 @@ const Shelf = ({
         renderLeftControl={renderLeftControl}
         renderRightControl={renderRightControl}
         renderPaginationDots={renderPaginationDots}
+        renderPageIndicator={renderPageIndicator}
         renderTile={renderTile}
       />
     </div>

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         class="_leftControl_22abb0"
       >
         <div
-          aria-label="slide_left"
+          aria-label="slide_previous"
           class="_chevron_81910b _disabled_81910b"
           role="button"
           tabindex="-1"
@@ -34,8 +34,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
       >
         <li
           aria-hidden="true"
-          aria-posinset="3"
-          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
         >
@@ -61,8 +59,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
-          aria-posinset="4"
-          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
         >
@@ -88,8 +84,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
-          aria-posinset="1"
-          aria-setsize="4"
           class=""
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
         >
@@ -126,8 +120,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
-          aria-posinset="2"
-          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
         >
@@ -153,8 +145,6 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         </li>
         <li
           aria-hidden="true"
-          aria-posinset="3"
-          aria-setsize="4"
           class="_notInView_22abb0"
           style="width: 100%; padding-left: 4px; padding-right: 4px; box-sizing: border-box; transition: opacity .2s ease-in 0s;"
         >
@@ -183,7 +173,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         class="_rightControl_22abb0"
       >
         <div
-          aria-label="slide_right"
+          aria-label="slide_next"
           class="_chevron_81910b"
           role="button"
           tabindex="0"
@@ -218,6 +208,12 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
         class="_dot_81910b"
       />
     </div>
+    <div
+      aria-live="polite"
+      class="hidden"
+    >
+      slide_indicator
+    </div>
   </div>
 </div>
 `;
@@ -240,8 +236,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
       >
         <li
           aria-hidden="false"
-          aria-posinset="1"
-          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
         >
@@ -282,8 +276,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
-          aria-posinset="2"
-          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
         >
@@ -324,8 +316,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
-          aria-posinset="3"
-          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
         >
@@ -366,8 +356,6 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
         </li>
         <li
           aria-hidden="false"
-          aria-posinset="4"
-          aria-setsize="4"
           class=""
           style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
         >

--- a/packages/ui-react/src/components/TileDock/TileDock.tsx
+++ b/packages/ui-react/src/components/TileDock/TileDock.tsx
@@ -23,6 +23,7 @@ export type TileDockProps<T> = {
   renderLeftControl?: (handleClick: () => void) => ReactNode;
   renderRightControl?: (handleClick: () => void) => ReactNode;
   renderPaginationDots?: (index: number, pageIndex: number) => ReactNode;
+  renderPageIndicator?: (pageIndex: number, pages: number) => ReactNode;
 };
 
 type Tile<T> = {
@@ -74,6 +75,7 @@ function TileDock<T>({
   renderLeftControl,
   renderRightControl,
   renderPaginationDots,
+  renderPageIndicator,
 }: TileDockProps<T>) {
   const [index, setIndex] = useState(0);
   const [slideToIndex, setSlideToIndex] = useState(0);
@@ -254,6 +256,7 @@ function TileDock<T>({
           {wrapWithEmptyTiles ? (
             <li
               className={styles.emptyTile}
+              aria-hidden="true"
               style={{
                 width: `${tileWidth}%`,
                 paddingLeft: spacing / 2,
@@ -263,14 +266,11 @@ function TileDock<T>({
             />
           ) : null}
           {tileList.map((tile: Tile<T>, listIndex) => {
-            const posInSet = items.findIndex((item) => item === tile.item); // TODO optimize this for performances
             const isInView = !isMultiPage || (listIndex > tilesToShow - slideOffset && listIndex < tilesToShow * 2 + 1 - slideOffset);
 
             return (
               <li
                 key={tile.key}
-                aria-setsize={items.length}
-                aria-posinset={posInSet + 1}
                 aria-hidden={!isInView}
                 className={classNames({ [styles.notInView]: !isInView })}
                 style={{
@@ -288,6 +288,7 @@ function TileDock<T>({
           {wrapWithEmptyTiles ? (
             <li
               className={styles.emptyTile}
+              aria-hidden="true"
               style={{
                 width: `${tileWidth}%`,
                 paddingLeft: spacing / 2,
@@ -300,6 +301,7 @@ function TileDock<T>({
         {showRightControl && !!renderRightControl && <div className={styles.rightControl}>{renderRightControl(() => slide('right'))}</div>}
       </div>
       {paginationDots()}
+      {isMultiPage && renderPageIndicator && renderPageIndicator(Math.ceil(index / tilesToShow), Math.ceil(pages))}
     </React.Fragment>
   );
 }

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -34,8 +34,6 @@ exports[`Home Component tests > Home test 1`] = `
             >
               <li
                 aria-hidden="false"
-                aria-posinset="1"
-                aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
               >
@@ -76,8 +74,6 @@ exports[`Home Component tests > Home test 1`] = `
               </li>
               <li
                 aria-hidden="false"
-                aria-posinset="2"
-                aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
               >
@@ -141,8 +137,6 @@ exports[`Home Component tests > Home test 1`] = `
             >
               <li
                 aria-hidden="false"
-                aria-posinset="1"
-                aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
               >
@@ -183,8 +177,6 @@ exports[`Home Component tests > Home test 1`] = `
               </li>
               <li
                 aria-hidden="false"
-                aria-posinset="2"
-                aria-setsize="2"
                 class=""
                 style="width: 20%; padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
               >

--- a/platforms/web/public/locales/en/common.json
+++ b/platforms/web/public/locales/en/common.json
@@ -24,6 +24,9 @@
   "series": "series",
   "sign_in": "Sign in",
   "sign_up": "Sign up",
+  "slide_indicator": "Page {{page}} of {{pages}}",
   "slide_left": "Slide left",
+  "slide_next": "Next slide",
+  "slide_previous": "Previous slide",
   "slide_right": "Slide right"
 }

--- a/platforms/web/public/locales/es/common.json
+++ b/platforms/web/public/locales/es/common.json
@@ -24,6 +24,9 @@
   "series": "serie",
   "sign_in": "Iniciar sesión",
   "sign_up": "Registrarse",
+  "slide_indicator": "Página {{page}} de {{pages}}",
   "slide_left": "Deslizar hacia la izquierda",
+  "slide_next": "Siguiente diapositiva",
+  "slide_previous": "Diapositiva anterior",
   "slide_right": "Deslizar hacia la derecha"
 }

--- a/platforms/web/test-e2e/tests/home_test.ts
+++ b/platforms/web/test-e2e/tests/home_test.ts
@@ -44,7 +44,7 @@ Scenario('I can slide within the featured shelf', async ({ I }) => {
 
   async function slide(swipeText: string) {
     if (isDesktop) {
-      I.click({ css: 'div[aria-label="Slide right"]' });
+      I.click({ css: 'div[aria-label="Next slide"]' });
     } else {
       await I.swipeLeft({ text: swipeText });
     }
@@ -79,7 +79,7 @@ Scenario('I can slide within non-featured shelves', async ({ I }) => {
 
   async function slideRight(swipeText) {
     if (isDesktop) {
-      I.click({ css: 'div[aria-label="Slide right"]' }, makeShelfXpath(ShelfId.allFilms));
+      I.click({ css: 'div[aria-label="Next slide"]' }, makeShelfXpath(ShelfId.allFilms));
     } else {
       await I.swipeLeft({ text: swipeText });
     }
@@ -87,7 +87,7 @@ Scenario('I can slide within non-featured shelves', async ({ I }) => {
 
   async function slideLeft(swipeText) {
     if (isDesktop) {
-      I.click({ css: 'div[aria-label="Slide left"]' }, makeShelfXpath(ShelfId.allFilms));
+      I.click({ css: 'div[aria-label="Previous slide"]' }, makeShelfXpath(ShelfId.allFilms));
     } else {
       await I.swipeRight({ text: swipeText });
     }

--- a/platforms/web/test-e2e/utils/steps_file.ts
+++ b/platforms/web/test-e2e/utils/steps_file.ts
@@ -512,7 +512,7 @@ const stepsObj = {
           direction: scrollToTheRight ? 'left' : 'right',
         });
       } else {
-        this.click({ css: `div[aria-label="Slide ${scrollToTheRight ? 'right' : 'left'}"]` }, shelfLocator);
+        this.click({ css: `div[aria-label="${scrollToTheRight ? 'Next slide' : 'Previous slide'}"]` }, shelfLocator);
       }
 
       this.wait(1);


### PR DESCRIPTION
Originally when I optimised the slider, I tried to make it smart such as:
- Automatically setting the focus to the card when using the chevron buttons
- Making the screen reader pronounce the amount of (invisible) slides and the current index

But based on my PR feedback and articles that I read, I learned that I should not make it too "smart" and more reflect the current state of the UI. Letting the screen reader pronounce "item 1 from 15" and reaching a chevron button around item 4, could maybe make it a bit weird for some users.

These are the changes I applied:
1. Pronounce the current state of the carrousel as pages. It gets read when you use the chevron buttons
2. Remove `aria-posinset` and `aria-setsize` so the current state of the list is reflected/pronounced. Now the screen reader just pronounces the slides as "item x of y". Where y is the amount of visible items (inside the view). The browser will ignore the list-items with `aria-hidden="true"`
3. Left /right as a label is maybe to ambiguous, so I translated it to Next/Previous. Left/right is still used for the EPG for a different purpose.
4. applied `aria-hidden="true"` to the empty tiles

I also experimented with `aria-live="polite"` applied to the shelf container. This is alright when there is only 1 item in the view, but when there are more they all will get read, making it a not so pleasant experience.

I tested it on MacOS, Android and iOS.

Ticket: https://videodock.atlassian.net/browse/OTT-797
e2e fix: https://videodock.atlassian.net/browse/OTT-912

Also fixes: https://videodock.atlassian.net/browse/OTT-791
