### PR TITLE
Fix / videoplayer focus (iOS) & restoration

### DIFF
--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -49,17 +49,6 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
       // prevent scrolling under the modal
       document.body.style.marginRight = `${scrollbarSize()}px`;
       document.body.style.overflowY = 'hidden';
-
-      // focus the first element in the modal, after a short delay to allow the modal to be rendered
-      setTimeout(() => {
-        if (modalRef.current) {
-          const interactiveElement = modalRef.current.querySelectorAll(
-            'div[role="dialog"] input, div[role="dialog"] a, div[role="dialog"] button, div[role="dialog"] [tabindex]',
-          )[0] as HTMLElement | null;
-
-          if (interactiveElement) interactiveElement.focus();
-        }
-      }, 10);
     } else {
       if (appView) {
         appView.inert = false;
@@ -67,13 +56,26 @@ const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = 
 
       document.body.style.removeProperty('margin-right');
       document.body.style.removeProperty('overflow-y');
+    }
+  }, [open]);
 
+  useEffect(() => {
+    if (visible) {
+      // focus the first element in the modal
+      if (modalRef.current) {
+        const interactiveElement = modalRef.current.querySelectorAll(
+          'div[role="dialog"] input, div[role="dialog"] a, div[role="dialog"] button, div[role="dialog"] [tabindex]',
+        )[0] as HTMLElement | null;
+
+        if (interactiveElement) interactiveElement.focus();
+      }
+    } else {
       // restore last focussed element
       if (lastFocus.current) {
         lastFocus.current.focus();
       }
     }
-  }, [open]);
+  }, [visible]);
 
   if (!open && !visible) return null;
 

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -80,7 +80,7 @@ const Cinema: React.FC<Props> = ({
 
   return (
     <Modal open={open} animationContainerClassName={styles.cinemaContainer} onClose={onClose}>
-      <div className={styles.cinema}>
+      <div className={styles.cinema} aria-modal="true" role="dialog" aria-label={t('videoplayer')}>
         <Fade open={!isPlaying || userActive} keepMounted>
           <div className={styles.playerOverlay}>
             <div className={styles.playerContent}>

--- a/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
+++ b/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
@@ -23,7 +23,10 @@ exports[`<Cinema> > renders and matches snapshot 1`] = `
           style="transition: transform 0.2s ease-out; transform: scale(0.7);"
         >
           <div
+            aria-label="videoplayer"
+            aria-modal="true"
             class="_cinema_555f3c"
+            role="dialog"
           >
             <div
               style="transition: opacity 0.25s ease-in-out; opacity: 0;"

--- a/platforms/web/public/locales/en/common.json
+++ b/platforms/web/public/locales/en/common.json
@@ -28,5 +28,6 @@
   "slide_left": "Slide left",
   "slide_next": "Next slide",
   "slide_previous": "Previous slide",
-  "slide_right": "Slide right"
+  "slide_right": "Slide right",
+  "videoplayer": "Videoplayer"
 }

--- a/platforms/web/public/locales/en/common.json
+++ b/platforms/web/public/locales/en/common.json
@@ -29,5 +29,5 @@
   "slide_next": "Next slide",
   "slide_previous": "Previous slide",
   "slide_right": "Slide right",
-  "videoplayer": "Videoplayer"
+  "videoplayer": "Video player"
 }

--- a/platforms/web/public/locales/es/common.json
+++ b/platforms/web/public/locales/es/common.json
@@ -28,5 +28,6 @@
   "slide_left": "Deslizar hacia la izquierda",
   "slide_next": "Siguiente diapositiva",
   "slide_previous": "Diapositiva anterior",
-  "slide_right": "Deslizar hacia la derecha"
+  "slide_right": "Deslizar hacia la derecha",
+  "videoplayer": "Reproductor de video"
 }


### PR DESCRIPTION
Adding `aria-modal="true"` and `role="dialog"` to the cinema component fixed the focus issues ). It was one of the first things I tried and it was successful.

With this change you are able to control the video player completely with the iOS screen reader. It still behaves a little bit weird on Android screenreader, though. This is something I already [previously noted](https://github.com/Videodock/ott-web-app/pull/124#issuecomment-1956415915). This needs further research.

I also noticed that on iOS the focus would not get restored to the last element (start watching button), but will be somewhere at the bottom of the page. This took a bit longer to understand and to solve.

I realised it was because of the open/close CSS animation. So I moved the focus code (initial and restoration) so a separate `useEffect` based on the `visible` state. Now we don't need to add a timeout anymore!

I tested and verified it on iOS and Android.

Opinionated: Also I added a `aria-label="Videoplayer"` to the modal. I think it is good to give the user some idea about what he/she is seeing/controlling. Especially because it behaves a little bit undesirably.  Using `aria-labeledby` and pointing to the cinema `h1` is an alternative, but I reasoned that the `h1` is the second element in the component (after the close button) already speaks for itself. Let me know what you think.

Demo video:

https://github.com/Videodock/ott-web-app/assets/1019129/98fcb936-08fd-407c-867d-8e7e34d865ba

As you can hear it is quite annoying that the video progression is read because of JW has implemented `aria-live="assertive"` as can be seen below. This should be discussed with JW sometime (but this is not the only a11y issue with the player).
![Screenshot 2024-02-23 at 10 46 39](https://github.com/Videodock/ott-web-app/assets/1019129/084350c8-19ba-4a61-833c-218be11c958c)


