### PR TITLE
Fix / remove focus on start watching button due to inconsistency

### DIFF
--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.test.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.test.tsx
@@ -1,11 +1,25 @@
 import React from 'react';
 
-import { renderWithRouter } from '../../../test/utils';
+import { renderWithRouter, waitForWithFakeTimers } from '../../../test/utils';
 
 import RegistrationForm from './RegistrationForm';
 
+// The SocialButton component contains an SVG import that results in an absolute path on the current machine
+// This results in snapshot inconsistencies per machine
+vi.mock('../SocialButton/SocialButton.tsx', () => ({
+  default: (props: { href: string }) => {
+    return <a href={props.href}>Social Button</a>;
+  },
+}));
+
+const socialLoginURLs = {
+  twitter: 'https://staging-v2.inplayer.com/',
+  facebook: 'https://www.facebook.com/',
+  google: 'https://accounts.google.com/',
+};
+
 describe('<RegistrationForm>', () => {
-  test('renders and matches snapshot', () => {
+  test('renders and matches snapshot', async () => {
     const { container } = renderWithRouter(
       <RegistrationForm
         publisherConsents={null}
@@ -19,8 +33,11 @@ describe('<RegistrationForm>', () => {
         consentValues={{}}
         loading={false}
         onConsentChange={vi.fn()}
+        socialLoginURLs={socialLoginURLs}
       />,
     );
+
+    await waitForWithFakeTimers();
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -5,6 +5,7 @@ import DOMPurify from 'dompurify';
 import type { FormErrors } from '@jwp/ott-common/types/form';
 import type { CustomFormField, RegistrationFormData } from '@jwp/ott-common/types/account';
 import { testId } from '@jwp/ott-common/src/utils/common';
+import type { SocialLoginURLs } from '@jwp/ott-hooks-react/src/useSocialLoginUrls';
 import useToggle from '@jwp/ott-hooks-react/src/useToggle';
 import Visibility from '@jwp/ott-theme/assets/icons/visibility.svg?react';
 import VisibilityOff from '@jwp/ott-theme/assets/icons/visibility_off.svg?react';
@@ -20,6 +21,7 @@ import LoadingOverlay from '../LoadingOverlay/LoadingOverlay';
 import Link from '../Link/Link';
 import Icon from '../Icon/Icon';
 import { modalURLFromLocation } from '../../utils/location';
+import SocialButtonsList from '../SocialButtonsList/SocialButtonsList';
 
 import styles from './RegistrationForm.module.scss';
 
@@ -36,6 +38,7 @@ type Props = {
   submitting: boolean;
   validationError?: boolean;
   publisherConsents: CustomFormField[] | null;
+  socialLoginURLs: SocialLoginURLs | null;
 };
 
 const RegistrationForm: React.FC<Props> = ({
@@ -51,6 +54,7 @@ const RegistrationForm: React.FC<Props> = ({
   consentValues,
   onConsentChange,
   consentErrors,
+  socialLoginURLs,
 }: Props) => {
   const [viewPassword, toggleViewPassword] = useToggle();
 
@@ -80,7 +84,6 @@ const RegistrationForm: React.FC<Props> = ({
 
   return (
     <form onSubmit={onSubmit} data-testid={testId('registration-form')} noValidate>
-      <h2 className={styles.title}>{t('registration.sign_up')}</h2>
       <div ref={ref}>
         {errors.form ? (
           <FormFeedback variant="error" visible={!validationError}>
@@ -88,6 +91,8 @@ const RegistrationForm: React.FC<Props> = ({
           </FormFeedback>
         ) : null}
       </div>
+      <SocialButtonsList socialLoginURLs={socialLoginURLs} />
+      <h2 className={styles.title}>{t('registration.sign_up')}</h2>
       <TextField
         value={values.email}
         onChange={onChange}

--- a/packages/ui-react/src/components/RegistrationForm/__snapshots__/RegistrationForm.test.tsx.snap
+++ b/packages/ui-react/src/components/RegistrationForm/__snapshots__/RegistrationForm.test.tsx.snap
@@ -6,12 +6,31 @@ exports[`<RegistrationForm> > renders and matches snapshot 1`] = `
     data-testid="registration-form"
     novalidate=""
   >
+    <div />
+    <div
+      class="_socialButtonsListContainer_313d0d"
+    >
+      <a
+        href="https://staging-v2.inplayer.com/"
+      >
+        Social Button
+      </a>
+      <a
+        href="https://www.facebook.com/"
+      >
+        Social Button
+      </a>
+      <a
+        href="https://accounts.google.com/"
+      >
+        Social Button
+      </a>
+    </div>
     <h2
       class="_title_a472a0"
     >
       registration.sign_up
     </h2>
-    <div />
     <div
       class="_textField_e16c1b"
     >

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -6,6 +6,7 @@ import type { RegistrationFormData } from '@jwp/ott-common/types/account';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import AccountController from '@jwp/ott-common/src/controllers/AccountController';
 import { checkConsentsFromValues, extractConsentValues, formatConsentsFromValues } from '@jwp/ott-common/src/utils/collection';
+import useSocialLoginUrls from '@jwp/ott-hooks-react/src/useSocialLoginUrls';
 import useForm from '@jwp/ott-hooks-react/src/useForm';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
@@ -54,6 +55,8 @@ const Registration = () => {
     setConsentValues(extractConsentValues(publisherConsents));
   }, [accountController, publisherConsents]);
 
+  const socialLoginURLs = useSocialLoginUrls(window.location.href.split('?')[0]);
+
   const { handleSubmit, handleChange, handleBlur, values, errors, validationSchemaError, submitting } = useForm<RegistrationFormData>({
     initialValues: { email: '', password: '' },
     validationSchema: object().shape({
@@ -95,6 +98,7 @@ const Registration = () => {
       consentValues={consentValues}
       publisherConsents={publisherConsents}
       loading={loading || publisherConsentsLoading}
+      socialLoginURLs={socialLoginURLs}
     />
   );
 };

--- a/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Registration.tsx
@@ -8,7 +8,7 @@ import AccountController from '@jwp/ott-common/src/controllers/AccountController
 import { checkConsentsFromValues, extractConsentValues, formatConsentsFromValues } from '@jwp/ott-common/src/utils/collection';
 import useSocialLoginUrls from '@jwp/ott-hooks-react/src/useSocialLoginUrls';
 import useForm from '@jwp/ott-hooks-react/src/useForm';
-import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
+import { modalURLFromLocation, modalURLFromWindowLocation } from '@jwp/ott-ui-react/src/utils/location';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 
 import RegistrationForm from '../../../components/RegistrationForm/RegistrationForm';
@@ -55,7 +55,7 @@ const Registration = () => {
     setConsentValues(extractConsentValues(publisherConsents));
   }, [accountController, publisherConsents]);
 
-  const socialLoginURLs = useSocialLoginUrls(window.location.href.split('?')[0]);
+  const socialLoginURLs = useSocialLoginUrls(modalURLFromWindowLocation('personal-details'));
 
   const { handleSubmit, handleChange, handleBlur, values, errors, validationSchemaError, submitting } = useForm<RegistrationFormData>({
     initialValues: { email: '', password: '' },

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -94,7 +94,6 @@ const LegacySeries = () => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {
@@ -133,7 +132,6 @@ const LegacySeries = () => {
   const shareButton = <ShareButton title={selectedItem?.title} description={pageDescription} url={canonicalUrl} />;
   const startWatchingButton = (
     <StartWatchingButton
-      key={episodeId} // necessary to fix autofocus on TalkBack
       item={episode || firstEpisode}
       playUrl={legacySeriesURL({ episodeId: episode?.mediaid || firstEpisode?.mediaid, seriesId, play: true, playlistId: feedId })}
     />

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -84,7 +84,6 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI
@@ -99,14 +98,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   );
 
   const shareButton = <ShareButton title={media.title} description={media.description} url={canonicalUrl} />;
-  const startWatchingButton = (
-    <StartWatchingButton
-      key={id} // necessary to fix autofocus on TalkBack
-      item={media}
-      playUrl={mediaURL({ media, playlistId, play: true })}
-      disabled={!liveEvent.isPlayable}
-    />
-  );
+  const startWatchingButton = <StartWatchingButton item={media} playUrl={mediaURL({ media, playlistId, play: true })} disabled={!liveEvent.isPlayable} />;
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={media} />;
   const trailerButton = (!!trailerItem || isTrailerLoading) && (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -19,7 +19,6 @@ const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [data]);
 
   return (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -73,7 +73,6 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [id]);
 
   // UI
@@ -82,13 +81,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   const primaryMetadata = <VideoMetaData attributes={createVideoMetadata(data)} />;
   const shareButton = <ShareButton title={data.title} description={data.description} url={canonicalUrl} />;
-  const startWatchingButton = (
-    <StartWatchingButton
-      key={id} // necessary to fix autofocus on TalkBack
-      item={data}
-      playUrl={mediaURL({ media: data, playlistId: feedId, play: true })}
-    />
-  );
+  const startWatchingButton = <StartWatchingButton item={data} playUrl={mediaURL({ media: data, playlistId: feedId, play: true })} />;
 
   const favoriteButton = isFavoritesEnabled && <FavoriteButton item={data} />;
   const trailerButton = (!!trailerItem || isTrailerLoading) && (

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -136,7 +136,6 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   // Effects
   useEffect(() => {
     (document.scrollingElement || document.body).scroll({ top: 0 });
-    (document.querySelector('#video-details button') as HTMLElement)?.focus();
   }, [episode]);
 
   useEffect(() => {
@@ -165,14 +164,13 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   const startWatchingButton = useMemo(
     () => (
       <StartWatchingButton
-        key={episodeId} // necessary to fix autofocus on TalkBack
         item={episode || firstEpisode}
         onClick={() => {
           setSearchParams({ ...searchParams, e: (episode || firstEpisode).mediaid, r: feedId || '', play: '1' }, { replace: true });
         }}
       />
     ),
-    [episodeId, episode, firstEpisode, setSearchParams, searchParams, feedId],
+    [episode, firstEpisode, setSearchParams, searchParams, feedId],
   );
 
   // UI

--- a/platforms/web/src/containers/AppRoutes/AppRoutes.tsx
+++ b/platforms/web/src/containers/AppRoutes/AppRoutes.tsx
@@ -32,6 +32,7 @@ import {
   PATH_USER_PROFILES_EDIT_PROFILE,
   PATH_SEARCH,
   PATH_USER,
+  PATH_HOME,
 } from '@jwp/ott-common/src/paths';
 
 import useNotifications from '#src/hooks/useNotifications';
@@ -53,7 +54,7 @@ export default function AppRoutes() {
   useNotifications();
 
   if (userData.user && !userData.loading && window.location.href.includes('#token')) {
-    return <Navigate to="/" />; // component instead of hook to prevent extra re-renders
+    return <Navigate to={`${PATH_HOME}${location.search}`} />; // component instead of hook to prevent extra re-renders
   }
 
   if (userData.user && selectingProfileAvatar !== null) {


### PR DESCRIPTION
## Description

- **Removes setting the focus on the start watching button due to inconsistent behaviour** || OTT-1300
  - The original solution to apply a blur when clicking on a `Card` to make sure the `body` element is focused, was also inconsistent. If you'd then start tabbing, the focus lands on the footer, suggesting it's still on the previous `Card` in the `CardGrid`. 
  - It has been internally discussed with the team and other solutions have been tried, such as setting the focus on the body via a different route or setting it on the 'skip to content link', with no success. Therefore, it's decided to remove the focus (also the `key` prop on the `StartWatching` button) and accept that the focus stays on the previous card when navigating from the `CardGrid`.

### Update 17th of April:

The modifications in this PR do not alter the current behavior in the app. Submitting this PR to JW that reverts recent changes made us is not necessary. Discussed with Roy and Chris to label this PR as a draft and further explore another solution proposed by Chris, see: [Slack link](https://videodock.slack.com/archives/GQLRVR7B8/p1713356217989729?thread_ts=1713279518.636439&cid=GQLRVR7B8).

**Christiaan's idea:**
- Responds to history changes causing all pages to disappear.
- Only scroll to top when navigating forward (back handles this itself).
- Do nothing if the user modal is open (or closes) because it handles focus itself.
- The target main is also accessible during loading.

```ts
const useFocusOnNavigate = () => {
  const location = useLocation();
  const lastStateIdRef = useRef(0);
  const prevLocation = useRef(location);

  useEffect(() => {
    const stateId = window.history.state?.idx;
    const prevStateId = lastStateIdRef.current;
    const searchParams = createSearchParams(location.search);
    const prevSearchParams = createSearchParams(prevLocation.current.search);

    lastStateIdRef.current = stateId;
    prevLocation.current = location;

    if (typeof stateId !== 'number') return;
    if (searchParams.has('u') || prevSearchParams.has('u')) return;

    if (prevStateId !== stateId) {
      // forward navigation, reset the scroll top
      if (stateId >= prevStateId) {
        (document.scrollingElement || document.body).scrollTo({ top: 0, behavior: 'instant' });
      }

      // focus (choose a best practice element (body, main, h1, interactive element??))
      document.querySelector('main')?.focus({ preventScroll: true });
    }
  }, [location]);
};
```

##### To also take into account:
It's important to remember to check how `Search` is affected by this: Do we support the history state of IDX (after each navigation, a state is pushed or popped). History is an array, so using `.push()` adds an entry. IDX represents the ID of the item.