### PR TITLE
Chore / fix react warning

### DIFF
--- a/packages/ui-react/src/components/VideoMetaData/VideoMetaData.tsx
+++ b/packages/ui-react/src/components/VideoMetaData/VideoMetaData.tsx
@@ -11,14 +11,14 @@ const VideoMetaData: React.FC<Props> = ({ attributes, separator = '•' }: Props
   return (
     <>
       {attributes.map((value, index) => (
-        <>
-          <span key={index}>{value}</span>
+        <React.Fragment key={value}>
+          <span>{value}</span>
           {index < attributes.length - 1 && (
             <span className={styles.separator} aria-hidden="true">
               {separator}
             </span>
           )}
-        </>
+        </React.Fragment>
       ))}
     </>
   );


### PR DESCRIPTION
## Description

I got the following React warning caused by a missing `key` prop:

> VideoMetaData.tsx?t=1708457925479:20 Warning: Each child in a list should have a unique "key" prop.
>
> Check the render method of `VideoMetaData`. See https://reactjs.org/link/warning-keys for more information.
>    at VideoMetaData (http://localhost:8080/@fs/../packages/ui-react/src/components/VideoMetaData/VideoMetaData.tsx?t=1708457925479:19:26)

The `key` was added to the wrong element 😄