### PR TITLE
Fix / paypal await payment

### DIFF
--- a/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
+++ b/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
@@ -6,11 +6,13 @@ import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 
 import Spinner from '../Spinner/Spinner';
 import { useAriaAnnouncer } from '../../containers/AnnouncementProvider/AnnoucementProvider';
+import useQueryParam from '../../hooks/useQueryParam';
 
 import styles from './WaitingForPayment.module.scss';
 
 const WaitingForPayment = () => {
   const { t } = useTranslation('account');
+  const offerId = useQueryParam('offerId') || undefined;
   const location = useLocation();
   const navigate = useNavigate();
   const announce = useAriaAnnouncer();
@@ -20,6 +22,7 @@ const WaitingForPayment = () => {
     intervalCheckAccess({
       interval: 3000,
       iterations: 5,
+      offerId,
       callback: (hasAccess) => {
         if (!hasAccess) return;
 

--- a/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
@@ -102,10 +102,9 @@ const Checkout = () => {
   }
 
   const cancelUrl = createURL(window.location.href, { u: 'payment-cancelled' });
-  const waitingUrl = createURL(window.location.href, { u: 'waiting-for-payment' });
+  const waitingUrl = createURL(window.location.href, { u: 'waiting-for-payment', offerId: selectedOffer?.offerId });
   const errorUrl = createURL(window.location.href, { u: 'payment-error' });
-  const successUrl = offerType === 'svod' ? welcomeUrl : closeModalUrl;
-  const successUrlWithOrigin = `${window.location.origin}${successUrl}`;
+  const successUrlPaypal = offerType === 'svod' ? waitingUrl : closeModalUrl;
   const referrer = window.location.href;
 
   const paymentMethod = paymentMethods?.find((method) => method.id === parseInt(paymentMethodId));
@@ -154,7 +153,7 @@ const Checkout = () => {
       )}
       {isPayPalPayment && (
         <PayPal
-          onSubmit={() => submitPaymentPaypal.mutate({ successUrl: successUrlWithOrigin, waitingUrl, cancelUrl, errorUrl, couponCode })}
+          onSubmit={() => submitPaymentPaypal.mutate({ successUrl: successUrlPaypal, waitingUrl, cancelUrl, errorUrl, couponCode })}
           error={submitPaymentPaypal.error?.message || null}
         />
       )}


### PR DESCRIPTION
## Paypal await payment
Mike [found out](https://github.com/Videodock/ott-web-app/pull/93#pullrequestreview-1889934128) that the UI doesn't update after a paypal payment: on the payment screen, the button still says "Complete your subscription".  @langemike
- I figured that for paypal payments we can navigate to the waiting-for-payment modal, just like for adyen/stripe payments, and (repeatedly) check access for the offer.
- Implementing this, I found a bug there too: it always assumes that we should check access for the first offer, but that's of course not always the case (see `useCheckAccess()` L26). I fixed this by adding the offerId to the query params.
- Despite these 2 fixes, sometimes still the UI doesn't update, due to a 3rd bug: Cleeng gives us `accessGranted=true`, but the `/subscriptions` call after that still returns an empty array. Perhaps this Cleeng bug (api delay) only occurs in the sandbox env. For now I want to leave this as is. This PR still fixes 1 hard bug and 1 fix for most cases.