### PR TITLE
Fix /  default infinitescroll to not use window

### DIFF
--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -73,7 +73,13 @@ function CardGrid({
   }, [playlist.feedid]);
 
   return (
-    <InfiniteScroll pageStart={0} loadMore={loadMore ?? defaultLoadMore} hasMore={hasMore ?? defaultHasMore} loader={<InfiniteScrollLoader key="loader" />}>
+    <InfiniteScroll
+      pageStart={0}
+      loadMore={loadMore ?? defaultLoadMore}
+      hasMore={hasMore ?? defaultHasMore}
+      loader={<InfiniteScrollLoader key="loader" />}
+      useWindow={false}
+    >
       <LayoutGrid
         className={classNames(styles.container, styles[`cols-${visibleTiles}`])}
         data={loadMore ? playlist.playlist : playlist.playlist.slice(0, rowCount * visibleTiles)}

--- a/packages/ui-react/src/components/VideoList/VideoList.tsx
+++ b/packages/ui-react/src/components/VideoList/VideoList.tsx
@@ -58,6 +58,7 @@ function VideoList({
           hasMore={hasMore ?? false}
           className={styles.list}
           loader={<InfiniteScrollLoader key="loader" />}
+          useWindow={false}
         >
           {playlist?.playlist?.map((playlistItem: PlaylistItem) => (
             <li key={playlistItem.mediaid}>

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -59,6 +59,7 @@ const ShelfList = ({ rows }: Props) => {
         loadMore={() => setRowsToLoad((current) => current + ROWS_TO_LOAD_STEP)}
         hasMore={rowsToLoad < rows.length}
         loader={<InfiniteScrollLoader key="loader" />}
+        useWindow={false}
       >
         {rows.slice(0, rowsToLoad).map(({ type, featured, title }, index) => {
           const { data: playlist, isLoading, error } = playlists[index];


### PR DESCRIPTION
## Default infinitescroll to not use window
This fixes an infinite spinner on platforms that use a scrollingElement other than the window.

@langemike I've re-initiated this PR, so that we can add it to our release. Will you pick up from here and create a PR to the OS repo?