### PR TITLE
Fix / a11y optimize footer for accessibility

### DIFF
--- a/packages/ui-react/src/components/Footer/Footer.module.scss
+++ b/packages/ui-react/src/components/Footer/Footer.module.scss
@@ -1,0 +1,37 @@
+@use '@jwp/ott-ui-react/src/styles/variables';
+
+.footer {
+  padding: 20px 40px;
+  line-height: variables.$base-line-height;
+  letter-spacing: 0.15px;
+  text-align: center;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);
+
+  a,
+  a:visited,
+  a:active,
+  a:hover {
+    color: variables.$white;
+    text-decoration: none;
+  }
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: inline-block;
+    padding: 0 4px;
+
+    &:not(:last-child)::after {
+      content: '|';
+      padding-left: 2px;
+    }
+  }
+}
+
+.testFixMargin {
+  margin-bottom: 50px;
+}

--- a/packages/ui-react/src/components/Footer/Footer.module.scss
+++ b/packages/ui-react/src/components/Footer/Footer.module.scss
@@ -23,11 +23,10 @@
 
   li {
     display: inline-block;
-    padding: 0 4px;
+    padding: 0 3px;
 
     &:not(:last-child)::after {
-      content: '|';
-      padding-left: 2px;
+      content: ' | ';
     }
   }
 }

--- a/packages/ui-react/src/components/Footer/Footer.test.tsx
+++ b/packages/ui-react/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Footer from './Footer';
+
+describe('<Footer>', () => {
+  test('renders and matches snapshot', () => {
+    const { container } = render(<Footer text="Simple" />);
+
+    expect(container).toMatchSnapshot();
+  });
+  test('renders and matches snapshot without links', () => {
+    const { container } = render(<Footer text="Text one | Text two" />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders and matches snapshot with two links', () => {
+    const { container } = render(<Footer text="Two links | [jwplayer.com](https://www.jwplayer.com/) | [jwplayer.com](https://www.jwplayer.com/)" />);
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/ui-react/src/components/Footer/Footer.tsx
+++ b/packages/ui-react/src/components/Footer/Footer.tsx
@@ -11,23 +11,13 @@ type Props = {
 };
 
 const Footer: React.FC<Props> = ({ text }) => {
-  const chunks = text.split('|');
+  const chunks = text.split('|').map((chuck) => chuck.trim());
+  const footerContent = chunks.map((value, index) => <MarkdownComponent key={index} markdownString={value} inline tag={chunks.length > 1 ? 'li' : 'div'} />);
+  const wrapper = chunks.length > 1 ? <ul className={styles.list}>{footerContent}</ul> : footerContent;
 
   return (
     // The extra style below is just to fix the footer on mobile when the dev selector is shown
-    <footer className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}>
-      {(() => {
-        const footerContent = chunks.map((value, index) => (
-          <MarkdownComponent key={index} markdownString={value} inline tag={chunks.length > 1 ? 'li' : 'div'} />
-        ));
-
-        if (chunks.length > 1) {
-          return <ul className={styles.list}>{footerContent}</ul>;
-        } else {
-          return footerContent;
-        }
-      })()}
-    </footer>
+    <footer className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}>{wrapper}</footer>
   );
 };
 

--- a/packages/ui-react/src/components/Footer/Footer.tsx
+++ b/packages/ui-react/src/components/Footer/Footer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import classNames from 'classnames';
+import { IS_DEVELOPMENT_BUILD } from '@jwp/ott-common/src/utils/common';
+
+import MarkdownComponent from '../MarkdownComponent/MarkdownComponent';
+
+import styles from './Footer.module.scss';
+
+const MARKDOWN_LINK_REGEX = /\[([^[]+)]\(((https?:\/\/|www\.)?[^)]+)\)/gi;
+
+type Props = {
+  text: string;
+};
+
+const Footer: React.FC<Props> = ({ text }) => {
+  const linkMatches = text.match(MARKDOWN_LINK_REGEX)?.length || 0;
+  const chunks = text.split('|');
+
+  return (
+    // The extra style below is just to fix the footer on mobile when the dev selector is shown
+    <footer className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}>
+      {(() => {
+        const footerContent = chunks.map((value, index) => (
+          <MarkdownComponent key={index} markdownString={value} inline tag={chunks.length > 1 ? 'li' : 'div'} />
+        ));
+
+        if (linkMatches > 0) {
+          return <nav>{chunks.length > 1 ? <ul className={styles.list}>{footerContent}</ul> : footerContent}</nav>;
+        } else if (chunks.length > 1) {
+          return <ul className={styles.list}>{footerContent}</ul>;
+        } else {
+          return footerContent;
+        }
+      })()}
+    </footer>
+  );
+};
+
+export default Footer;

--- a/packages/ui-react/src/components/Footer/Footer.tsx
+++ b/packages/ui-react/src/components/Footer/Footer.tsx
@@ -6,14 +6,11 @@ import MarkdownComponent from '../MarkdownComponent/MarkdownComponent';
 
 import styles from './Footer.module.scss';
 
-const MARKDOWN_LINK_REGEX = /\[([^[]+)]\(((https?:\/\/|www\.)?[^)]+)\)/gi;
-
 type Props = {
   text: string;
 };
 
 const Footer: React.FC<Props> = ({ text }) => {
-  const linkMatches = text.match(MARKDOWN_LINK_REGEX)?.length || 0;
   const chunks = text.split('|');
 
   return (
@@ -24,9 +21,7 @@ const Footer: React.FC<Props> = ({ text }) => {
           <MarkdownComponent key={index} markdownString={value} inline tag={chunks.length > 1 ? 'li' : 'div'} />
         ));
 
-        if (linkMatches > 0) {
-          return <nav>{chunks.length > 1 ? <ul className={styles.list}>{footerContent}</ul> : footerContent}</nav>;
-        } else if (chunks.length > 1) {
+        if (chunks.length > 1) {
           return <ul className={styles.list}>{footerContent}</ul>;
         } else {
           return footerContent;

--- a/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -25,12 +25,11 @@ exports[`<Footer> > renders and matches snapshot with two links 1`] = `
       <li
         class="_markdown_e219e2"
       >
-        Two links 
+        Two links
       </li>
       <li
         class="_markdown_e219e2"
       >
-         
         <a
           href="https://www.jwplayer.com/"
           rel="noopener"
@@ -38,12 +37,10 @@ exports[`<Footer> > renders and matches snapshot with two links 1`] = `
         >
           jwplayer.com
         </a>
-         
       </li>
       <li
         class="_markdown_e219e2"
       >
-         
         <a
           href="https://www.jwplayer.com/"
           rel="noopener"
@@ -68,12 +65,12 @@ exports[`<Footer> > renders and matches snapshot without links 1`] = `
       <li
         class="_markdown_e219e2"
       >
-        Text one 
+        Text one
       </li>
       <li
         class="_markdown_e219e2"
       >
-         Text two
+        Text two
       </li>
     </ul>
   </footer>

--- a/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -19,42 +19,40 @@ exports[`<Footer> > renders and matches snapshot with two links 1`] = `
   <footer
     class="_footer_33bf66 _testFixMargin_33bf66"
   >
-    <nav>
-      <ul
-        class="_list_33bf66"
+    <ul
+      class="_list_33bf66"
+    >
+      <li
+        class="_markdown_e219e2"
       >
-        <li
-          class="_markdown_e219e2"
+        Two links 
+      </li>
+      <li
+        class="_markdown_e219e2"
+      >
+         
+        <a
+          href="https://www.jwplayer.com/"
+          rel="noopener"
+          target="_blank"
         >
-          Two links 
-        </li>
-        <li
-          class="_markdown_e219e2"
+          jwplayer.com
+        </a>
+         
+      </li>
+      <li
+        class="_markdown_e219e2"
+      >
+         
+        <a
+          href="https://www.jwplayer.com/"
+          rel="noopener"
+          target="_blank"
         >
-           
-          <a
-            href="https://www.jwplayer.com/"
-            rel="noopener"
-            target="_blank"
-          >
-            jwplayer.com
-          </a>
-           
-        </li>
-        <li
-          class="_markdown_e219e2"
-        >
-           
-          <a
-            href="https://www.jwplayer.com/"
-            rel="noopener"
-            target="_blank"
-          >
-            jwplayer.com
-          </a>
-        </li>
-      </ul>
-    </nav>
+          jwplayer.com
+        </a>
+      </li>
+    </ul>
   </footer>
 </div>
 `;

--- a/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ui-react/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<Footer> > renders and matches snapshot 1`] = `
+<div>
+  <footer
+    class="_footer_33bf66 _testFixMargin_33bf66"
+  >
+    <div
+      class="_markdown_e219e2"
+    >
+      Simple
+    </div>
+  </footer>
+</div>
+`;
+
+exports[`<Footer> > renders and matches snapshot with two links 1`] = `
+<div>
+  <footer
+    class="_footer_33bf66 _testFixMargin_33bf66"
+  >
+    <nav>
+      <ul
+        class="_list_33bf66"
+      >
+        <li
+          class="_markdown_e219e2"
+        >
+          Two links 
+        </li>
+        <li
+          class="_markdown_e219e2"
+        >
+           
+          <a
+            href="https://www.jwplayer.com/"
+            rel="noopener"
+            target="_blank"
+          >
+            jwplayer.com
+          </a>
+           
+        </li>
+        <li
+          class="_markdown_e219e2"
+        >
+           
+          <a
+            href="https://www.jwplayer.com/"
+            rel="noopener"
+            target="_blank"
+          >
+            jwplayer.com
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </footer>
+</div>
+`;
+
+exports[`<Footer> > renders and matches snapshot without links 1`] = `
+<div>
+  <footer
+    class="_footer_33bf66 _testFixMargin_33bf66"
+  >
+    <ul
+      class="_list_33bf66"
+    >
+      <li
+        class="_markdown_e219e2"
+      >
+        Text one 
+      </li>
+      <li
+        class="_markdown_e219e2"
+      >
+         Text two
+      </li>
+    </ul>
+  </footer>
+</div>
+`;

--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -11,26 +11,6 @@
   flex: 1;
 }
 
-.footer {
-  padding: 20px 40px;
-  line-height: variables.$base-line-height;
-  letter-spacing: 0.15px;
-  text-align: center;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);
-
-  a,
-  a:visited,
-  a:active,
-  a:hover {
-    color: variables.$white;
-    text-decoration: none;
-  }
-}
-
-div.testFixMargin {
-  margin-bottom: 50px;
-}
-
 .buttonContainer {
   display: flex;
   flex-direction: column;

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
-import classNames from 'classnames';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import { useUIStore } from '@jwp/ott-common/src/stores/UIStore';
@@ -11,7 +10,7 @@ import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { useProfileStore } from '@jwp/ott-common/src/stores/ProfileStore';
 import ProfileController from '@jwp/ott-common/src/controllers/ProfileController';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
-import { IS_DEVELOPMENT_BUILD, unicodeToChar } from '@jwp/ott-common/src/utils/common';
+import { unicodeToChar } from '@jwp/ott-common/src/utils/common';
 import { ACCESS_MODEL } from '@jwp/ott-common/src/constants';
 import useSearchQueryUpdater from '@jwp/ott-ui-react/src/hooks/useSearchQueryUpdater';
 import { useProfiles, useSelectProfile } from '@jwp/ott-hooks-react/src/useProfiles';
@@ -20,12 +19,12 @@ import { PATH_HOME, PATH_USER_PROFILES } from '@jwp/ott-common/src/paths';
 import { playlistURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import env from '@jwp/ott-common/src/env';
 
-import MarkdownComponent from '../../components/MarkdownComponent/MarkdownComponent';
 import Header from '../../components/Header/Header';
 import Sidebar from '../../components/Sidebar/Sidebar';
 import MenuButton from '../../components/MenuButton/MenuButton';
 import UserMenu from '../../components/UserMenu/UserMenu';
 import Button from '../../components/Button/Button';
+import Footer from '../../components/Footer/Footer';
 
 import styles from './Layout.module.scss';
 
@@ -203,15 +202,7 @@ const Layout = () => {
         <main id="content" className={styles.main} tabIndex={-1}>
           <Outlet />
         </main>
-        {!!footerText && (
-          <MarkdownComponent
-            // The extra style below is just to fix the footer on mobile when the dev selector is shown
-            className={classNames(styles.footer, { [styles.testFixMargin]: IS_DEVELOPMENT_BUILD })}
-            markdownString={footerText}
-            tag="footer"
-            inline
-          />
-        )}
+        {!!footerText && <Footer text={footerText} />}
       </div>
       <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
         <ul>


### PR DESCRIPTION
Optimizes the footer when it contains links and/or multiple pipe characters.

When it has more than 2 items (based on pipe-character) it will convert it to a list.

I finally decided to remove a wrapping `<nav>` within the footer, because the links are not part of significant part of the site's navigation. 

Ticket: https://videodock.atlassian.net/browse/OTT-700
~e2e test~ / Became a snapshot test: https://videodock.atlassian.net/browse/OTT-927