### PR TITLE
Rework / fix statusicon metadata alignment

### DIFF
--- a/packages/ui-react/src/components/StatusIcon/StatusIcon.module.scss
+++ b/packages/ui-react/src/components/StatusIcon/StatusIcon.module.scss
@@ -1,3 +1,13 @@
+@use '@jwp/ott-ui-react/src/styles/mixins/responsive';
+
 .icon {
   margin-right: 8px;
+
+  @include responsive.mobile-only() {
+    padding: 2px 4px;
+  }
+
+  @include responsive.mobile-and-small-tablet() {
+    font-size: 14px;
+  }
 }

--- a/packages/ui-react/src/components/StatusIcon/StatusIcon.tsx
+++ b/packages/ui-react/src/components/StatusIcon/StatusIcon.tsx
@@ -17,7 +17,11 @@ export default function StatusIcon({ mediaStatus }: Props) {
   if (mediaStatus === MediaStatus.SCHEDULED || mediaStatus === MediaStatus.VOD) {
     return <Icon icon={Today} className={styles.icon} />;
   } else if (mediaStatus === MediaStatus.LIVE) {
-    return <Tag isLive>{t('live')}</Tag>;
+    return (
+      <Tag isLive className={styles.icon}>
+        {t('live')}
+      </Tag>
+    );
   }
 
   return null;

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -76,7 +76,6 @@
   letter-spacing: 0.15px;
 
   @include responsive.mobile-only() {
-    order: 2;
     font-size: 14px;
   }
 }

--- a/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.module.scss
+++ b/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.module.scss
@@ -78,21 +78,6 @@ div.title {
   font-size: 16px;
   line-height: variables.$base-line-height;
   letter-spacing: 0.15px;
-
-  > :first-child {
-    display: inline-block;
-    margin-right: 8px;
-
-    @include responsive.mobile-only() {
-      margin: 2px 4px 0 0;
-      padding: 2px 4px;
-    }
-  }
-
-  @include responsive.mobile-and-small-tablet() {
-    margin-bottom: variables.$base-spacing;
-    font-size: 14px;
-  }
 }
 
 .secondaryMetadata {

--- a/packages/ui-react/src/components/VideoMetaData/VideoMetaData.tsx
+++ b/packages/ui-react/src/components/VideoMetaData/VideoMetaData.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const VideoMetaData: React.FC<Props> = ({ attributes, separator = '•' }: Props) => {
   return (
-    <>
+    <div>
       {attributes.map((value, index) => (
         <React.Fragment key={value}>
           <span>{value}</span>
@@ -20,7 +20,7 @@ const VideoMetaData: React.FC<Props> = ({ attributes, separator = '•' }: Props
           )}
         </React.Fragment>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/packages/ui-react/src/components/VideoMetaData/__snapshots__/VideoMetaData.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoMetaData/__snapshots__/VideoMetaData.test.tsx.snap
@@ -2,26 +2,28 @@
 
 exports[`<VideoMetaData> > renders and matches snapshot 1`] = `
 <div>
-  <span>
-    2023
-  </span>
-  <span
-    aria-hidden="true"
-    class="_separator_1267df"
-  >
-    |
-  </span>
-  <span>
-    Comedy
-  </span>
-  <span
-    aria-hidden="true"
-    class="_separator_1267df"
-  >
-    |
-  </span>
-  <span>
-    something
-  </span>
+  <div>
+    <span>
+      2023
+    </span>
+    <span
+      aria-hidden="true"
+      class="_separator_1267df"
+    >
+      |
+    </span>
+    <span>
+      Comedy
+    </span>
+    <span
+      aria-hidden="true"
+      class="_separator_1267df"
+    >
+      |
+    </span>
+    <span>
+      something
+    </span>
+  </div>
 </div>
 `;

--- a/packages/ui-react/src/containers/Cinema/Cinema.module.scss
+++ b/packages/ui-react/src/containers/Cinema/Cinema.module.scss
@@ -63,13 +63,14 @@
 }
 
 .primaryMetadata {
+  display: flex;
+  align-items: center;
   margin-bottom: 8px;
   font-size: 16px;
   line-height: variables.$base-line-height;
   letter-spacing: 0.15px;
 
   @include responsive.mobile-only() {
-    order: 2;
     font-size: 14px;
   }
 }


### PR DESCRIPTION
Fix alignment.

https://videodock.atlassian.net/browse/OTT-1031 & https://videodock.atlassian.net/browse/OTT-1019

Changes:
- Removed code from inline player CSS, because there is never a statusicon (or live badge) at that position in the DOM
- Moved the code to the StatusIcon.module.scss, because statusicon + metadata are used in conjunction. Made minor changes.
- `order: 2; `is not used, because the parent is not a flex element. So I removed it

Previews:
![Screenshot 2024-02-28 at 15 46 13](https://github.com/Videodock/ott-web-app/assets/1019129/0b1cf295-821d-4325-b756-0fd578a74399)
![Screenshot 2024-02-28 at 15 46 20](https://github.com/Videodock/ott-web-app/assets/1019129/2e4a73e6-eb4e-4115-977c-91858e5a7da2)
![Screenshot 2024-02-28 at 15 46 52](https://github.com/Videodock/ott-web-app/assets/1019129/b2c8ec31-bbf3-4789-9551-f36fd44eee1a)
![Screenshot 2024-02-28 at 15 47 04](https://github.com/Videodock/ott-web-app/assets/1019129/4f5bf83a-b383-411c-9865-0682d077dc0b)
![Screenshot 2024-02-28 at 15 47 14](https://github.com/Videodock/ott-web-app/assets/1019129/41700aaf-7cfe-4532-b570-b75ba1d70509)


