### PR TITLE
Rework / ensure modals overlay underlying elements

### DIFF
--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -3,6 +3,7 @@
 
 .layout {
   position: relative;
+  z-index: 0;
 }
 
 .buttonContainer {


### PR DESCRIPTION
## This PR

- Improves the modal overlay functionality by setting `z-index: 0` on the `.layout` class, ensuring proper stacking order. Previously, the `z-index` defaulted to `auto`, but this adjustment establishes a stacking context, effectively positioning `.layout` below other elements.
  - solves: [OTT-1119](https://videodock.atlassian.net/browse/OTT-1119)

[OTT-1119]: https://videodock.atlassian.net/browse/OTT-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ