### PR TITLE
Feat / add modal provider and hook

### DIFF
--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -45,7 +45,8 @@
     "typescript-plugin-css-modules": "^5.0.2",
     "vi-fetch": "^0.8.0",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^1.3.1"
+    "vitest": "^1.3.1",
+    "wicg-inert": "^3.1.2"
   },
   "peerDependencies": {
     "@jwp/ott-common": "*",

--- a/packages/ui-react/src/components/Alert/Alert.test.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Alert from './Alert';
 
 describe('<Alert>', () => {
   test('renders and matches snapshot', () => {
-    const { container } = render(<Alert message="Body" open={true} onClose={vi.fn()} />);
+    const { container } = renderWithRouter(<Alert message="Body" open={true} onClose={vi.fn()} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import ConfirmationDialog from './ConfirmationDialog';
 
 describe('<ConfirmationDialog>', () => {
   test('renders and matches snapshot', () => {
-    const { container } = render(<ConfirmationDialog body="Body" title="Title" open={true} onConfirm={vi.fn()} onClose={vi.fn()} />);
+    const { container } = renderWithRouter(<ConfirmationDialog body="Body" title="Title" open={true} onConfirm={vi.fn()} onClose={vi.fn()} />);
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/ui-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Dialog from './Dialog';
 
 describe('<Dialog>', () => {
   test('renders and matches snapshot', () => {
-    const { baseElement } = render(
+    const { baseElement } = renderWithRouter(
       <>
         <span>Some content</span>
         <Dialog onClose={vi.fn()} open={true} role="dialog">
@@ -19,7 +20,7 @@ describe('<Dialog>', () => {
   });
 
   test('Should ensure Dialog is properly marked as a modal and has role "dialog"', () => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithRouter(
       <>
         <span>Some content</span>
         <Dialog onClose={vi.fn()} open={true} role="dialog" data-testid="dialog">

--- a/packages/ui-react/src/components/Modal/Modal.test.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Modal from './Modal';
 
 describe('<Modal>', () => {
   test('renders and matches snapshot', () => {
-    const { container } = render(
+    const { container } = renderWithRouter(
       <Modal open={true} onClose={vi.fn()}>
         <p>Test modal</p>
       </Modal>,
@@ -16,16 +18,16 @@ describe('<Modal>', () => {
 
   test('calls the onClose function when clicking the backdrop', () => {
     const onClose = vi.fn();
-    const { getByTestId } = render(<Modal open={true} onClose={onClose} />);
+    const { getByTestId } = renderWithRouter(<Modal open={true} onClose={onClose} />);
 
     fireEvent.click(getByTestId('backdrop'));
 
     expect(onClose).toBeCalledTimes(1);
   });
 
-  test('Should add inert attribute on the root div when open', () => {
+  test('add the inert attribute on the root div when open', () => {
     const onClose = vi.fn();
-    const { getByTestId, rerender } = render(
+    const { getByTestId, rerender } = renderWithRouter(
       <div id="root" data-testid="root">
         <Modal open={true} onClose={onClose} />
       </div>,
@@ -42,9 +44,9 @@ describe('<Modal>', () => {
     expect(getByTestId('root')).toHaveProperty('inert', false);
   });
 
-  test('should add overflowY hidden on the body element when open', () => {
+  test('add overflowY hidden on the body element when open', () => {
     const onClose = vi.fn();
-    const { container, rerender } = render(<Modal open={true} onClose={onClose} />);
+    const { container, rerender } = renderWithRouter(<Modal open={true} onClose={onClose} />);
 
     expect(container.parentNode).toHaveStyle({ overflowY: 'hidden' });
 

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { testId } from '@jwp/ott-common/src/utils/common';
 
 import Fade from '../Animation/Fade/Fade';
 import Grow from '../Animation/Grow/Grow';
-import scrollbarSize from '../../utils/dom';
+import { useModal } from '../../containers/ModalProvider/useModal';
 
 import styles from './Modal.module.scss';
 
@@ -16,74 +16,16 @@ type Props = {
   animationContainerClassName?: string;
 } & React.AriaAttributes;
 
-const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, animationContainerClassName, ...ariaAtributes }: Props) => {
-  const [visible, setVisible] = useState(open);
-  const lastFocus = useRef<HTMLElement>() as React.MutableRefObject<HTMLElement>;
+const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, animationContainerClassName, ...ariaAttributes }: Props) => {
   const modalRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
 
-  const keyDownEventHandler = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape' && onClose) {
-      onClose();
-    }
-  };
-
-  // delay the transition state so the CSS transition kicks in after toggling the `open` prop
-  useEffect(() => {
-    const activeElement = document.activeElement as HTMLElement;
-    const appView = document.querySelector('#root') as HTMLDivElement;
-
-    if (open) {
-      // store last focussed element
-      if (activeElement) {
-        lastFocus.current = activeElement;
-      }
-
-      // reset the visible state
-      setVisible(true);
-
-      // make sure main content is hidden for screen readers and inert
-      if (appView) {
-        appView.inert = true;
-      }
-
-      // prevent scrolling under the modal
-      document.body.style.marginRight = `${scrollbarSize()}px`;
-      document.body.style.overflowY = 'hidden';
-    } else {
-      if (appView) {
-        appView.inert = false;
-      }
-
-      document.body.style.removeProperty('margin-right');
-      document.body.style.removeProperty('overflow-y');
-    }
-  }, [open]);
-
-  useEffect(() => {
-    if (visible) {
-      // focus the first element in the modal
-      if (modalRef.current) {
-        const interactiveElement = modalRef.current.querySelectorAll(
-          'div[role="dialog"] input, div[role="dialog"] a, div[role="dialog"] button, div[role="dialog"] [tabindex]',
-        )[0] as HTMLElement | null;
-
-        if (interactiveElement) interactiveElement.focus();
-      }
-    } else {
-      // restore last focussed element
-      if (lastFocus.current) {
-        lastFocus.current.focus();
-      }
-    }
-  }, [visible]);
-
-  if (!open && !visible) return null;
+  useModal({ open, onClose, modalRef });
 
   return ReactDOM.createPortal(
-    <Fade open={open} duration={300} onCloseAnimationEnd={() => setVisible(false)}>
-      <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
+    <Fade open={open} duration={300}>
+      <div className={styles.modal} ref={modalRef}>
         <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
-        <div className={styles.container} {...ariaAtributes}>
+        <div className={styles.container} {...ariaAttributes}>
           <AnimationComponent open={open} duration={200} className={animationContainerClassName}>
             {children}
           </AnimationComponent>

--- a/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
@@ -8,6 +8,14 @@ import Sidebar from './Sidebar';
 describe('<SideBar />', () => {
   const playlistMenuItems = [<Button key="key" label="Home" to="/" />];
 
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   test('renders sideBar opened', () => {
     const { container } = renderWithRouter(
       <Sidebar isOpen={true} onClose={vi.fn()}>
@@ -26,5 +34,88 @@ describe('<SideBar />', () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  test('sets inert on the given containerRef', () => {
+    const ref = {
+      current: document.createElement('div'),
+    };
+    const { rerender } = renderWithRouter(
+      <Sidebar isOpen={true} onClose={vi.fn()} containerRef={ref}>
+        {playlistMenuItems}
+      </Sidebar>,
+    );
+
+    expect(ref.current).toHaveProperty('inert', true);
+
+    rerender(
+      <Sidebar isOpen={false} onClose={vi.fn()} containerRef={ref}>
+        {playlistMenuItems}
+      </Sidebar>,
+    );
+
+    expect(ref.current).toHaveProperty('inert', false);
+  });
+
+  test('should add overflowY hidden on the body element when open', () => {
+    const { container, rerender } = renderWithRouter(<Sidebar isOpen={true} onClose={vi.fn()} />);
+
+    expect(container.parentNode).toHaveStyle({ overflowY: 'hidden' });
+
+    rerender(<Sidebar isOpen={false} onClose={vi.fn()} />);
+
+    expect(container.parentNode).not.toHaveStyle({ overflowY: 'hidden' });
+  });
+
+  test('should focus the first interactive element in the sidebar when opened', () => {
+    const { getByLabelText, rerender } = renderWithRouter(
+      <Sidebar isOpen={false} onClose={vi.fn()}>
+        <button>close</button>
+      </Sidebar>,
+    );
+
+    expect(document.activeElement).toBe(document.body);
+
+    rerender(
+      <Sidebar isOpen={true} onClose={vi.fn()}>
+        <button>close</button>
+      </Sidebar>,
+    );
+    vi.runAllTimers();
+
+    expect(document.activeElement).toBe(getByLabelText('close_menu'));
+  });
+
+  test('should focus the last focused element when the sidebar is closed', () => {
+    const { getByText, rerender } = renderWithRouter(
+      <>
+        <button>open</button>
+        <Sidebar isOpen={false} onClose={vi.fn()}>
+          <button>close</button>
+        </Sidebar>
+      </>,
+    );
+    getByText('open').focus();
+    rerender(
+      <>
+        <button>open</button>
+        <Sidebar isOpen={true} onClose={vi.fn()}>
+          <button>close</button>
+        </Sidebar>
+      </>,
+    );
+    vi.runAllTimers();
+
+    rerender(
+      <>
+        <button>open</button>
+        <Sidebar isOpen={false} onClose={vi.fn()}>
+          <button>close</button>
+        </Sidebar>
+      </>,
+    );
+    vi.runAllTimers();
+
+    expect(document.activeElement).toBe(getByText('open'));
   });
 });

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -1,11 +1,11 @@
-import React, { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
+import React, { Fragment, type ReactNode, type RefObject, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import Close from '@jwp/ott-theme/assets/icons/close.svg?react';
 
 import IconButton from '../IconButton/IconButton';
 import Icon from '../Icon/Icon';
-import scrollbarSize from '../../utils/dom';
+import { useModal } from '../../containers/ModalProvider/useModal';
 
 import styles from './Sidebar.module.scss';
 
@@ -13,68 +13,23 @@ type SidebarProps = {
   isOpen: boolean;
   onClose: () => void;
   children?: ReactNode;
+  containerRef?: RefObject<HTMLElement>;
 };
 
-const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
+const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, containerRef, children }) => {
   const { t } = useTranslation('menu');
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
-  const [visible, setVisible] = useState(false);
+
+  useModal({ open: isOpen, onClose, modalRef: sidebarRef, containerRef });
 
   const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
 
   useEffect(() => {
-    if (isOpen) {
-      // Before inert on the body is applied in Layout, we need to set this ref
-      lastFocusedElementRef.current = document.activeElement as HTMLElement;
-
-      // When opened, adjust the margin-right to accommodate for the scrollbar width to prevent UI shifts in background
-      document.body.style.marginRight = `${scrollbarSize()}px`;
-      document.body.style.overflowY = 'hidden';
-
-      // Scroll the sidebar to the top if the user has previously scrolled down in the sidebar
-      if (sidebarRef.current) {
-        sidebarRef.current.scrollTop = 0;
-      }
-    } else {
-      document.body.style.removeProperty('margin-right');
-      document.body.style.removeProperty('overflow-y');
+    // Scroll the sidebar to the top if the user has previously scrolled down in the sidebar
+    if (isOpen && sidebarRef.current) {
+      sidebarRef.current.scrollTop = 0;
     }
   }, [isOpen]);
-
-  useEffect(() => {
-    const handleEscKey = (event: KeyboardEvent) => {
-      if (isOpen && event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscKey);
-
-    return () => {
-      document.removeEventListener('keydown', handleEscKey);
-    };
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    const sidebarElement = sidebarRef.current;
-    const handleTransitionEnd = () => {
-      setVisible(isOpen);
-    };
-
-    sidebarElement?.addEventListener('transitionend', handleTransitionEnd);
-
-    return () => {
-      sidebarElement?.removeEventListener('transitionend', handleTransitionEnd);
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (visible) {
-      sidebarRef.current?.querySelectorAll('a')[0]?.focus({ preventScroll: true });
-    } else {
-      lastFocusedElementRef.current?.focus({ preventScroll: true });
-    }
-  }, [visible]);
 
   return (
     <Fragment>

--- a/packages/ui-react/src/containers/Layout/Layout.tsx
+++ b/packages/ui-react/src/containers/Layout/Layout.tsx
@@ -32,6 +32,7 @@ const Layout = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { t, i18n } = useTranslation('common');
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const { config, accessModel, supportedLanguages } = useConfigStore(
     ({ config, accessModel, supportedLanguages }) => ({ config, accessModel, supportedLanguages }),
@@ -147,8 +148,6 @@ const Layout = () => {
     );
   };
 
-  const containerProps = { inert: sideBarOpen ? '' : undefined }; // inert is not yet officially supported in react
-
   return (
     <div className={styles.layout}>
       <Helmet>
@@ -159,7 +158,7 @@ const Layout = () => {
         <meta name="twitter:title" content={siteName} />
         <meta name="twitter:description" content={metaDescription} />
       </Helmet>
-      <div {...containerProps}>
+      <div ref={containerRef}>
         <Header
           onMenuButtonClick={() => setSideBarOpen(true)}
           logoSrc={banner}
@@ -207,7 +206,7 @@ const Layout = () => {
         </main>
         {!!footerText && <Footer text={footerText} />}
       </div>
-      <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)}>
+      <Sidebar isOpen={sideBarOpen} onClose={() => setSideBarOpen(false)} containerRef={containerRef}>
         <ul>
           <li>
             <MenuButton label={t('home')} to="/" />

--- a/packages/ui-react/src/containers/ModalProvider/ModalProvider.test.tsx
+++ b/packages/ui-react/src/containers/ModalProvider/ModalProvider.test.tsx
@@ -1,0 +1,142 @@
+import React, { type RefObject, useRef } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import ModalProvider from './ModalProvider';
+import { useModal } from './useModal';
+
+type Props = {
+  open: boolean;
+  onClose?: () => void;
+  modalRef: RefObject<HTMLElement>;
+  containerRef?: RefObject<HTMLElement>;
+};
+
+const TestModal = ({ open, onClose, containerRef, name }: Omit<Props, 'modalRef'> & { name: string }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useModal({ open, onClose, containerRef, modalRef });
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div data-testid={`modal-${name}`} ref={modalRef}>
+      <button onClick={onClose}>close {name}</button>
+    </div>
+  );
+};
+
+const renderSingleModal = (open: boolean, onClose?: () => void) => {
+  return (
+    <ModalProvider>
+      <>
+        <div id="root" data-testid="root">
+          <button onClick={vi.fn()}>last focus</button>
+        </div>
+        <TestModal open={open} onClose={onClose} name="modal-1" />
+      </>
+    </ModalProvider>
+  );
+};
+
+const renderMultiModal = (open: boolean, secondOpen: boolean, onClose?: () => void, onSecondClose?: () => void) => {
+  return (
+    <ModalProvider>
+      <>
+        <div id="root" data-testid="root">
+          <button onClick={vi.fn()}>last focus</button>
+        </div>
+        <TestModal open={open} onClose={onClose} name="modal-1" />
+        <TestModal open={secondOpen} onClose={onSecondClose} name="modal-2" />
+      </>
+    </ModalProvider>
+  );
+};
+
+describe('<ModalProvider />', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test('renders provider with test modal', () => {
+    const { container, getByTestId } = render(renderSingleModal(true));
+
+    expect(container).toMatchSnapshot();
+    expect(getByTestId('root')).toHaveAttribute('inert');
+  });
+
+  test('clears inert when all modals are closed', () => {
+    const onClose = vi.fn();
+
+    const { getByTestId, getByText, rerender } = render(renderSingleModal(true, onClose));
+
+    expect(getByTestId('root')).toHaveAttribute('inert');
+
+    fireEvent.click(getByText('close modal-1'));
+
+    rerender(renderSingleModal(false, onClose));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(getByTestId('root')).not.toHaveAttribute('inert');
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  test('focus the first interactive element', () => {
+    const onClose = vi.fn();
+
+    const { getByText, rerender } = render(renderSingleModal(false, onClose));
+
+    rerender(renderSingleModal(true, onClose));
+    vi.runAllTimers();
+
+    expect(document.activeElement).toBe(getByText('close modal-1'));
+  });
+
+  test('restores focus to the last active element', () => {
+    const { getByText, rerender } = render(renderSingleModal(false));
+
+    // focus button
+    getByText('last focus').focus();
+
+    rerender(renderSingleModal(true));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('close modal-1'));
+
+    rerender(renderSingleModal(false));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('last focus'));
+  });
+
+  test('restores focus to the last active element when multiple modals are opened and closed', () => {
+    const { getByText, rerender } = render(renderMultiModal(false, false));
+
+    // focus button
+    getByText('last focus').focus();
+
+    rerender(renderMultiModal(true, false));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('close modal-1'));
+
+    rerender(renderMultiModal(true, true));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('close modal-2'));
+
+    rerender(renderMultiModal(true, false));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('close modal-1'));
+
+    rerender(renderMultiModal(false, false));
+
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(getByText('last focus'));
+  });
+});

--- a/packages/ui-react/src/containers/ModalProvider/ModalProvider.tsx
+++ b/packages/ui-react/src/containers/ModalProvider/ModalProvider.tsx
@@ -1,0 +1,225 @@
+import { createContext, type PropsWithChildren, type RefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
+import { logDev } from '@jwp/ott-common/src/utils/common';
+
+import scrollbarSize from '../../utils/dom';
+
+type Modal = {
+  modalId: string;
+  modalRef: RefObject<HTMLElement>;
+  onClose?: () => void;
+  containerRef?: RefObject<HTMLElement>;
+  lastFocus: Element | null;
+};
+
+type ModalContextValue = {
+  openModal: (modalId: string, modalRef: RefObject<HTMLElement>, onClose?: () => void, containerRef?: RefObject<HTMLElement>) => void;
+  closeModal: (modalId: string, notify?: boolean) => void;
+  closeAllModals: (notify?: boolean) => void;
+  focusActiveModal: () => void;
+  modals: Modal[];
+};
+
+export const ModalContext = createContext<ModalContextValue>({
+  openModal() {
+    throw new Error('Not implemented');
+  },
+  closeModal() {
+    throw new Error('Not implemented');
+  },
+  closeAllModals() {
+    throw new Error('Not implemented');
+  },
+  focusActiveModal() {
+    throw new Error('Not implemented');
+  },
+  modals: [],
+});
+
+const byId = (modalId: string) => (modal: Modal) => modal.modalId === modalId;
+const notById = (modalId: string) => (modal: Modal) => modal.modalId !== modalId;
+
+const focusModal = (openedModal: Modal, targetElement?: Element | null) => {
+  const { modalRef } = openedModal;
+
+  requestAnimationFrame(() => {
+    if (!modalRef.current) return;
+
+    // prefer focusing the targetElement
+    if (targetElement && targetElement instanceof HTMLElement && modalRef.current.contains(targetElement)) {
+      return targetElement.focus();
+    }
+
+    // find the first interactive element
+    const interactiveElement = modalRef.current.querySelectorAll('input, a, button, [tabindex]')[0] as HTMLElement | null;
+
+    if (!interactiveElement) {
+      logDev('Failed to focus modal contents', { openedModal, targetElement });
+    }
+
+    interactiveElement?.focus();
+  });
+};
+
+const elementIsFocusable = (element: Element | null): element is HTMLElement => {
+  const inertElements = document.querySelectorAll('[inert]');
+  const parentHasInert = Array.from(inertElements).some((parent) => parent.contains(element));
+
+  return element instanceof HTMLElement && document.body.contains(element) && !parentHasInert;
+};
+
+const restoreFocus = (closedModal: Modal, activeModals: Modal[]) => {
+  const activeModal = activeModals[activeModals.length - 1];
+
+  // if there is still an active modal, focus that
+  if (activeModal) {
+    return focusModal(activeModal, closedModal.lastFocus);
+  }
+
+  // temp variable because originFocusElement gets cleared
+  const originFocus = originFocusElement;
+
+  // focus the last focussed or origin element with fallback to the body element
+  requestAnimationFrame(() => {
+    if (elementIsFocusable(closedModal.lastFocus)) {
+      closedModal.lastFocus.focus({ preventScroll: true });
+    } else if (elementIsFocusable(originFocus)) {
+      originFocus.focus({ preventScroll: true });
+    } else if (document.activeElement instanceof HTMLElement) {
+      logDev('Failed to restore focus', { closedModal, originFocus });
+      document.activeElement.blur();
+      window.focus();
+    }
+  });
+};
+
+let originFocusElement: HTMLElement | null = null;
+
+const getInertTarget = (modal: Modal) => {
+  const appView = document.querySelector('#root') as HTMLDivElement | null;
+  return modal.containerRef?.current || appView;
+};
+
+const handleInert = (targetModal: Modal, activeModals: Modal[]) => {
+  const inertTarget = getInertTarget(targetModal);
+
+  if (inertTarget) {
+    inertTarget.inert = activeModals.some((modal) => getInertTarget(modal) === inertTarget);
+  }
+};
+
+const handleBodyScrolling = (activeModals: Modal[]) => {
+  if (activeModals.length > 0) {
+    document.body.style.marginRight = `${scrollbarSize()}px`;
+    document.body.style.overflowY = 'hidden';
+  } else {
+    document.body.style.removeProperty('margin-right');
+    document.body.style.removeProperty('overflow-y');
+  }
+};
+
+const ModalProvider = ({ children }: PropsWithChildren) => {
+  const [modals, setModals] = useState<Modal[]>([]);
+
+  const keyDownEventHandler = useEventCallback((event: globalThis.KeyboardEvent) => {
+    if (event.key === 'Escape' && modals.length) {
+      closeModal(modals[modals.length - 1].modalId);
+    }
+  });
+
+  useEffect(() => {
+    document.addEventListener('keydown', keyDownEventHandler);
+
+    return () => {
+      document.removeEventListener('keydown', keyDownEventHandler);
+    };
+  }, [keyDownEventHandler]);
+
+  useEffect(() => {
+    handleBodyScrolling(modals);
+
+    // keep track of the origin focus element in case we stack multiple modals, for example, sidebar -> account modal
+    if (modals.length === 1 && !originFocusElement) {
+      originFocusElement = modals[0].lastFocus as HTMLElement;
+    } else if (modals.length === 0) {
+      originFocusElement = null;
+    }
+  }, [modals]);
+
+  const openModal = useCallback((modalId: string, modalRef: RefObject<HTMLElement>, onClose?: () => void, containerRef?: RefObject<HTMLElement>) => {
+    const modal: Modal = {
+      modalId,
+      onClose,
+      modalRef,
+      containerRef,
+      lastFocus: document.activeElement,
+    };
+
+    setModals((current) => {
+      const newModals = [...current, modal];
+      focusModal(modal);
+      handleInert(modal, newModals);
+
+      return newModals;
+    });
+  }, []);
+
+  const closeModal = useCallback(
+    (modalId: string, notify = true) => {
+      const modal = modals.find(byId(modalId));
+
+      if (!modal) return;
+      if (notify) modal.onClose?.();
+
+      setModals((current) => {
+        const newModals = current.filter(notById(modalId));
+
+        restoreFocus(modal, newModals);
+        handleInert(modal, newModals);
+
+        return newModals;
+      });
+    },
+    [modals],
+  );
+
+  const closeAllModals = useCallback(
+    (notify = true) => {
+      // the first modal opened has the correct lastFocus
+      const firstModal = modals[0];
+
+      modals.forEach((modal) => {
+        if (notify) modal.onClose?.();
+        handleInert(modal, []);
+      });
+
+      if (firstModal) {
+        restoreFocus(firstModal, []);
+      }
+
+      setModals([]);
+    },
+    [modals],
+  );
+
+  const focusActiveModal = useCallback(() => {
+    const modal = modals[modals.length - 1];
+
+    if (modal) focusModal(modal);
+  }, [modals]);
+
+  const value = useMemo(
+    () => ({
+      openModal,
+      closeModal,
+      closeAllModals,
+      focusActiveModal,
+      modals,
+    }),
+    [closeAllModals, closeModal, focusActiveModal, modals, openModal],
+  );
+
+  return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>;
+};
+
+export default ModalProvider;

--- a/packages/ui-react/src/containers/ModalProvider/__snapshots__/ModalProvider.test.tsx.snap
+++ b/packages/ui-react/src/containers/ModalProvider/__snapshots__/ModalProvider.test.tsx.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<ModalProvider /> > renders provider with test modal 1`] = `
+<div>
+  <div
+    aria-hidden="true"
+    data-testid="root"
+    id="root"
+    inert=""
+  >
+    <button
+      tabindex="-1"
+    >
+      last focus
+    </button>
+  </div>
+  <div
+    data-testid="modal-modal-1"
+  >
+    <button>
+      close 
+      modal-1
+    </button>
+  </div>
+</div>
+`;

--- a/packages/ui-react/src/containers/ModalProvider/useModal.ts
+++ b/packages/ui-react/src/containers/ModalProvider/useModal.ts
@@ -1,0 +1,45 @@
+import { type RefObject, useContext, useEffect, useRef } from 'react';
+import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
+
+import { ModalContext } from './ModalProvider';
+
+type Params = {
+  open: boolean;
+  onClose?: () => void;
+  modalRef: RefObject<HTMLElement>;
+  containerRef?: RefObject<HTMLElement>;
+};
+
+export const useModal = ({ open, onClose, modalRef, containerRef }: Params) => {
+  const modalId = useRef(String(Math.round(Math.random() * 1_000_000))).current;
+  const { openModal, closeModal, modals } = useContext(ModalContext);
+  const isOpen = modals.some((modal) => modal.modalId === modalId);
+
+  const onCloseCallback = useEventCallback(onClose);
+
+  useEffect(() => {
+    if (open) {
+      openModal(modalId, modalRef, onCloseCallback, containerRef);
+    } else if (isOpen) {
+      closeModal(modalId, false);
+    }
+    // only react to `open` changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      isOpen && closeModal(modalId, false);
+    };
+    // unmount only to unregister the modal when it was open
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const close = () => closeModal(modalId);
+
+  return {
+    isOpen,
+    closeModal: close,
+    open,
+  };
+};

--- a/packages/ui-react/src/containers/ModalProvider/useModal.ts
+++ b/packages/ui-react/src/containers/ModalProvider/useModal.ts
@@ -15,31 +15,35 @@ export const useModal = ({ open, onClose, modalRef, containerRef }: Params) => {
   const { openModal, closeModal, modals } = useContext(ModalContext);
   const isOpen = modals.some((modal) => modal.modalId === modalId);
 
-  const onCloseCallback = useEventCallback(onClose);
-
-  useEffect(() => {
+  // replace with React `useEffectEvent` when stable: https://react.dev/reference/react/experimental_useEffectEvent
+  const openModalEvent = useEventCallback(() => {
     if (open) {
-      openModal(modalId, modalRef, onCloseCallback, containerRef);
+      openModal(modalId, modalRef, onClose, containerRef);
     } else if (isOpen) {
       closeModal(modalId, false);
     }
-    // only react to `open` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  });
+  const closeModalEvent = useEventCallback(() => {
+    if (isOpen) {
+      closeModal(modalId, false);
+    }
+  });
+
+  useEffect(() => {
+    // react when the `open` prop changes
+    openModalEvent();
+  }, [open, openModalEvent]);
 
   useEffect(() => {
     return () => {
-      isOpen && closeModal(modalId, false);
+      // cleanup open modal when this component unmounts (without the `open` prop to false)
+      closeModalEvent();
     };
-    // unmount only to unregister the modal when it was open
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const close = () => closeModal(modalId);
+  }, [closeModalEvent]);
 
   return {
     isOpen,
-    closeModal: close,
+    closeModal: closeModalEvent,
     open,
   };
 };

--- a/packages/ui-react/test/utils.tsx
+++ b/packages/ui-react/test/utils.tsx
@@ -1,10 +1,11 @@
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import React, { type ReactElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { render, act, type RenderOptions } from '@testing-library/react';
+import { act, render, type RenderOptions } from '@testing-library/react';
 
 import QueryProvider from '../src/containers/QueryProvider/QueryProvider';
 import { AriaAnnouncerProvider } from '../src/containers/AnnouncementProvider/AnnoucementProvider';
+import ModalProvider from '../src/containers/ModalProvider/ModalProvider';
 
 interface WrapperProps {
   children?: ReactNode;
@@ -29,7 +30,9 @@ export const createWrapper = () => {
 export const wrapper = ({ children }: WrapperProps) => (
   <QueryProvider>
     <AriaAnnouncerProvider>
-      <Router>{children as ReactElement}</Router>
+      <ModalProvider>
+        <Router>{children as ReactElement}</Router>
+      </ModalProvider>
     </AriaAnnouncerProvider>
   </QueryProvider>
 );

--- a/packages/ui-react/vitest.setup.ts
+++ b/packages/ui-react/vitest.setup.ts
@@ -2,6 +2,7 @@ import 'vi-fetch/setup';
 import 'reflect-metadata';
 import '@testing-library/jest-dom'; // Including this for the expect extensions
 import 'react-app-polyfill/stable';
+import 'wicg-inert';
 import type { ComponentType } from 'react';
 
 const country = {

--- a/platforms/web/src/App.tsx
+++ b/platforms/web/src/App.tsx
@@ -4,6 +4,7 @@ import QueryProvider from '@jwp/ott-ui-react/src/containers/QueryProvider/QueryP
 import { ErrorPageWithoutTranslation } from '@jwp/ott-ui-react/src/components/ErrorPage/ErrorPage';
 import LoadingOverlay from '@jwp/ott-ui-react/src/components/LoadingOverlay/LoadingOverlay';
 import { AriaAnnouncerProvider } from '@jwp/ott-ui-react/src/containers/AnnouncementProvider/AnnoucementProvider';
+import ModalProvider from '@jwp/ott-ui-react/src/containers/ModalProvider/ModalProvider';
 
 import initI18n from './i18n/config';
 import Root from './containers/Root/Root';
@@ -44,7 +45,9 @@ export default function App() {
     <QueryProvider>
       <BrowserRouter>
         <AriaAnnouncerProvider>
-          <Root />
+          <ModalProvider>
+            <Root />
+          </ModalProvider>
         </AriaAnnouncerProvider>
       </BrowserRouter>
     </QueryProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11447,7 +11447,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-wicg-inert@^3.1.1:
+wicg-inert@^3.1.1, wicg-inert@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.1.2.tgz#df10cf756b773a96fce107c3ddcd43be5d1e3944"
   integrity sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang==


### PR DESCRIPTION
## Description

Feat or refactor? 😅 

This PR implements a `ModalProvider` and `useModal` hook that manages the visible modals when registered via the `useModals` hook.

By doing so, the following features are added:

- Close specific or all open modals using the context (Android back button)
- Open multiple modals without interfering with each other
- Keep the initial focus of the first modal opened in case of `open (1) -> close (1) and open(2) -> close(2)`
- Handle HTMLElement#inert and body scrolling from a single place
- Escape key only closes the last opened modal

**Why didn't I choose a library?**

I've searched for existing libraries, but unfortunately, most come bundled with a UI framework or don't use context to manage modals externally.

**Candidates:**

- https://www.npmjs.com/package/react-modal
- https://www.npmjs.com/package/ez-modal-react

**How does it work?**

Because we control all modals from a higher (or global) state via the `open` and `onClose` prop, I've ensured that the `useModal` hook consumes the given `open` state. In other words, when the `open` prop changes, the `useModal` hook updates the context.

This introduced a problem. When I want to close a modal from the outside (via the ModalContext), the `open` state must also be updated. So, I also chose to pass the `onClose` prop, which is called when the modal is closed externally. A' notify' argument is added to prevent redundant `onClose` calls, which blocks calling `onClose` when not needed.

```tsx
const Modal = ({ open, onClose }: Props) => {
  useModal({ open, onClose });

  return <div><h1>Modal!</h1></div>
};
```

The `ModalContext` keeps track of all opened modals in order. When a modal is opened, the `document.activeElement` is stored to keep track of the previously focused element. This is used when the modal is closed.

I found a problem (also in production) when the "Sign in"/"Sign up" modal is opened via the sidebar. Because the `document.activeElement` is present in the sidebar, closing the account modal results in a lost focus. 

To mitigate this issue, I store the originating element. This means I keep track of this element separately when the first modal is opened. When all modals are closed, and the `lastFocus` element can't be focused (not in DOM or inerted), the origin focussed element is used instead.

**The Sidebar component**

I also refactored the Sidebar component to use the `useModal` hook. This worked fine, but there is one difference between modals and the sidebar, which is the layout. I'm not even sure if, since we're using inert, this is still needed, but I added the functionality to change the element to inert.

By adding a `containerRef` property to the `useModal` arguments, the provider applies inert to that element instead of the `#root` element. This made the inert restoration a bit more complicated because it needed to keep track of all inerted elements and restore them when the modal closed.

Fixes OTT-1216, OTT-1217, OTT-983


