### PR TITLE
Fix / improve screenreader focus on start watching button

### DIFF
--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -94,12 +94,7 @@ const LegacySeries = () => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-
-    // Delay focusing on 'Start watching' button until scrolling completes,
-    // ensuring proper focus on screenreaders
-    setTimeout(() => {
-      (document.querySelector('#video-details button') as HTMLElement)?.focus();
-    }, 100);
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {
@@ -138,6 +133,7 @@ const LegacySeries = () => {
   const shareButton = <ShareButton title={selectedItem?.title} description={pageDescription} url={canonicalUrl} />;
   const startWatchingButton = (
     <StartWatchingButton
+      key={episodeId}
       item={episode || firstEpisode}
       playUrl={legacySeriesURL({ episodeId: episode?.mediaid || firstEpisode?.mediaid, seriesId, play: true, playlistId: feedId })}
     />

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -94,7 +94,12 @@ const LegacySeries = () => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
+
+    // Delay focusing on 'Start watching' button until scrolling completes,
+    // ensuring proper focus on screenreaders
+    setTimeout(() => {
+      (document.querySelector('#video-details button') as HTMLElement)?.focus();
+    }, 100);
   }, [episode]);
 
   useEffect(() => {

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -133,7 +133,7 @@ const LegacySeries = () => {
   const shareButton = <ShareButton title={selectedItem?.title} description={pageDescription} url={canonicalUrl} />;
   const startWatchingButton = (
     <StartWatchingButton
-      key={episodeId}
+      key={episodeId} // necessary to fix autofocus on TalkBack
       item={episode || firstEpisode}
       playUrl={legacySeriesURL({ episodeId: episode?.mediaid || firstEpisode?.mediaid, seriesId, play: true, playlistId: feedId })}
     />

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -100,7 +100,12 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
 
   const shareButton = <ShareButton title={media.title} description={media.description} url={canonicalUrl} />;
   const startWatchingButton = (
-    <StartWatchingButton key={id} item={media} playUrl={mediaURL({ media, playlistId, play: true })} disabled={!liveEvent.isPlayable} />
+    <StartWatchingButton
+      key={id} // necessary to fix autofocus on TalkBack
+      item={media}
+      playUrl={mediaURL({ media, playlistId, play: true })}
+      disabled={!liveEvent.isPlayable}
+    />
   );
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={media} />;

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -84,7 +84,12 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
+
+    // Delay focusing on 'Start watching' button until scrolling completes,
+    // ensuring proper focus on screenreaders
+    setTimeout(() => {
+      (document.querySelector('#video-details button') as HTMLElement)?.focus();
+    }, 100);
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -84,12 +84,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-
-    // Delay focusing on 'Start watching' button until scrolling completes,
-    // ensuring proper focus on screenreaders
-    setTimeout(() => {
-      (document.querySelector('#video-details button') as HTMLElement)?.focus();
-    }, 100);
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI
@@ -104,7 +99,9 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   );
 
   const shareButton = <ShareButton title={media.title} description={media.description} url={canonicalUrl} />;
-  const startWatchingButton = <StartWatchingButton item={media} playUrl={mediaURL({ media, playlistId, play: true })} disabled={!liveEvent.isPlayable} />;
+  const startWatchingButton = (
+    <StartWatchingButton key={id} item={media} playUrl={mediaURL({ media, playlistId, play: true })} disabled={!liveEvent.isPlayable} />
+  );
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={media} />;
   const trailerButton = (!!trailerItem || isTrailerLoading) && (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -19,12 +19,7 @@ const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-
-    // Delay focusing on 'Start watching' button until scrolling completes,
-    // ensuring proper focus on screenreaders
-    setTimeout(() => {
-      (document.querySelector('#video-details button') as HTMLElement)?.focus();
-    }, 100);
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [data]);
 
   return (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -19,7 +19,12 @@ const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
+
+    // Delay focusing on 'Start watching' button until scrolling completes,
+    // ensuring proper focus on screenreaders
+    setTimeout(() => {
+      (document.querySelector('#video-details button') as HTMLElement)?.focus();
+    }, 100);
   }, [data]);
 
   return (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -73,12 +73,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-
-    // Delay focusing on 'Start watching' button until scrolling completes,
-    // ensuring proper focus on screenreaders
-    setTimeout(() => {
-      (document.querySelector('#video-details button') as HTMLElement)?.focus();
-    }, 100);
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI
@@ -87,7 +82,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   const primaryMetadata = <VideoMetaData attributes={createVideoMetadata(data)} />;
   const shareButton = <ShareButton title={data.title} description={data.description} url={canonicalUrl} />;
-  const startWatchingButton = <StartWatchingButton item={data} playUrl={mediaURL({ media: data, playlistId: feedId, play: true })} />;
+  const startWatchingButton = <StartWatchingButton key={id} item={data} playUrl={mediaURL({ media: data, playlistId: feedId, play: true })} />;
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={data} />;
   const trailerButton = (!!trailerItem || isTrailerLoading) && (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -82,7 +82,13 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   const primaryMetadata = <VideoMetaData attributes={createVideoMetadata(data)} />;
   const shareButton = <ShareButton title={data.title} description={data.description} url={canonicalUrl} />;
-  const startWatchingButton = <StartWatchingButton key={id} item={data} playUrl={mediaURL({ media: data, playlistId: feedId, play: true })} />;
+  const startWatchingButton = (
+    <StartWatchingButton
+      key={id} // necessary to fix autofocus on TalkBack
+      item={data}
+      playUrl={mediaURL({ media: data, playlistId: feedId, play: true })}
+    />
+  );
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={data} />;
   const trailerButton = (!!trailerItem || isTrailerLoading) && (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -71,10 +71,14 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
     return nextItem && navigate(mediaURL({ media: nextItem, playlistId: features?.recommendationsPlaylist, play: true }));
   }, [id, playlist, navigate, features?.recommendationsPlaylist]);
 
-  // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
+
+    // Delay focusing on 'Start watching' button until scrolling completes,
+    // ensuring proper focus on screenreaders
+    setTimeout(() => {
+      (document.querySelector('#video-details button') as HTMLElement)?.focus();
+    }, 100);
   }, [id]);
 
   // UI

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -136,7 +136,12 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
+
+    // Delay focusing on 'Start watching' button until scrolling completes,
+    // ensuring proper focus on screenreaders
+    setTimeout(() => {
+      (document.querySelector('#video-details button') as HTMLElement)?.focus();
+    }, 100);
   }, [episode]);
 
   useEffect(() => {

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -165,7 +165,7 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   const startWatchingButton = useMemo(
     () => (
       <StartWatchingButton
-        key={episodeId}
+        key={episodeId} // necessary to fix autofocus on TalkBack
         item={episode || firstEpisode}
         onClick={() => {
           setSearchParams({ ...searchParams, e: (episode || firstEpisode).mediaid, r: feedId || '', play: '1' }, { replace: true });

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -136,12 +136,7 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-
-    // Delay focusing on 'Start watching' button until scrolling completes,
-    // ensuring proper focus on screenreaders
-    setTimeout(() => {
-      (document.querySelector('#video-details button') as HTMLElement)?.focus();
-    }, 100);
+    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {
@@ -170,13 +165,14 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   const startWatchingButton = useMemo(
     () => (
       <StartWatchingButton
+        key={episodeId}
         item={episode || firstEpisode}
         onClick={() => {
           setSearchParams({ ...searchParams, e: (episode || firstEpisode).mediaid, r: feedId || '', play: '1' }, { replace: true });
         }}
       />
     ),
-    [episode, firstEpisode, feedId, searchParams, setSearchParams],
+    [episodeId, episode, firstEpisode, setSearchParams, searchParams, feedId],
   );
 
   // UI


### PR DESCRIPTION
## This PR

- Ensures the "Start watching" button is always focused on screenreader when switching between video detail pages **|| OTT-914**

   - The issue is still not completely understood within the team, but this solution by setting a `key` prop on the StartWatching component, helps React preserve the component across renders. We now trigger React to unmount the previous instance and mount a new one whenever the 'id or 'episodeId' changes. Because React now handles the remounting process, we can more likely ensure that the button receives focus immediately after the page is loaded
   - Tested on Android TalkBack