### PR TITLE
Fix / improve accessibility of offers modal 

### DIFF
--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.module.scss
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.module.scss
@@ -22,7 +22,7 @@
   margin-bottom: 24px;
 
   > input  {
-    &:checked + .offerDescription {
+    &:checked + .label {
       border-radius: 4px;
       transform: scale(1.02);
     }
@@ -38,7 +38,7 @@
   flex: 1;
   margin: 0 4px;
 
-  &:focus-within .offerDescription {
+  &:focus-within .label {
     @include accessibility.accessibleOutlineContrast;
     transform: scale(1.03);
   }
@@ -53,14 +53,14 @@
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
 
-  &:checked + .offerDescription {
+  &:checked + .label {
     color: variables.$black;
     background-color: variables.$white;
     border-color: variables.$white;
   }
 }
 
-.offerDescription {
+.label {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -136,3 +136,4 @@
     font-size: 12px;
   }
 }
+

--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.module.scss
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.module.scss
@@ -22,7 +22,7 @@
   margin-bottom: 24px;
 
   > input  {
-    &:checked + .label {
+    &:checked + .offerDescription {
       border-radius: 4px;
       transform: scale(1.02);
     }
@@ -38,7 +38,7 @@
   flex: 1;
   margin: 0 4px;
 
-  &:focus-within .label {
+  &:focus-within .offerDescription {
     @include accessibility.accessibleOutlineContrast;
     transform: scale(1.03);
   }
@@ -53,14 +53,14 @@
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
 
-  &:checked + .label {
+  &:checked + .offerDescription {
     color: variables.$black;
     background-color: variables.$white;
     border-color: variables.$white;
   }
 }
 
-.label {
+.offerDescription {
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
@@ -40,8 +40,17 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
     return null;
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderListItem = (text: string, icon: any) => (
+    <li>
+      <Icon icon={icon} />
+      {text}
+      <span className="hidden">.</span>
+    </li>
+  );
+
   const renderOption = ({ title, periodString, secondBenefit }: { title: string; periodString?: string; secondBenefit?: string }) => (
-    <div className={styles.offer} role="option">
+    <div className={styles.offer} role="option" aria-labelledby={`title-${offer.offerId}`} aria-describedby={`desc-${offer.offerId}`}>
       <input
         className={styles.radio}
         onChange={onChange}
@@ -52,30 +61,26 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
         checked={selected}
         data-testid={testId(offer.offerId)}
       />
-      <label className={styles.label} htmlFor={offer.offerId}>
-        <h2 className={styles.offerTitle}>{title}</h2>
-        <hr className={styles.offerDivider} />
-        <ul className={styles.offerBenefits}>
-          {offer.freeDays || offer.freePeriods ? (
-            <li>
-              <Icon icon={CheckCircle} /> {getFreeTrialText(offer)}
-            </li>
-          ) : null}
-
-          {!!secondBenefit && (
-            <li>
-              <Icon icon={CheckCircle} /> {secondBenefit}
-            </li>
-          )}
-          <li>
-            <Icon icon={CheckCircle} /> {t('choose_offer.benefits.watch_on_all_devices')}
-          </li>
-        </ul>
-        <div className={styles.fill} />
-        <div className={styles.offerPrice}>
-          {getOfferPrice(offer)} {!!periodString && <small>/{periodString}</small>}
+      {/* @TODO: only when label is clicked, the styling such as white background gets applied */}
+      <div className={styles.offerDescription}>
+        <label htmlFor={offer.offerId}>
+          <h2 className={styles.offerTitle} id={`title-${offer.offerId}`}>
+            {title}
+          </h2>
+        </label>
+        <div id={`desc-${offer.offerId}`}>
+          <hr className={styles.offerDivider} />
+          <ul className={styles.offerBenefits}>
+            {offer.freeDays || offer.freePeriods ? renderListItem(getFreeTrialText(offer) || '', CheckCircle) : null}
+            {!!secondBenefit && renderListItem(secondBenefit, CheckCircle)}
+            {renderListItem(t('choose_offer.benefits.watch_on_all_devices'), CheckCircle)}
+          </ul>
+          <div className={styles.fill} />
+          <div className={styles.offerPrice}>
+            {getOfferPrice(offer)} {!!periodString && <small>/{periodString}</small>}
+          </div>
         </div>
-      </label>
+      </div>
     </div>
   );
 

--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type FC, type SVGProps } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import type { FormErrors } from '@jwp/ott-common/types/form';
@@ -40,8 +40,7 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
     return null;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const renderListItem = (text: string, icon: any) => (
+  const renderListItem = (text: string, icon: FC<SVGProps<SVGSVGElement>>) => (
     <li>
       <Icon icon={icon} />
       {text}
@@ -50,7 +49,7 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
   );
 
   const renderOption = ({ title, periodString, secondBenefit }: { title: string; periodString?: string; secondBenefit?: string }) => (
-    <div className={styles.offer} role="option" aria-labelledby={`title-${offer.offerId}`} aria-describedby={`desc-${offer.offerId}`}>
+    <div className={styles.offer} aria-labelledby={`title-${offer.offerId}`}>
       <input
         className={styles.radio}
         onChange={onChange}
@@ -61,15 +60,13 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
         checked={selected}
         data-testid={testId(offer.offerId)}
       />
-      {/* @TODO: only when label is clicked, the styling such as white background gets applied */}
-      <div className={styles.offerDescription}>
+      <div className={styles.label}>
         <label htmlFor={offer.offerId}>
           <h2 className={styles.offerTitle} id={`title-${offer.offerId}`}>
             {title}
           </h2>
-        </label>
-        <div id={`desc-${offer.offerId}`}>
-          <hr className={styles.offerDivider} />
+          <span className="hidden">.</span>
+          <hr className={styles.offerDivider} aria-hidden={true} />
           <ul className={styles.offerBenefits}>
             {offer.freeDays || offer.freePeriods ? renderListItem(getFreeTrialText(offer) || '', CheckCircle) : null}
             {!!secondBenefit && renderListItem(secondBenefit, CheckCircle)}
@@ -79,7 +76,7 @@ const OfferBox: React.FC<OfferBoxProps> = ({ offer, selected, onChange }: OfferB
           <div className={styles.offerPrice}>
             {getOfferPrice(offer)} {!!periodString && <small>/{periodString}</small>}
           </div>
-        </div>
+        </label>
       </div>
     </div>
   );

--- a/packages/ui-react/src/components/ChooseOfferForm/__snapshots__/ChooseOfferForm.test.tsx.snap
+++ b/packages/ui-react/src/components/ChooseOfferForm/__snapshots__/ChooseOfferForm.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
         value="svod"
       />
       <label
-        class="_offerGroupLabel_f7961f"
+        class="_label_f7961f _offerGroupLabel_f7961f"
         for="svod"
       >
         choose_offer.subscription
@@ -41,7 +41,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
         value="tvod"
       />
       <label
-        class="_offerGroupLabel_f7961f"
+        class="_label_f7961f _offerGroupLabel_f7961f"
         for="tvod"
       >
         choose_offer.one_time_only
@@ -51,10 +51,8 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
       class="_offers_f7961f"
     >
       <div
-        aria-describedby="desc-S916977979_NL"
         aria-labelledby="title-S916977979_NL"
         class="_offer_f7961f"
-        role="option"
       >
         <input
           checked=""
@@ -66,7 +64,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
           value="S916977979_NL"
         />
         <div
-          class="_offerDescription_f7961f"
+          class="_label_f7961f"
         >
           <label
             for="S916977979_NL"
@@ -77,11 +75,13 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
             >
               choose_offer.monthly
             </h2>
-          </label>
-          <div
-            id="desc-S916977979_NL"
-          >
+            <span
+              class="hidden"
+            >
+              .
+            </span>
             <hr
+              aria-hidden="true"
               class="_offerDivider_f7961f"
             />
             <ul
@@ -155,14 +155,12 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
                 periods.month
               </small>
             </div>
-          </div>
+          </label>
         </div>
       </div>
       <div
-        aria-describedby="desc-S345569153_NL"
         aria-labelledby="title-S345569153_NL"
         class="_offer_f7961f"
-        role="option"
       >
         <input
           class="_radio_f7961f"
@@ -173,7 +171,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
           value="S345569153_NL"
         />
         <div
-          class="_offerDescription_f7961f"
+          class="_label_f7961f"
         >
           <label
             for="S345569153_NL"
@@ -184,11 +182,13 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
             >
               choose_offer.yearly
             </h2>
-          </label>
-          <div
-            id="desc-S345569153_NL"
-          >
+            <span
+              class="hidden"
+            >
+              .
+            </span>
             <hr
+              aria-hidden="true"
               class="_offerDivider_f7961f"
             />
             <ul
@@ -262,7 +262,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
                 periods.year
               </small>
             </div>
-          </div>
+          </label>
         </div>
       </div>
     </div>
@@ -306,7 +306,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
         value="svod"
       />
       <label
-        class="_offerGroupLabel_f7961f"
+        class="_label_f7961f _offerGroupLabel_f7961f"
         for="svod"
       >
         choose_offer.subscription
@@ -320,7 +320,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
         value="tvod"
       />
       <label
-        class="_offerGroupLabel_f7961f"
+        class="_label_f7961f _offerGroupLabel_f7961f"
         for="tvod"
       >
         choose_offer.one_time_only
@@ -330,10 +330,8 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
       class="_offers_f7961f"
     >
       <div
-        aria-describedby="desc-R892134629_NL"
         aria-labelledby="title-R892134629_NL"
         class="_offer_f7961f"
-        role="option"
       >
         <input
           checked=""
@@ -345,7 +343,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
           value="R892134629_NL"
         />
         <div
-          class="_offerDescription_f7961f"
+          class="_label_f7961f"
         >
           <label
             for="R892134629_NL"
@@ -356,11 +354,13 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
             >
               One Time - TVOD offer
             </h2>
-          </label>
-          <div
-            id="desc-R892134629_NL"
-          >
+            <span
+              class="hidden"
+            >
+              .
+            </span>
             <hr
+              aria-hidden="true"
               class="_offerDivider_f7961f"
             />
             <ul
@@ -394,7 +394,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
               € 2,90
                
             </div>
-          </div>
+          </label>
         </div>
       </div>
     </div>

--- a/packages/ui-react/src/components/ChooseOfferForm/__snapshots__/ChooseOfferForm.test.tsx.snap
+++ b/packages/ui-react/src/components/ChooseOfferForm/__snapshots__/ChooseOfferForm.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
         value="svod"
       />
       <label
-        class="_label_f7961f _offerGroupLabel_f7961f"
+        class="_offerGroupLabel_f7961f"
         for="svod"
       >
         choose_offer.subscription
@@ -41,7 +41,7 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
         value="tvod"
       />
       <label
-        class="_label_f7961f _offerGroupLabel_f7961f"
+        class="_offerGroupLabel_f7961f"
         for="tvod"
       >
         choose_offer.one_time_only
@@ -51,6 +51,8 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
       class="_offers_f7961f"
     >
       <div
+        aria-describedby="desc-S916977979_NL"
+        aria-labelledby="title-S916977979_NL"
         class="_offer_f7961f"
         role="option"
       >
@@ -63,80 +65,102 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
           type="radio"
           value="S916977979_NL"
         />
-        <label
-          class="_label_f7961f"
-          for="S916977979_NL"
+        <div
+          class="_offerDescription_f7961f"
         >
-          <h2
-            class="_offerTitle_f7961f"
+          <label
+            for="S916977979_NL"
           >
-            choose_offer.monthly
-          </h2>
-          <hr
-            class="_offerDivider_f7961f"
-          />
-          <ul
-            class="_offerBenefits_f7961f"
-          >
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.first_periods_free
-            </li>
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.cancel_anytime
-            </li>
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.watch_on_all_devices
-            </li>
-          </ul>
+            <h2
+              class="_offerTitle_f7961f"
+              id="title-S916977979_NL"
+            >
+              choose_offer.monthly
+            </h2>
+          </label>
           <div
-            class="_fill_f7961f"
-          />
-          <div
-            class="_offerPrice_f7961f"
+            id="desc-S916977979_NL"
           >
-            € 6,99
-             
-            <small>
-              /
-              periods.month
-            </small>
+            <hr
+              class="_offerDivider_f7961f"
+            />
+            <ul
+              class="_offerBenefits_f7961f"
+            >
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.first_periods_free
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.cancel_anytime
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.watch_on_all_devices
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+            </ul>
+            <div
+              class="_fill_f7961f"
+            />
+            <div
+              class="_offerPrice_f7961f"
+            >
+              € 6,99
+               
+              <small>
+                /
+                periods.month
+              </small>
+            </div>
           </div>
-        </label>
+        </div>
       </div>
       <div
+        aria-describedby="desc-S345569153_NL"
+        aria-labelledby="title-S345569153_NL"
         class="_offer_f7961f"
         role="option"
       >
@@ -148,78 +172,98 @@ exports[`<OffersForm> > renders and matches snapshot 1`] = `
           type="radio"
           value="S345569153_NL"
         />
-        <label
-          class="_label_f7961f"
-          for="S345569153_NL"
+        <div
+          class="_offerDescription_f7961f"
         >
-          <h2
-            class="_offerTitle_f7961f"
+          <label
+            for="S345569153_NL"
           >
-            choose_offer.yearly
-          </h2>
-          <hr
-            class="_offerDivider_f7961f"
-          />
-          <ul
-            class="_offerBenefits_f7961f"
-          >
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.first_days_free
-            </li>
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.cancel_anytime
-            </li>
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
-               
-              choose_offer.benefits.watch_on_all_devices
-            </li>
-          </ul>
+            <h2
+              class="_offerTitle_f7961f"
+              id="title-S345569153_NL"
+            >
+              choose_offer.yearly
+            </h2>
+          </label>
           <div
-            class="_fill_f7961f"
-          />
-          <div
-            class="_offerPrice_f7961f"
+            id="desc-S345569153_NL"
           >
-            € 50,00
-             
-            <small>
-              /
-              periods.year
-            </small>
+            <hr
+              class="_offerDivider_f7961f"
+            />
+            <ul
+              class="_offerBenefits_f7961f"
+            >
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.first_days_free
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.cancel_anytime
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.watch_on_all_devices
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+            </ul>
+            <div
+              class="_fill_f7961f"
+            />
+            <div
+              class="_offerPrice_f7961f"
+            >
+              € 50,00
+               
+              <small>
+                /
+                periods.year
+              </small>
+            </div>
           </div>
-        </label>
+        </div>
       </div>
     </div>
     <button
@@ -262,7 +306,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
         value="svod"
       />
       <label
-        class="_label_f7961f _offerGroupLabel_f7961f"
+        class="_offerGroupLabel_f7961f"
         for="svod"
       >
         choose_offer.subscription
@@ -276,7 +320,7 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
         value="tvod"
       />
       <label
-        class="_label_f7961f _offerGroupLabel_f7961f"
+        class="_offerGroupLabel_f7961f"
         for="tvod"
       >
         choose_offer.one_time_only
@@ -286,6 +330,8 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
       class="_offers_f7961f"
     >
       <div
+        aria-describedby="desc-R892134629_NL"
+        aria-labelledby="title-R892134629_NL"
         class="_offer_f7961f"
         role="option"
       >
@@ -298,46 +344,58 @@ exports[`<OffersForm> > renders and matches snapshot 2`] = `
           type="radio"
           value="R892134629_NL"
         />
-        <label
-          class="_label_f7961f"
-          for="R892134629_NL"
+        <div
+          class="_offerDescription_f7961f"
         >
-          <h2
-            class="_offerTitle_f7961f"
+          <label
+            for="R892134629_NL"
           >
-            One Time - TVOD offer
-          </h2>
-          <hr
-            class="_offerDivider_f7961f"
-          />
-          <ul
-            class="_offerBenefits_f7961f"
+            <h2
+              class="_offerTitle_f7961f"
+              id="title-R892134629_NL"
+            >
+              One Time - TVOD offer
+            </h2>
+          </label>
+          <div
+            id="desc-R892134629_NL"
           >
-            <li>
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                />
-              </svg>
+            <hr
+              class="_offerDivider_f7961f"
+            />
+            <ul
+              class="_offerBenefits_f7961f"
+            >
+              <li>
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+                  />
+                </svg>
+                choose_offer.benefits.watch_on_all_devices
+                <span
+                  class="hidden"
+                >
+                  .
+                </span>
+              </li>
+            </ul>
+            <div
+              class="_fill_f7961f"
+            />
+            <div
+              class="_offerPrice_f7961f"
+            >
+              € 2,90
                
-              choose_offer.benefits.watch_on_all_devices
-            </li>
-          </ul>
-          <div
-            class="_fill_f7961f"
-          />
-          <div
-            class="_offerPrice_f7961f"
-          >
-            € 2,90
-             
+            </div>
           </div>
-        </label>
+        </div>
       </div>
     </div>
     <button


### PR DESCRIPTION
## Description

- In the past, the screen reader would read the entire offer in one go, making it less user friendly since it was hard to understand. This PR addresses this issue by adding punctuation via the `renderListItem` function to the offer after the offer title and each benefit, thus fixing its readability.
- Previous PR was closed, see: https://github.com/Videodock/ott-web-app/pull/184
  - Solves: OTT-772

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
