### PR TITLE
Fix / a11y EPG using `aria-owns` and `role="listitem"` (POC)

### DIFF
--- a/packages/ui-react/src/components/Epg/Epg.tsx
+++ b/packages/ui-react/src/components/Epg/Epg.tsx
@@ -50,10 +50,17 @@ export default function Epg({ channels, selectedChannel, onChannelClick, onProgr
   const catchupHoursDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.catchupHours])), [channels]);
   const titlesDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.title])), [channels]);
 
+  const onNowClick = () => {
+    onScrollToNow();
+    if (program) {
+      document.getElementById(`program-${program.id}`)?.focus();
+    }
+  };
+
   return (
     <div className={styles.epg}>
       <div className={styles.timelineControl}>
-        <Button className={styles.timelineNowButton} variant="contained" label={t('now')} color="primary" onClick={onScrollToNow} size="small" />
+        <Button className={styles.timelineNowButton} variant="contained" label={t('now')} color="primary" onClick={onNowClick} size="small" />
         <IconButton className={styles.leftControl} aria-label={t('slide_left')} onClick={() => onScrollLeft()}>
           <Icon icon={ChevronLeft} />
         </IconButton>

--- a/packages/ui-react/src/components/Epg/Epg.tsx
+++ b/packages/ui-react/src/components/Epg/Epg.tsx
@@ -72,20 +72,25 @@ export default function Epg({ channels, selectedChannel, onChannelClick, onProgr
         <Layout
           {...getLayoutProps()}
           renderTimeline={(props) => <EpgTimeline {...props} />}
-          renderChannel={({ channel: epgChannel }) => (
-            <EpgChannelItem
-              key={epgChannel.uuid}
-              channel={epgChannel}
-              channelItemWidth={channelItemWidth}
-              sidebarWidth={sidebarWidth}
-              onClick={(toChannel) => {
-                onChannelClick(toChannel.uuid);
-                onScrollToNow();
-              }}
-              title={titlesDict[epgChannel.uuid] || ''}
-              isActive={selectedChannel?.id === epgChannel.uuid}
-            />
-          )}
+          renderChannel={({ channel: epgChannel }) => {
+            const currentChannel = channels.find((c) => c.id === epgChannel.uuid);
+            const owns = currentChannel?.programs.map((program) => `program-${program.id}`).join(' '); // Doesn't take virtualization in to account
+            return (
+              <EpgChannelItem
+                key={epgChannel.uuid}
+                channel={epgChannel}
+                channelItemWidth={channelItemWidth}
+                sidebarWidth={sidebarWidth}
+                onClick={(toChannel) => {
+                  onChannelClick(toChannel.uuid);
+                  onScrollToNow();
+                }}
+                title={titlesDict[epgChannel.uuid] || ''}
+                isActive={selectedChannel?.id === epgChannel.uuid}
+                aria-owns={owns}
+              />
+            );
+          }}
           renderProgram={({ program: programItem, isBaseTimeFormat }) => {
             const catchupHours = catchupHoursDict[programItem.data.channelUuid];
             const disabled = isBefore(new Date(programItem.data.since), subHours(new Date(), catchupHours));

--- a/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
+++ b/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
@@ -28,6 +28,7 @@ const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWi
         onClick={() => onClick && onClick(channel)}
         data-testid={testId(uuid)}
         role="button"
+        tabIndex={0}
       >
         <Image className={styles.epgChannelLogo} image={channelLogoImage} alt={title} width={320} />
       </div>

--- a/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
+++ b/packages/ui-react/src/components/EpgChannel/EpgChannelItem.tsx
@@ -16,12 +16,12 @@ type Props = {
   title: string;
 };
 
-const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWidth, onClick, isActive, title }) => {
+const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWidth, onClick, isActive, title, ...rest }) => {
   const { position, uuid, channelLogoImage } = channel;
   const style = { top: position.top, height: position.height, width: sidebarWidth };
 
   return (
-    <div className={styles.epgChannelBox} style={style}>
+    <div className={styles.epgChannelBox} style={style} role="list" id={`channel-${channel.uuid}`} {...rest}>
       <div
         className={classNames(styles.epgChannel, { [styles.active]: isActive })}
         style={{ width: channelItemWidth }}

--- a/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
+++ b/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
@@ -29,7 +29,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
 
   const { t } = useTranslation('common');
   const { data } = program;
-  const { image, title, since, till } = data;
+  const { id, image, title, since, till } = data;
 
   const sinceTime = formatTime(since, set12HoursTimeFormat()).toLowerCase();
   const tillTime = formatTime(till, set12HoursTimeFormat()).toLowerCase();
@@ -39,7 +39,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
-    <div className={styles.epgProgramBox} style={position} onClick={() => onClick && onClick(program)}>
+    <div className={styles.epgProgramBox} style={position}>
       <div
         className={classNames(styles.epgProgram, {
           [styles.selected]: isActive,
@@ -48,6 +48,10 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
         })}
         style={{ width: styles.width }}
         data-testid={testId(program.data.id)}
+        onClick={() => onClick && onClick(program)}
+        role="button"
+        tabIndex={0}
+        id={`program-${id}`}
       >
         {showImage && <img className={styles.epgProgramImage} src={image} alt={alt} />}
         {showLiveTagInImage && <div className={styles.epgLiveTag}>{t('live')}</div>}

--- a/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
+++ b/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.tsx
@@ -15,7 +15,7 @@ type Props = {
   isBaseTimeFormat: boolean;
 };
 
-const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, disabled, isBaseTimeFormat }) => {
+const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, disabled, isBaseTimeFormat, ...rest }) => {
   const {
     styles: { position },
     formatTime,
@@ -39,7 +39,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
-    <div className={styles.epgProgramBox} style={position}>
+    <div className={styles.epgProgramBox} style={position} role="listitem" id={`program-${id}`}>
       <div
         className={classNames(styles.epgProgram, {
           [styles.selected]: isActive,
@@ -51,7 +51,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
         onClick={() => onClick && onClick(program)}
         role="button"
         tabIndex={0}
-        id={`program-${id}`}
+        {...rest}
       >
         {showImage && <img className={styles.epgProgramImage} src={image} alt={alt} />}
         {showLiveTagInImage && <div className={styles.epgLiveTag}>{t('live')}</div>}

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -106,6 +106,10 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
 
     // scroll to top when clicking a program
     (document.scrollingElement || document.body).scroll({ top: 0, behavior: 'smooth' });
+
+    // focus first interactive element
+    const focusableElement = document.querySelector('#content button') as HTMLElement | null;
+    focusableElement?.focus();
   };
 
   const handleChannelClick = (channelId: string) => {


### PR DESCRIPTION
Based of old PR: #114

I tried experimenting with rewriting the channels to a `list` role and programs to `listitem` role and making parent/child relationships with `aria-owns`.

## role="list" and role="listitem"
This makes the screenreader pronounce the correct of list items. Only at this moment I realised that everything that is out of the view it not rendered (virtualized). You could argue it corresponds with how we optimised the shelfs, namely: only announce the current state of the UI. Though it only works correctly on Android. These list/listitems roles get ignored on iOS.

## aria-owns
While working on this I found out that this attribute is [not supported on voiceover](https://a11ysupport.io/tech/aria/aria-owns_attribute) (macOS + iOS), so this solution is also not viable.

I also think the solution is not really elegant. I originally thought the implementation was a bit different, that aria-owns will be on child (program) pointing to the parent (channel), but how it actually works (the other way around) I consider it quite an ugly solution.

_I also found out there is no other solutions for changing relationships between elements while maintaining the same DOM hierarchy_

## focus state
The are also some issues with having the currently focussed item (proram) inside the view.  Happens on iOS only.

## Summary
Unfortunately a lot of different behaviour in Android and iOS which - in my eyes - are difficult to solve. I consider having the relationships and semantics (list items) between channel and programs and subsequently as a must to be accessible or pass an audit.


Ticket : [OTT-478](https://videodock.atlassian.net/browse/OTT-478) (part 1) and [OTT-977](https://videodock.atlassian.net/browse/OTT-977) (part 2)

[OTT-478]: https://videodock.atlassian.net/browse/OTT-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ