### PR TITLE
Feat / Sidebar accessibility improvements

### DIFF
--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -30,6 +30,7 @@
   width: 270px;
   max-width: 90vw;
   height: 100vh;
+  overflow-y: auto;
   background-color: var(--body-background-color);
   transform: translateX(-100%);
   transition: transform 0.3s cubic-bezier(0.52, 0.51, 0.2, 1);
@@ -45,7 +46,6 @@
   flex-direction: column;
   max-height: 100%;
   padding: variables.$base-spacing 0;
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -21,13 +21,39 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
 
   useEffect(() => {
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
     if (isOpen) {
       lastFocusedElementRef.current = document.activeElement as HTMLElement;
       sidebarRef.current?.querySelectorAll('a')[0]?.focus({ preventScroll: true });
+
+      // When opened, adjust the margin-right to accommodate for the scrollbar width to prevent UI shifts in background
+      document.body.style.marginRight = `${scrollbarWidth}px`;
+      document.body.style.overflowY = 'hidden';
+
+      // Scroll the sidebar to the top if the user has previously scrolled down in the sidebar
+      if (sidebarRef.current) {
+        sidebarRef.current.scrollTop = 0;
+      }
     } else {
       lastFocusedElementRef.current?.focus({ preventScroll: true });
+      document.body.style.removeProperty('margin-right');
+      document.body.style.removeProperty('overflow-y');
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (isOpen && event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleEscKey);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onClose]);
 
   return (
     <Fragment>

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import Close from '@jwp/ott-theme/assets/icons/close.svg?react';
 
 import IconButton from '../IconButton/IconButton';
 import Icon from '../Icon/Icon';
+import scrollbarSize from '../../utils/dom';
 
 import styles from './Sidebar.module.scss';
 
@@ -18,17 +19,16 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const { t } = useTranslation('menu');
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
+
   const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
 
   useEffect(() => {
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-
     if (isOpen) {
       lastFocusedElementRef.current = document.activeElement as HTMLElement;
       sidebarRef.current?.querySelectorAll('a')[0]?.focus({ preventScroll: true });
 
       // When opened, adjust the margin-right to accommodate for the scrollbar width to prevent UI shifts in background
-      document.body.style.marginRight = `${scrollbarWidth}px`;
+      document.body.style.marginRight = `${scrollbarSize()}px`;
       document.body.style.overflowY = 'hidden';
 
       // Scroll the sidebar to the top if the user has previously scrolled down in the sidebar

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -142,7 +142,6 @@
   position: absolute;
   top: 0;
   right: -15px;
-  // right: 0;
 
   z-index: -1;
 

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -141,7 +141,8 @@
 .poster {
   position: absolute;
   top: 0;
-  right: 0;
+  right: -15px;
+  // right: 0;
 
   z-index: -1;
 
@@ -172,6 +173,7 @@
 .posterFade {
   position: absolute;
   top: 0;
+  right: -15px;
   left: 0;
   z-index: -1;
   width: 100%;

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -2,6 +2,7 @@
 @use '@jwp/ott-ui-react/src/styles/theme';
 
 .layout {
+  position: relative;
   display: flex;
   flex-grow: 1;
   flex-direction: column;


### PR DESCRIPTION
## This PR

- Ensures that while the sidebar is open, the background or the rest of the app's body remains unscrollable. || **OTT-905**
  - During testing, the `margin-right` adjustment positively affects every page. However, on the detail page, a slight UI shift occurs due to the media item poster moving to the right when the scrollbar is removed. I attempted to address this issue, also looking at Symphony for potential solutions, but the differing HTML structure posed challenges. If anyone has insights into resolving this issue, please share. Otherwise, I propose noting it as a known issue. This issue has existed in the app for years and is for example already noticeable when opening the trailer modal or the player, but it isn't really prominent there so nobody noticed

- Makes sure all menu items are reachable by moving the `overflow-y` property to the `.sidebar` selector || **OTT-906**
  - This was necessary because the `overflow-y: auto` solution on the `.group` div wasn't sufficient due to:
    - It often displayed the scrollbar too late on certain viewports, making the buttons inaccessible
    - With these changes, the entire sidebar is now scrollable, which does cause the 'X' button to also scroll away. However, users now have three ways to close the sidebar: Clicking outside the menu, using the ESC key or just scroll up
    
- Adds the feature to close the sidebar with the ESC key || **OTT-907**