### PR TITLE
Rework / fix empty duration video metadata

### DIFF
--- a/packages/common/src/utils/media.ts
+++ b/packages/common/src/utils/media.ts
@@ -54,9 +54,10 @@ export const isLiveChannel = (item: PlaylistItem): item is RequiredProperties<Pl
 
 export const createVideoMetadata = (media: PlaylistItem, episodesLabel?: string) => {
   const metaData = [];
+  const duration = formatDuration(media.duration);
 
   if (media.pubdate) metaData.push(String(new Date(media.pubdate * 1000).getFullYear()));
-  if (!episodesLabel && media.duration) metaData.push(formatDuration(media.duration));
+  if (!episodesLabel && duration) metaData.push(duration);
   if (episodesLabel) metaData.push(episodesLabel);
   if (media.genre) metaData.push(media.genre);
   if (media.rating) metaData.push(media.rating);
@@ -77,9 +78,10 @@ export const createPlaylistMetadata = (playlist: Playlist, episodesLabel?: strin
 export const createLiveEventMetadata = (media: PlaylistItem, locale: string) => {
   const metaData = [];
   const scheduled = formatVideoSchedule(locale, media.scheduledStart, media.scheduledEnd);
+  const duration = formatDuration(media.duration);
 
   if (scheduled) metaData.push(scheduled);
-  if (media.duration) metaData.push(formatDuration(media.duration));
+  if (duration) metaData.push(duration);
   if (media.genre) metaData.push(media.genre);
   if (media.rating) metaData.push(media.rating);
 


### PR DESCRIPTION
When the calculated and rounded `minutes` is `0`, then `formatDuration` returns an empty string. This causes an empty meta data item to be rendered.

This happened with media item with a `duration` of below 55. I came to the conclusion that this bug was already happening on production: https://app-preview.jwplayer.com/m/aofru6Y6/nature-and-landscapes-3?r=xJj9XpnT%3Fapp-config%3D2basfsic&app-config=2basfsic

Ticket: https://videodock.atlassian.net/browse/OTT-1008