### PR TITLE
Fix / active state of language menu and apply aria-current

### DIFF
--- a/packages/ui-react/src/components/LanguageMenu/LanguageMenu.module.scss
+++ b/packages/ui-react/src/components/LanguageMenu/LanguageMenu.module.scss
@@ -27,6 +27,8 @@
 }
 
 .menuItemActive {
+  background: rgba(variables.$white, 0.08);
+
   > a {
     font-weight: bold;
   }

--- a/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
@@ -55,7 +55,7 @@ const LanguageMenu = ({ onClick, className, languages, currentLanguage, language
       >
         <Icon icon={Language} />
       </IconButton>
-      <Popover isOpen={true} onClose={closeLanguageMenu} aria-expanded={languageMenuOpen}>
+      <Popover isOpen={languageMenuOpen} onClose={closeLanguageMenu} aria-expanded={languageMenuOpen}>
         <Panel id="language-panel">
           <ul className={styles.menuItems}>
             {languages.map(({ code, displayName }) => {

--- a/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
@@ -25,7 +25,6 @@ type Props = {
 
 const LanguageMenu = ({ onClick, className, languages, currentLanguage, languageMenuOpen, closeLanguageMenu, openLanguageMenu }: Props) => {
   const { t } = useTranslation('menu');
-  const ariaAttributes: React.AriaAttributes = {};
 
   const handleLanguageSelect = (event: MouseEvent<HTMLElement>, code: string) => {
     event.preventDefault();
@@ -56,17 +55,15 @@ const LanguageMenu = ({ onClick, className, languages, currentLanguage, language
       >
         <Icon icon={Language} />
       </IconButton>
-      <Popover isOpen={languageMenuOpen} onClose={closeLanguageMenu} aria-expanded={languageMenuOpen}>
+      <Popover isOpen={true} onClose={closeLanguageMenu} aria-expanded={languageMenuOpen}>
         <Panel id="language-panel">
           <ul className={styles.menuItems}>
             {languages.map(({ code, displayName }) => {
-              const menuItemClassname = classNames(styles.menuItem, { [styles.menuItemActive]: currentLanguage?.code === code });
-              if (currentLanguage?.code === code) {
-                ariaAttributes['aria-current'] = 'true';
-              }
+              const isActive = currentLanguage?.code === code;
+              const menuItemClassname = classNames(styles.menuItem, { [styles.menuItemActive]: isActive });
               return (
                 <li key={code} className={menuItemClassname} onClick={(event) => handleLanguageSelect(event, code)}>
-                  <Link onFocus={openLanguageMenu} onBlur={closeLanguageMenu} href="#" {...ariaAttributes}>
+                  <Link onFocus={openLanguageMenu} onBlur={closeLanguageMenu} href="#" aria-current={isActive}>
                     {displayName}
                   </Link>
                 </li>

--- a/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/packages/ui-react/src/components/LanguageMenu/LanguageMenu.tsx
@@ -25,6 +25,7 @@ type Props = {
 
 const LanguageMenu = ({ onClick, className, languages, currentLanguage, languageMenuOpen, closeLanguageMenu, openLanguageMenu }: Props) => {
   const { t } = useTranslation('menu');
+  const ariaAttributes: React.AriaAttributes = {};
 
   const handleLanguageSelect = (event: MouseEvent<HTMLElement>, code: string) => {
     event.preventDefault();
@@ -60,10 +61,12 @@ const LanguageMenu = ({ onClick, className, languages, currentLanguage, language
           <ul className={styles.menuItems}>
             {languages.map(({ code, displayName }) => {
               const menuItemClassname = classNames(styles.menuItem, { [styles.menuItemActive]: currentLanguage?.code === code });
-
+              if (currentLanguage?.code === code) {
+                ariaAttributes['aria-current'] = 'true';
+              }
               return (
                 <li key={code} className={menuItemClassname} onClick={(event) => handleLanguageSelect(event, code)}>
-                  <Link onFocus={openLanguageMenu} onBlur={closeLanguageMenu} href="#">
+                  <Link onFocus={openLanguageMenu} onBlur={closeLanguageMenu} href="#" {...ariaAttributes}>
                     {displayName}
                   </Link>
                 </li>

--- a/packages/ui-react/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/packages/ui-react/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -24,5 +24,44 @@ exports[`<LanguageMenu> > renders and matches snapshot 1`] = `
       />
     </svg>
   </div>
+  <div
+    style="transition: transform 0.25s ease, opacity 0.25s ease; transform: translate(15px, 0); opacity: 0; z-index: 15; position: relative;"
+  >
+    <div
+      class="_popover_9be12f"
+    >
+      <div
+        class="_panel_505028"
+        id="language-panel"
+      >
+        <ul
+          class="_menuItems_0acc33"
+        >
+          <li
+            class="_menuItem_0acc33 _menuItemActive_0acc33"
+          >
+            <a
+              aria-current="true"
+              class="_link_a14c64"
+              href="#"
+            >
+              English
+            </a>
+          </li>
+          <li
+            class="_menuItem_0acc33"
+          >
+            <a
+              aria-current="false"
+              class="_link_a14c64"
+              href="#"
+            >
+              español
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/ui-react/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/packages/ui-react/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -24,44 +24,5 @@ exports[`<LanguageMenu> > renders and matches snapshot 1`] = `
       />
     </svg>
   </div>
-  <div
-    style="transition: transform 0.25s ease, opacity 0.25s ease; transform: translate(15px, 0); opacity: 0; z-index: 15; position: relative;"
-  >
-    <div
-      class="_popover_9be12f"
-    >
-      <div
-        class="_panel_505028"
-        id="language-panel"
-      >
-        <ul
-          class="_menuItems_0acc33"
-        >
-          <li
-            class="_menuItem_0acc33 _menuItemActive_0acc33"
-          >
-            <a
-              aria-current="true"
-              class="_link_a14c64"
-              href="#"
-            >
-              English
-            </a>
-          </li>
-          <li
-            class="_menuItem_0acc33"
-          >
-            <a
-              aria-current="false"
-              class="_link_a14c64"
-              href="#"
-            >
-              español
-            </a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </div>
 `;


### PR DESCRIPTION
## This PR

- Adds a background color to the active button in the language menu, similar to the Sidebar, solves: OTT-843
- In this process, Mike suggested adding the `aria-current` attribute to the active element
   - `aria-current` can be used used to denote the current state within a set of related elements, which fits the scenario of indicating the currently selected language in the language menu