### PR TITLE
Fix / prevent keyboard from persisting in searchbar on submit

### DIFF
--- a/packages/ui-react/src/components/ErrorPage/ErrorPage.tsx
+++ b/packages/ui-react/src/components/ErrorPage/ErrorPage.tsx
@@ -32,11 +32,12 @@ const ErrorPage = ({ title, message, learnMoreLabel, ...rest }: Props) => {
 
 export const ErrorPageWithoutTranslation = ({ title, children, message, learnMoreLabel, error, helpLink }: Props) => {
   const logo = useConfigStore((s) => s.config?.assets?.banner);
+  const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
     <div className={styles.errorPage}>
       <div className={styles.box}>
-        <img className={styles.image} src={logo || '/images/logo.png'} alt={'Logo'} />
+        <img className={styles.image} src={logo || '/images/logo.png'} alt={alt} />
         <h1 className={styles.title}>{title || 'An error occurred'}</h1>
         <div className={styles.main}>
           <p className={styles.message}>{message || 'Try refreshing this page or come back later.'}</p>

--- a/packages/ui-react/src/components/ErrorPage/__snapshots__/ErrorPage.test.tsx.snap
+++ b/packages/ui-react/src/components/ErrorPage/__snapshots__/ErrorPage.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<ErrorPage> > renders and matches snapshot 1`] = `
       class="_box_8c5621"
     >
       <img
-        alt="Logo"
+        alt=""
         class="_image_8c5621"
         src="/images/logo.png"
       />

--- a/packages/ui-react/src/components/SearchBar/SearchBar.module.scss
+++ b/packages/ui-react/src/components/SearchBar/SearchBar.module.scss
@@ -3,7 +3,10 @@
 
 .searchBar {
   position: relative;
-  height: variables.$search-height;
+}
+
+.searchForm {
+    height: variables.$search-height;
 }
 
 .icon {
@@ -47,7 +50,6 @@
 
 .clearButton {
   position: absolute;
-  top: -2px;
   right: 0;
 
   > svg {

--- a/packages/ui-react/src/components/SearchBar/SearchBar.tsx
+++ b/packages/ui-react/src/components/SearchBar/SearchBar.tsx
@@ -20,20 +20,24 @@ const SearchBar: React.FC<Props> = ({ query, onQueryChange, onClearButtonClick, 
   const { t } = useTranslation('search');
   const handleSubmit = (event: React.ChangeEvent<HTMLFormElement>) => {
     event.preventDefault();
-    inputRef?.current?.blur();
+    inputRef?.current.focus(); // Force hide mobile keyboard
+    (document.querySelector('#content') as HTMLElement)?.focus();
   };
 
   return (
     <div className={styles.searchBar}>
       <Icon icon={Search} className={styles.icon} />
       <form className={styles.searchForm} role="search" onSubmit={handleSubmit}>
+        <label htmlFor="searchbar-input" className="hidden">
+          {t('search_bar.search_label')}
+        </label>
         <input
           className={styles.input}
+          id="searchbar-input"
           type="search"
           value={query}
           onChange={onQueryChange}
           onKeyDown={(event) => event.key === 'Escape' && onClose?.()}
-          aria-label={t('search_bar.search_label')}
           placeholder={t('search_bar.search_placeholder')}
           ref={inputRef}
         />

--- a/packages/ui-react/src/components/SearchBar/SearchBar.tsx
+++ b/packages/ui-react/src/components/SearchBar/SearchBar.tsx
@@ -18,25 +18,31 @@ export type Props = {
 
 const SearchBar: React.FC<Props> = ({ query, onQueryChange, onClearButtonClick, onClose, inputRef }: Props) => {
   const { t } = useTranslation('search');
+  const handleSubmit = (event: React.ChangeEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    inputRef?.current?.blur();
+  };
 
   return (
     <div className={styles.searchBar}>
       <Icon icon={Search} className={styles.icon} />
-      <input
-        className={styles.input}
-        type="search"
-        value={query}
-        onChange={onQueryChange}
-        onKeyDown={(event) => event.key === 'Escape' && onClose?.()}
-        aria-label={t('search_bar.search_label')}
-        placeholder={t('search_bar.search_placeholder')}
-        ref={inputRef}
-      />
-      {query ? (
-        <IconButton className={styles.clearButton} aria-label={t('search_bar.clear_search_label')} onClick={onClearButtonClick}>
-          <Icon icon={Cancel} />
-        </IconButton>
-      ) : null}
+      <form className={styles.searchForm} role="search" onSubmit={handleSubmit}>
+        <input
+          className={styles.input}
+          type="search"
+          value={query}
+          onChange={onQueryChange}
+          onKeyDown={(event) => event.key === 'Escape' && onClose?.()}
+          aria-label={t('search_bar.search_label')}
+          placeholder={t('search_bar.search_placeholder')}
+          ref={inputRef}
+        />
+        {query ? (
+          <IconButton className={styles.clearButton} aria-label={t('search_bar.clear_search_label')} onClick={onClearButtonClick}>
+            <Icon icon={Cancel} />
+          </IconButton>
+        ) : null}
+      </form>
     </div>
   );
 };

--- a/packages/ui-react/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/packages/ui-react/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -15,30 +15,35 @@ exports[`<SearchBar> > renders and matches snapshot 1`] = `
         d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
       />
     </svg>
-    <input
-      aria-label="search_bar.search_label"
-      class="_input_3bb1d7"
-      placeholder="search_bar.search_placeholder"
-      type="search"
-      value="My search query"
-    />
-    <div
-      aria-label="search_bar.clear_search_label"
-      class="_iconButton_0fef65 _clearButton_3bb1d7"
-      role="button"
-      tabindex="0"
+    <form
+      class="_searchForm_3bb1d7"
+      role="search"
     >
-      <svg
-        aria-hidden="true"
-        class="_icon_585b29"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <input
+        aria-label="search_bar.search_label"
+        class="_input_3bb1d7"
+        placeholder="search_bar.search_placeholder"
+        type="search"
+        value="My search query"
+      />
+      <div
+        aria-label="search_bar.clear_search_label"
+        class="_iconButton_0fef65 _clearButton_3bb1d7"
+        role="button"
+        tabindex="0"
       >
-        <path
-          d="M9 1C4.58 1 1 4.58 1 9s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4 10.87L11.87 13 9 10.13 6.13 13 5 11.87 7.87 9 5 6.13 6.13 5 9 7.87 11.87 5 13 6.13 10.13 9 13 11.87z"
-        />
-      </svg>
-    </div>
+        <svg
+          aria-hidden="true"
+          class="_icon_585b29"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9 1C4.58 1 1 4.58 1 9s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm4 10.87L11.87 13 9 10.13 6.13 13 5 11.87 7.87 9 5 6.13 6.13 5 9 7.87 11.87 5 13 6.13 10.13 9 13 11.87z"
+          />
+        </svg>
+      </div>
+    </form>
   </div>
 </div>
 `;

--- a/packages/ui-react/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/packages/ui-react/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -19,9 +19,15 @@ exports[`<SearchBar> > renders and matches snapshot 1`] = `
       class="_searchForm_3bb1d7"
       role="search"
     >
+      <label
+        class="hidden"
+        for="searchbar-input"
+      >
+        search_bar.search_label
+      </label>
       <input
-        aria-label="search_bar.search_label"
         class="_input_3bb1d7"
+        id="searchbar-input"
         placeholder="search_bar.search_placeholder"
         type="search"
         value="My search query"

--- a/packages/ui-react/src/pages/Search/Search.tsx
+++ b/packages/ui-react/src/pages/Search/Search.tsx
@@ -11,6 +11,7 @@ import { mediaURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import useFirstRender from '@jwp/ott-hooks-react/src/useFirstRender';
 import useSearchQueryUpdater from '@jwp/ott-ui-react/src/hooks/useSearchQueryUpdater';
 import usePlaylist from '@jwp/ott-hooks-react/src/usePlaylist';
+import useOpaqueId from '@jwp/ott-hooks-react/src/useOpaqueId';
 
 import CardGrid from '../../components/CardGrid/CardGrid';
 import ErrorPage from '../../components/ErrorPage/ErrorPage';
@@ -21,6 +22,7 @@ const Search = () => {
   const { t } = useTranslation('search');
   const { config, accessModel } = useConfigStore(({ config, accessModel }) => ({ config, accessModel }), shallow);
   const { siteName, features } = config;
+  const headingId = useOpaqueId('search_heading');
 
   const firstRender = useFirstRender();
   const searchQuery = useUIStore((state) => state.searchQuery);
@@ -88,9 +90,17 @@ const Search = () => {
         </title>
       </Helmet>
       <header className={styles.header}>
-        <h2>{t('heading')}</h2>
+        <h2 id={headingId}>{t('heading')}</h2>
       </header>
-      <CardGrid getUrl={getURL} playlist={playlist} isLoading={firstRender} accessModel={accessModel} isLoggedIn={!!user} hasSubscription={!!subscription} />
+      <CardGrid
+        aria-labelledby={headingId}
+        getUrl={getURL}
+        playlist={playlist}
+        isLoading={firstRender}
+        accessModel={accessModel}
+        isLoggedIn={!!user}
+        hasSubscription={!!subscription}
+      />
     </div>
   );
 };

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -410,9 +410,7 @@ exports[`User Component tests > Favorites Page 1`] = `
           <div
             aria-rowcount="1"
             class="_container_7175d1 _cols-3_7175d1"
-            id="layout_grid"
             role="grid"
-            tabindex="-1"
           >
             <div
               aria-rowindex="0"

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -410,7 +410,9 @@ exports[`User Component tests > Favorites Page 1`] = `
           <div
             aria-rowcount="1"
             class="_container_7175d1 _cols-3_7175d1"
+            id="layout_grid"
             role="grid"
+            tabindex="-1"
           >
             <div
               aria-rowindex="0"

--- a/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
+++ b/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<DemoConfigDialog> > renders and matches snapshot error dialog 1`] = `
         class="_box_d73633"
       >
         <img
-          alt="Logo"
+          alt=""
           class="_image_d73633"
           src="/images/logo.png"
         />

--- a/platforms/web/test-e2e/tests/search_test.ts
+++ b/platforms/web/test-e2e/tests/search_test.ts
@@ -5,7 +5,7 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 import constants from '#utils/constants';
 
 const openSearchLocator = { css: 'div[aria-label="Open search"]' };
-const searchBarLocator = { css: 'input[aria-label="Search"]' };
+const searchBarLocator = 'input[type="search"]';
 const emptySearchPrompt = 'Type something in the search box to start searching';
 const clearSearchLocator = { css: 'div[aria-label="Clear search"]' };
 const closeSearchLocator = { css: 'div[aria-label="Close search"]' };


### PR DESCRIPTION
## This PR

- Fixes the issue on mobile where the keyboard persisted after submitting a query in the search bar **|| OTT-833**

   - In the previous `SearchBar.tsx` format, I encountered difficulties accessing the 'Enter' or 'Search' event key on the keyboard, which prevented me from implementing the desired functionality of listening for these events and then triggering the `blur` action to hide the keyboard.
        - **Extra info**: Android’s search key does not always trigger standard key events in the way other keys do, especially in web applications. For this reason, relying solely on key events for the search key can be problematic
   - Implemented a `<form>` element around the search bar, this is semantically correct and makes the `onSubmit` prop available
    - **Bonus fix**: Removed the `top: -2px` to align the clear button correctly with the input field and 'Close' button (tested on desktop and mobile)

**Demo of pressing the 'Search' keyboard button**

https://github.com/Videodock/ott-web-app/assets/48496458/d41203d8-0386-4764-9f3e-ed55c0176482

