### PR TITLE
Fix / Sidebar menu overflow

### DIFF
--- a/packages/ui-react/src/pages/User/User.module.scss
+++ b/packages/ui-react/src/pages/User/User.module.scss
@@ -38,7 +38,8 @@
 }
 
 .button span {
-  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .logoutLi {


### PR DESCRIPTION
Replaces break-word with an ellipsis. The ellipsis will  only show on really lengthy buttons. Only for the sidebar on the Account pages.

Applied to the span, because it would not work on the above (block) element because:
> The text-overflow property only affects content that is overflowing a block container element in its inline progression direction (not text overflowing at the bottom of a box, for example).

Previously:
![Screenshot 2024-02-22 at 13 37 24](https://github.com/Videodock/ott-web-app/assets/1019129/9de38513-7864-4d7c-bf0c-57147b4b805f)

With ellipsis (same as this fix):
![Screenshot 2024-02-22 at 13 38 08](https://github.com/Videodock/ott-web-app/assets/1019129/574a5194-a7ab-4648-9eba-e6e3acc3926c)

Or without  ellipsis (an alternative - LMKWYT):
![Screenshot 2024-02-22 at 13 37 42](https://github.com/Videodock/ott-web-app/assets/1019129/d19b408e-1889-4249-96d2-f1bd49f68277)


Fixes: https://videodock.atlassian.net/browse/OTT-865