### PR TITLE
Fix / a11y focus lost when submitting a form

### DIFF
--- a/packages/ui-react/src/components/Button/Button.tsx
+++ b/packages/ui-react/src/components/Button/Button.tsx
@@ -79,7 +79,7 @@ const Button: React.FC<Props> = ({
   }
 
   return (
-    <button className={buttonClassName(active)} onClick={onClick} type={type} disabled={disabled} aria-disabled={disabled} {...rest}>
+    <button className={buttonClassName(active)} onClick={onClick} type={type} aria-disabled={disabled} {...rest}>
       {content}
     </button>
   );

--- a/packages/ui-react/src/components/Button/Button.tsx
+++ b/packages/ui-react/src/components/Button/Button.tsx
@@ -79,7 +79,7 @@ const Button: React.FC<Props> = ({
   }
 
   return (
-    <button className={buttonClassName(active)} onClick={onClick} type={type} aria-disabled={disabled} {...rest}>
+    <button className={buttonClassName(active)} onClick={disabled ? undefined : onClick} type={type} aria-disabled={disabled} {...rest}>
       {content}
     </button>
   );

--- a/packages/ui-react/src/components/LoginForm/LoginForm.test.tsx
+++ b/packages/ui-react/src/components/LoginForm/LoginForm.test.tsx
@@ -116,7 +116,7 @@ describe('<LoginForm>', () => {
 
     await waitForWithFakeTimers();
 
-    expect(getByRole('button', { name: 'login.sign_in' })).toBeDisabled();
+    expect(getByRole('button', { name: 'login.sign_in' })).toHaveAttribute('aria-disabled', 'true');
   });
 
   test('calls the onSubmit callback when the form gets submitted', async () => {

--- a/platforms/web/test-e2e/tests/live_channel_test.ts
+++ b/platforms/web/test-e2e/tests/live_channel_test.ts
@@ -148,7 +148,7 @@ Scenario('I can select an upcoming program on the same channel', async ({ I }) =
   I.dontSee('LIVE', locate('div').inside(videoDetailsLocator));
   I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 
-  I.seeElement(locate('button[disabled]').withText('Start watching'));
+  I.seeElement(locate('button[aria-disabled]').withText('Start watching'));
 
   I.seeElement(channel1LiveProgramLocator);
   await isLiveProgram(I, channel1LiveProgramLocator, 'channel 1');


### PR DESCRIPTION
Because the submit button gets disabled for a short moment during submission it will lose the focus completely.  Causing the page title to be read. Only happens on Android screen reader.

Removing the `disabled` attribute - while maintaining the `aria-disabled` attribute  - to fix the issue maybe raises the question where the focus should be set when a generic error occurs. This error message is invisible when it's a validation error and visible on any other error.  I reasoned to keep it simple: maintain the focus on the submit-button, so the users knows where he/she is in the UI instead of moving the focusing to something that we consider the most "relevant" element.

A disabled button should still be able to receive focus and be read by the screen reader. A good example is the Start Watching button which can be disabled for a upcoming live event.

`aria-disabled` has the same purpose as the native `disabled` attribute, but the disabled attribute makes the button unfocusable/tab-able.  Causing the issue. Strangely enough only for submit-buttons and on android?

I can write a lot more about `disabled` vs. `aria-disabled`. But I hope I gave you enough food for thought.

Some related articles:
- https://www.reddit.com/r/reactjs/comments/18hc7pz/should_you_use_ariadisabled_or_disabled_for
- https://ux.stackexchange.com/a/103246
- https://www.smashingmagazine.com/2023/02/guide-accessible-form-validation/#disabling-the-submit-button

Ticket : https://videodock.atlassian.net/browse/OTT-1067