### PR TITLE
Rework / sprint 3 rs

### DIFF
--- a/packages/hooks-react/src/useCheckAccess.ts
+++ b/packages/hooks-react/src/useCheckAccess.ts
@@ -31,7 +31,7 @@ const useCheckAccess = () => {
         const hasAccess = await accountController.checkEntitlements(offerId);
 
         if (hasAccess) {
-          await accountController.reloadSubscriptions();
+          await accountController.reloadSubscriptions({ delay: 2000 }); // Delay needed for backend processing (Cleeng API returns empty subscription, even after accessGranted from entitlements call
           callback?.(true);
         } else if (--iterations === 0) {
           window.clearInterval(intervalRef.current);

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -122,7 +122,7 @@ function Card({
             {featured && !disabled && heading}
             <div className={styles.tags}>
               {isLocked && (
-                <div className={classNames(styles.tag, styles.lock)} aria-label={t('card_lock')}>
+                <div className={classNames(styles.tag, styles.lock)} aria-label={t('card_lock')} role="img">
                   <Icon icon={Lock} />
                 </div>
               )}

--- a/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`<Card> > should render anchor tag 1`] = `
           <div
             aria-label="card_lock"
             class="_tag_d75732 _lock_d75732"
+            role="img"
           >
             <svg
               aria-hidden="true"

--- a/packages/ui-react/src/components/Filter/Filter.tsx
+++ b/packages/ui-react/src/components/Filter/Filter.tsx
@@ -41,10 +41,11 @@ const Filter: FC<Props> = ({ name, value, defaultLabel, options, setValue, force
           {options.map((option) => {
             const optionLabel = typeof option === 'string' ? option : option.label;
             const optionValue = typeof option === 'string' ? option : option.value;
+            const active = value === optionValue;
 
-            return <Button label={optionLabel} onClick={() => setValue(optionValue)} key={optionValue} active={value === optionValue} role="option" />;
+            return <Button label={optionLabel} onClick={() => setValue(optionValue)} key={optionValue} active={active} role="option" aria-selected={active} />;
           })}
-          <Button label={defaultLabel} onClick={() => setValue('')} active={value === ''} key={defaultLabel} role="option" />
+          <Button label={defaultLabel} onClick={() => setValue('')} active={value === ''} key={defaultLabel} role="option" aria-selected={value === ''} />
         </div>
       ) : (
         <div className={styles.filterDropDown}>

--- a/packages/ui-react/src/components/Filter/__snapshots__/Filter.test.tsx.snap
+++ b/packages/ui-react/src/components/Filter/__snapshots__/Filter.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<Filter> > renders Filter 1`] = `
     role="listbox"
   >
     <button
+      aria-selected="false"
       class="_button_f8f296 _default_f8f296 _outlined_f8f296"
       role="option"
       type="button"
@@ -17,6 +18,7 @@ exports[`<Filter> > renders Filter 1`] = `
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_button_f8f296 _default_f8f296 _outlined_f8f296"
       role="option"
       type="button"
@@ -26,6 +28,7 @@ exports[`<Filter> > renders Filter 1`] = `
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_button_f8f296 _default_f8f296 _outlined_f8f296"
       role="option"
       type="button"
@@ -35,6 +38,7 @@ exports[`<Filter> > renders Filter 1`] = `
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_button_f8f296 _default_f8f296 _outlined_f8f296"
       role="option"
       type="button"

--- a/packages/ui-react/src/components/Modal/Modal.module.scss
+++ b/packages/ui-react/src/components/Modal/Modal.module.scss
@@ -8,7 +8,7 @@
   left: 0;
   z-index: variables.$modals-z-index;
   width: 100vw;
-  height: calc(100vh - calc(100vh - 100%));
+  height: 100dvh;
 }
 
 .backdrop {

--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -14,7 +14,7 @@
   display: none;
   width: 100%;
   height: 100%;
-  background: rgba(variables.$black, 0.4);
+  background: theme.$modal-backdrop-bg;
   transition: all 0.3s ease;
 }
 
@@ -72,9 +72,11 @@
   .backdrop {
     display: inline-block;
     visibility: hidden;
+    opacity: 0;
 
     &.visible {
       visibility: visible;
+      opacity: 1;
     }
   }
 }

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -106,34 +106,29 @@
 
 .buttonBar {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-start;
   align-items: center;
   width: 100%;
-  margin: 0 -6px;
 
   > button {
     justify-content: center;
-    margin: 6px;
-  }
-
-  @include responsive.mobile-and-tablet() {
-    flex-wrap: wrap;
-
-    > button {
+    
+    &:not(:last-child) {
+      margin-right: 12px;
+    }
+    
+    @include responsive.mobile-and-tablet() {
       flex: 1;
-      padding: 0 12px;
-
+      margin: 6px 6px 6px 0;
+      
       &:first-child {
         flex-basis: 100%;
+        margin: 0 0 6px 0;
       }
-    }
-  }
-
-  @include responsive.mobile-only() {
-    flex-wrap: wrap;
-
-    > button:first-child {
-      margin-bottom: 8px;
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 }

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -141,7 +141,7 @@
 .poster {
   position: absolute;
   top: 0;
-  right: -15px;
+  right: 0;
 
   z-index: -1;
 
@@ -172,7 +172,7 @@
 .posterFade {
   position: absolute;
   top: 0;
-  right: -15px;
+  right: 0;
   left: 0;
   z-index: -1;
   height: 120px;

--- a/packages/ui-react/src/pages/Loading/Loading.module.scss
+++ b/packages/ui-react/src/pages/Loading/Loading.module.scss
@@ -2,5 +2,5 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100dvh;
 }


### PR DESCRIPTION
## Rework Sprint 3 RS
- Fix new subscription not showing in UI - OTT-992
- Fix cinema not covering full viewport height - OTT-1022, OTT-1030, OTT-4043
- Fix page behind player too wide - OTT-1010
- Fix button alignment video detail mobile (see before/after below)
- Feat: align sidebar backdrop with modal: much less transparent and a gentle animation added
- Fix: add selected state to season filters - OTT-1004
- Add role to make lock icon readable (axetools warned about this, and I've confirmed it now gets read by the screen reader)

### Notes 
- New subscription fix: I find #147 more safe, but can imagine we find it risky
- The 'page too wide' issue was the result of the Sidebar scroller fix. I've reverted the negative margin. The downside of this revert is a narrow empty black area on Safari mobile, but I found this way more acceptable than the background next to the Cinema. Also, the new darker backdrop makes it less of an issue.


![Screenshot 2024-02-28 at 14 04 06](https://github.com/Videodock/ott-web-app/assets/61868085/99005642-2510-45d5-a006-fc953c4504b2)

![Screenshot 2024-02-28 at 14 04 00](https://github.com/Videodock/ott-web-app/assets/61868085/5fe2b5cc-614c-44ae-9514-727e805dc3c7)

