### PR TITLE
Feat / Manage minimum browser support

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -37,12 +37,13 @@ const config: KnipConfig = {
         '@babel/core', // Required peer dependency for babel plugins
         '@types/luxon', // Used in tests
         'babel-plugin-transform-typescript-metadata', // Used to build with decorators for ioc resolution
+        'core-js', // Conditionally imported at build time
         'eslint-plugin-codeceptjs', // Used by apps/web/test-e2e/.eslintrc.cjs
         'luxon', // Used in tests
         'playwright', // Used in test configs
         'sharp', // Requirement for @vite-pwa/assets-generator
         'tsconfig-paths', // Used for e2e test setup
-        'virtual:pwa-register', // Service Worker code is injected at build time,
+        'virtual:pwa-register', // Service Worker code is injected at build time
       ],
     },
     'configs/eslint-config-jwp': {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -44,6 +44,7 @@ const config: KnipConfig = {
         'sharp', // Requirement for @vite-pwa/assets-generator
         'tsconfig-paths', // Used for e2e test setup
         'virtual:pwa-register', // Service Worker code is injected at build time
+        'virtual:polyfills', // Polyfills are conditionally injected
       ],
     },
     'configs/eslint-config-jwp': {

--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -13,6 +13,7 @@
   display: inline-block;
   width: 270px;
   max-width: 90vw;
+  height: 100vh; // Fallback
   height: 100dvh;
   overflow-y: auto;
   background-color: var(--body-background-color);

--- a/packages/ui-react/src/pages/Loading/Loading.module.scss
+++ b/packages/ui-react/src/pages/Loading/Loading.module.scss
@@ -2,5 +2,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 100vh; // Fallback
   height: 100dvh;
 }

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1,13 +1,12 @@
-<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title><% name %></title>
+  <title><%- name %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <meta name="description" content="<% description %>" data-react-helmet="true" />
+  <meta name="description" content="<%- description %>" data-react-helmet="true" />
   <meta name="twitter:card" content="summary" data-react-helmet="true"  />
-  <meta property="og:title" content="<% name %>" data-react-helmet="true" >
+  <meta property="og:title" content="<%- name %>" data-react-helmet="true" >
   <meta property="og:description" content="<% description %>" data-react-helmet="true">
   <meta property="og:image" content="/images/icons/app-icon.png" data-react-helmet="true">
 

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -55,6 +55,7 @@
     "allure-commandline": "^2.17.2",
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "codeceptjs": "3.5.5",
+    "core-js": "^3.37.0",
     "eslint-plugin-codeceptjs": "^1.3.0",
     "jsdom": "^22.1.0",
     "luxon": "^3.2.1",

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -92,7 +92,6 @@
     "@jwp/ott-theme": "*",
     "@jwp/ott-ui-react": "*",
     "eslint-config-jwp": "*",
-    "postcss-config-jwp": "*",
-    "virtual:polyfills": "*"
+    "postcss-config-jwp": "*"
   }
 }

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -92,6 +92,7 @@
     "@jwp/ott-theme": "*",
     "@jwp/ott-ui-react": "*",
     "eslint-config-jwp": "*",
-    "postcss-config-jwp": "*"
+    "postcss-config-jwp": "*",
+    "virtual:polyfills": "*"
   }
 }

--- a/platforms/web/scripts/build-tools/plugins.ts
+++ b/platforms/web/scripts/build-tools/plugins.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from 'vite';
+
+export const legacyBrowserPlugin = (enabled: boolean = true): Plugin => {
+  return {
+    name: 'legacy-browser',
+    resolveId(id) {
+      if (id.includes('virtual:polyfills')) {
+        return '\0' + id;
+      }
+    },
+    load(id) {
+      if (id.includes('\0virtual:polyfills')) {
+        return enabled ? "import './src/polyfills';" : 'export default {};';
+      }
+    },
+    config(config) {
+      if (enabled) {
+        config.build = config.build ?? {};
+        config.build.target = ['es2020', 'edge88', 'firefox78', 'chrome68', 'safari14'];
+      }
+    },
+  };
+};

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -1,10 +1,10 @@
+import 'core-js/es/array/flat-map';
+import 'core-js/es/object/from-entries';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import 'wicg-inert';
 import { registerSW } from 'virtual:pwa-register';
 import { configureEnv } from '@jwp/ott-common/src/env';
-import 'core-js/es/array/flat-map';
-import 'core-js/es/object/from-entries';
 
 import './modules/register';
 

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -1,5 +1,4 @@
-import 'core-js/es/array/flat-map';
-import 'core-js/es/object/from-entries';
+import 'virtual:polyfills';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import 'wicg-inert';

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 import 'wicg-inert';
 import { registerSW } from 'virtual:pwa-register';
 import { configureEnv } from '@jwp/ott-common/src/env';
+import 'core-js/es/array/flat-map';
+import 'core-js/es/object/from-entries.js';
 
 import './modules/register';
 

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -4,7 +4,7 @@ import 'wicg-inert';
 import { registerSW } from 'virtual:pwa-register';
 import { configureEnv } from '@jwp/ott-common/src/env';
 import 'core-js/es/array/flat-map';
-import 'core-js/es/object/from-entries.js';
+import 'core-js/es/object/from-entries';
 
 import './modules/register';
 

--- a/platforms/web/src/polyfills.ts
+++ b/platforms/web/src/polyfills.ts
@@ -1,0 +1,2 @@
+import 'core-js/es/array/flat-map';
+import 'core-js/es/object/from-entries';

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -114,6 +114,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
       cssCodeSplit: false,
       sourcemap: true,
       minify: true,
+      target: ['es2020', 'edge88', 'firefox78', 'chrome68', 'safari14'],
       rollupOptions: {
         output: {
           manualChunks: (id) => {
@@ -129,6 +130,9 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
             }
             if (id.includes('/node_modules/@inplayer')) {
               return 'inplayer';
+            }
+            if (id.includes('/node_modules/core-js')) {
+              return 'polyfills';
             }
             if (id.includes('/node_modules/')) {
               return 'vendor';

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -11,6 +11,7 @@ import svgr from 'vite-plugin-svgr';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 import { basePath, favIconSizes, appleIconSizes } from './pwa-assets.config';
+import { legacyBrowserPlugin } from './scripts/build-tools/plugins';
 import {
   extractExternalFonts,
   getFileCopyTargets,
@@ -51,6 +52,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
 
   return defineConfig({
     plugins: [
+      legacyBrowserPlugin(!!process.env.APP_LEGACY_BUILD),
       react({
         // This is needed to do decorator transforms for ioc resolution to work for classes
         babel: { plugins: ['babel-plugin-transform-typescript-metadata', ['@babel/plugin-proposal-decorators', { legacy: true }]] },
@@ -114,7 +116,6 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
       cssCodeSplit: false,
       sourcemap: true,
       minify: true,
-      target: ['es2020', 'edge88', 'firefox78', 'chrome68', 'safari14'],
       rollupOptions: {
         output: {
           manualChunks: (id) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4285,6 +4285,11 @@ core-js@^3.19.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.36.0.tgz#e752fa0b0b462a0787d56e9d73f80b0f7c0dde68"
   integrity sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==
 
+core-js@^3.37.0:
+  version "3.37.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.37.0.tgz#d8dde58e91d156b2547c19d8a4efd5c7f6c426bb"
+  integrity sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -10034,7 +10039,7 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10050,6 +10055,15 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -10148,7 +10162,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10168,6 +10182,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -11773,7 +11794,16 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
We want to specifically support browsers from chrome68 and up.
Vite internally uses `['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']`. So the difference is quite small.

See: https://vitejs.dev/guide/build#browser-compatibility

I only needed to write a CSS fallback for the `dvh` unit because it was the only unsupported CSS feature we have  ran into.

I have written a [detailed explanation](https://videodock.atlassian.net/wiki/spaces/OTT/pages/2614263809/TV+support+web+app#Vite-legacy-plugin-(polyfills-%26-transforms)) why we do not want to use [@vitejs/plugin-legacy](https://www.npmjs.com/package/@vitejs/plugin-legacy) in this current stage.

I've tested this on Chrome 68 using browserstack.

Ticket: https://videodock.atlassian.net/browse/OTT-1335

