### PR TITLE
Fix / styling of the Hub page

### DIFF
--- a/packages/ui-react/src/components/Hero/Hero.module.scss
+++ b/packages/ui-react/src/components/Hero/Hero.module.scss
@@ -4,20 +4,49 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/typography';
 
 .hero {
-  height: 40vh;
+  display: flex;
+  max-width: 100vw;
+  min-height: 40vh;
+  color: var(--primary-color);
+  font-family: var(--body-font-family);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
 }
 
-.content {
-  max-width: 60vw;
+.heroPadding {
   padding: 37px 56px 0;
 
+    @include responsive.desktop-small-only() {
+      padding: 34px 36px 36px;
+    }
+
+    @include responsive.tablet-only() {
+      padding: 34px 24px 24px;
+    }
+
+    @include responsive.mobile-only() {
+      padding: 16px;
+  }
+}
+
+.info {
+  position: relative;
+  width: 50%;
+  max-width: 650px;
+  min-height: 440px;
+
+  @include responsive.desktop-small-only() {
+    min-height: 335px;
+  }
+
   @include responsive.tablet-only() {
-    padding: 32px;
+    width: 350px;
+    min-height: 335px;
   }
 
   @include responsive.mobile-only() {
-    max-width: none;
-    padding: 16px;
+    width: 100%;
+    min-height: 380px;
+    padding-top: 225px;
   }
 }
 
@@ -25,7 +54,14 @@
   @include typography.video-title-base;
 }
 
-.image {
+.description {
+  font-family: var(--body-font-family);
+  font-size: 18px;
+  line-height: variables.$base-line-height;
+  letter-spacing: 0.15px;
+}
+
+.poster {
   position: absolute;
   top: 0;
   right: 0;
@@ -46,4 +82,14 @@
     width: 110vw;
     height: calc(180vw / 16 * 9);
   }
+}
+
+.posterFade {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: -1;
+  height: 120px;
+  background: linear-gradient(0deg, transparent, var(--body-background-color, variables.$white));
 }

--- a/packages/ui-react/src/components/Hero/Hero.tsx
+++ b/packages/ui-react/src/components/Hero/Hero.tsx
@@ -1,5 +1,8 @@
+import classNames from 'classnames';
 import React from 'react';
 
+import useBreakpoint, { Breakpoint } from '../../hooks/useBreakpoint';
+import CollapsibleText from '../CollapsibleText/CollapsibleText';
 import Image from '../Image/Image';
 
 import styles from './Hero.module.scss';
@@ -11,12 +14,17 @@ type Props = {
 };
 
 const Hero = ({ title, description, image }: Props) => {
+  const breakpoint: Breakpoint = useBreakpoint();
+  const isMobile = breakpoint === Breakpoint.xs;
+  const alt = ''; // intentionally empty for a11y, because adjacent text alternative
+
   return (
-    <div className={styles.hero}>
-      <Image className={styles.image} image={image} width={1280} alt="" />
-      <div className={styles.content}>
+    <div className={classNames(styles.hero, styles.heroPadding)}>
+      <Image className={styles.poster} image={image} width={1280} alt={alt} />
+      <div className={styles.posterFade} />
+      <div className={styles.info}>
         <h1 className={styles.title}>{title}</h1>
-        <p>{description}</p>
+        <CollapsibleText text={description} className={styles.description} maxHeight={isMobile ? 60 : 'none'} />
       </div>
     </div>
   );


### PR DESCRIPTION
## This PR

- Fixes the styling of the Hub page **|| OTT-1024**  
  - The styling of this page was incomplete, this is now fixed. I initially wanted to implement the `VideoDetails` component. However, that component isn't usable due to its dependency on certain props that the Hub page can't supply, such as `primaryMetadata` and `startWatchingButton`. So it does contain duplicate styling code, I also deliberately corrected some selector names to make it match with selectors of `VideoDetail`.